### PR TITLE
add expression restructuring pass

### DIFF
--- a/.github/workflows/nv-build-and-test.yml
+++ b/.github/workflows/nv-build-and-test.yml
@@ -20,14 +20,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: FlagTree Build on NVIDIA-A100
+      - name: FlagTree Build
         shell: bash
         run: |
           source ~/env.sh
           cd python
-          MAX_JOBS=20 pip3.11 install . --no-build-isolation
+          MAX_JOBS=32 pip3.11 install . --no-build-isolation
 
-      - name: FlagTree Test on NVIDIA-A100
+      - name: FlagTree Test
         shell: bash
         run: |
           pytest -s python/test/unit
+          pytest -s python/test/operators

--- a/include/triton/Dialect/Triton/Transforms/Passes.h
+++ b/include/triton/Dialect/Triton/Transforms/Passes.h
@@ -11,6 +11,7 @@ std::unique_ptr<Pass> createCombineOpsPass();
 std::unique_ptr<Pass> createReorderBroadcastPass();
 std::unique_ptr<Pass> createRewriteTensorPointerPass();
 
+std::unique_ptr<Pass> createExpressionRestructingPass();
 } // namespace triton
 
 #define GEN_PASS_REGISTRATION

--- a/include/triton/Dialect/Triton/Transforms/Passes.td
+++ b/include/triton/Dialect/Triton/Transforms/Passes.td
@@ -41,4 +41,15 @@ def TritonRewriteTensorPointer : Pass</*cli-arg*/"triton-rewrite-tensor-pointer"
   let dependentDialects = ["mlir::triton::TritonDialect"];
 }
 
+def TritonExpressionRestructing : Pass</*cli-arg*/"triton-expression-resturcting", /*Op*/"mlir::ModuleOp"> {
+  let summary = "ExpressionRestructing";
+  let description = [{
+    transform a = b / c; d = a /e; to  a= c * e; d = b / a; 
+  }];
+
+  let constructor = "mlir::triton::createExpressionRestructingPass()";
+
+  let dependentDialects = ["mlir::triton::TritonDialect", "mlir::arith::ArithDialect"];
+}
+
 #endif

--- a/include/triton/Dialect/Triton/Transforms/Passes.td
+++ b/include/triton/Dialect/Triton/Transforms/Passes.td
@@ -44,7 +44,10 @@ def TritonRewriteTensorPointer : Pass</*cli-arg*/"triton-rewrite-tensor-pointer"
 def TritonExpressionRestructing : Pass</*cli-arg*/"triton-expression-resturcting", /*Op*/"mlir::ModuleOp"> {
   let summary = "ExpressionRestructing";
   let description = [{
-    transform a = b / c; d = a /e; to  a= c * e; d = b / a; 
+    transform a = b / c; d = a / e; to a = c * e; d = b / a;
+    transform a = b + c; d = a + c; to a = c + c; d = b + a;
+    transform a = b - c; d = a - c; to a = c + c; d = b - a;
+    transform a = b * c; d = a * c; to a = c * c; d = b * a;
   }];
 
   let constructor = "mlir::triton::createExpressionRestructingPass()";

--- a/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_triton_library(TritonTransforms
   RewriteTensorPointer.cpp
   ExpressionRestructing.cpp
 
+
   DEPENDS
   TritonTransformsIncGen
   TritonCombineIncGen

--- a/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_triton_library(TritonTransforms
   Combine.cpp
   ReorderBroadcast.cpp
   RewriteTensorPointer.cpp
+  ExpressionRestructing.cpp
 
   DEPENDS
   TritonTransformsIncGen

--- a/lib/Dialect/Triton/Transforms/ExpressionRestructing.cpp
+++ b/lib/Dialect/Triton/Transforms/ExpressionRestructing.cpp
@@ -11,165 +11,179 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/Transforms/Passes.h"
 
-
 #define GEN_PASS_CLASSES
 #include "triton/Dialect/Triton/Transforms/Passes.h.inc"
 
 using namespace mlir;
 using llvm::ArrayRef;
-namespace mlir::triton{
+namespace mlir::triton {
 
+struct Div2Mul : public OpRewritePattern<arith::DivFOp> {
+  using OpRewritePattern<arith::DivFOp>::OpRewritePattern;
 
-struct Div2Mul : public OpRewritePattern<arith::DivFOp>{
-    using OpRewritePattern<arith::DivFOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(arith::DivFOp op,
+                                PatternRewriter &rewriter) const override {
+    Value result = op.getResult();
+    Value l = op.getLhs();
+    Value r = op.getRhs();
+    auto loc = op.getLoc();
 
-    LogicalResult matchAndRewrite(arith::DivFOp op, PatternRewriter &rewriter) const override{
-        Value result = op.getResult();
-        Value l = op.getLhs();
-        Value r = op.getRhs();
-        auto loc = op.getLoc();
-
-        if (!result.hasOneUse())
-            return failure();
-        for (auto &use : result.getUses()){
-            if(!dyn_cast<arith::DivFOp>(use.getOwner()))
-                return failure();
-            auto DivUser = dyn_cast<arith::DivFOp>(use.getOwner());
-            if(DivUser.getLhs()!= op.getResult())
-                return failure();
-            auto originalInsertionPoint = rewriter.saveInsertionPoint();
-            rewriter.setInsertionPointAfter(DivUser);
-            auto loc_div = DivUser.getLoc();
-            auto product = rewriter.create<arith::MulFOp>(loc_div, r, DivUser.getRhs());
-            rewriter.setInsertionPointAfter(product);
-            auto ResultEnd = rewriter.create<arith::DivFOp>(loc_div, l, product.getResult());
-            rewriter.restoreInsertionPoint(originalInsertionPoint);
-            rewriter.replaceOp(op, product.getResult());
-            DivUser.replaceAllUsesWith(ResultEnd.getResult());
-            rewriter.eraseOp(DivUser);
-        }
-        return success();
+    if (!result.hasOneUse())
+      return failure();
+    for (auto &use : result.getUses()) {
+      if (!dyn_cast<arith::DivFOp>(use.getOwner()))
+        return failure();
+      auto DivUser = dyn_cast<arith::DivFOp>(use.getOwner());
+      if (DivUser.getLhs() != op.getResult())
+        return failure();
+      auto originalInsertionPoint = rewriter.saveInsertionPoint();
+      rewriter.setInsertionPointAfter(DivUser);
+      auto loc_div = DivUser.getLoc();
+      auto product =
+          rewriter.create<arith::MulFOp>(loc_div, r, DivUser.getRhs());
+      rewriter.setInsertionPointAfter(product);
+      auto ResultEnd =
+          rewriter.create<arith::DivFOp>(loc_div, l, product.getResult());
+      rewriter.restoreInsertionPoint(originalInsertionPoint);
+      rewriter.replaceOp(op, product.getResult());
+      DivUser.replaceAllUsesWith(ResultEnd.getResult());
+      rewriter.eraseOp(DivUser);
     }
+    return success();
+  }
 };
 
-struct Mul2Mul : public OpRewritePattern<arith::MulFOp>{
-    using OpRewritePattern<arith::MulFOp>::OpRewritePattern;
+struct Mul2Mul : public OpRewritePattern<arith::MulFOp> {
+  using OpRewritePattern<arith::MulFOp>::OpRewritePattern;
 
-    LogicalResult matchAndRewrite(arith::MulFOp op, PatternRewriter &rewriter) const override{
-        Value result = op.getResult();
-        Value l = op.getLhs();
-        Value r = op.getRhs();
-        auto loc = op.getLoc();
+  LogicalResult matchAndRewrite(arith::MulFOp op,
+                                PatternRewriter &rewriter) const override {
+    Value result = op.getResult();
+    Value l = op.getLhs();
+    Value r = op.getRhs();
+    auto loc = op.getLoc();
 
-        if (!result.hasOneUse())
-            return failure();
-        for (auto &use : result.getUses()){
-            if(!dyn_cast<arith::MulFOp>(use.getOwner()))
-                return failure();
-            auto MulUser = dyn_cast<arith::MulFOp>(use.getOwner());
-            if(!(MulUser.getLhs() == op.getResult() && ((MulUser.getRhs().getDefiningOp<arith::ConstantOp>()&& r.getDefiningOp<arith::ConstantOp>())||(r == MulUser.getRhs()))))
-                return failure();
-            auto originalInsertionPoint = rewriter.saveInsertionPoint();
-            rewriter.setInsertionPointAfter(MulUser);
-            auto loc_mul = MulUser.getLoc();
-            auto product = rewriter.create<arith::MulFOp>(loc_mul, r, MulUser.getRhs());
-            rewriter.setInsertionPointAfter(product);
-            auto ResultEnd = rewriter.create<arith::MulFOp>(loc_mul, l, product.getResult());
-            rewriter.restoreInsertionPoint(originalInsertionPoint);
-            rewriter.replaceOp(op, product.getResult());
-            MulUser.replaceAllUsesWith(ResultEnd.getResult());
-            rewriter.eraseOp(MulUser);
-        }
-        return success();
+    if (!result.hasOneUse())
+      return failure();
+    for (auto &use : result.getUses()) {
+      if (!dyn_cast<arith::MulFOp>(use.getOwner()))
+        return failure();
+      auto MulUser = dyn_cast<arith::MulFOp>(use.getOwner());
+      if (!(MulUser.getLhs() == op.getResult() &&
+            ((MulUser.getRhs().getDefiningOp<arith::ConstantOp>() &&
+              r.getDefiningOp<arith::ConstantOp>()) ||
+             (r == MulUser.getRhs()))))
+        return failure();
+      auto originalInsertionPoint = rewriter.saveInsertionPoint();
+      rewriter.setInsertionPointAfter(MulUser);
+      auto loc_mul = MulUser.getLoc();
+      auto product =
+          rewriter.create<arith::MulFOp>(loc_mul, r, MulUser.getRhs());
+      rewriter.setInsertionPointAfter(product);
+      auto ResultEnd =
+          rewriter.create<arith::MulFOp>(loc_mul, l, product.getResult());
+      rewriter.restoreInsertionPoint(originalInsertionPoint);
+      rewriter.replaceOp(op, product.getResult());
+      MulUser.replaceAllUsesWith(ResultEnd.getResult());
+      rewriter.eraseOp(MulUser);
     }
+    return success();
+  }
 };
 
-struct Add2Add : public OpRewritePattern<arith::AddFOp>{
-    using OpRewritePattern<arith::AddFOp>::OpRewritePattern;
+struct Add2Add : public OpRewritePattern<arith::AddFOp> {
+  using OpRewritePattern<arith::AddFOp>::OpRewritePattern;
 
-    LogicalResult matchAndRewrite(arith::AddFOp op, PatternRewriter &rewriter) const override{
-        Value result = op.getResult();
-        Value l = op.getLhs();
-        Value r = op.getRhs();
-        auto loc = op.getLoc();
+  LogicalResult matchAndRewrite(arith::AddFOp op,
+                                PatternRewriter &rewriter) const override {
+    Value result = op.getResult();
+    Value l = op.getLhs();
+    Value r = op.getRhs();
+    auto loc = op.getLoc();
 
-        if (!result.hasOneUse())
-            return failure();
-        for (auto &use : result.getUses()){
-            if(!dyn_cast<arith::AddFOp>(use.getOwner()))
-                return failure();
-            auto AddUser = dyn_cast<arith::AddFOp>(use.getOwner());
-            if(!(AddUser.getLhs() == op.getResult() && ((AddUser.getRhs().getDefiningOp<arith::ConstantOp>()&& r.getDefiningOp<arith::ConstantOp>())||(r == AddUser.getRhs()))))
-                return failure();
-            auto originalInsertionPoint = rewriter.saveInsertionPoint();
-            rewriter.setInsertionPointAfter(AddUser);
-            auto loc_add = AddUser.getLoc();
-            auto sum = rewriter.create<arith::AddFOp>(loc_add, r, AddUser.getRhs());
-            rewriter.setInsertionPointAfter(sum);
-            auto ResultEnd = rewriter.create<arith::AddFOp>(loc_add, l, sum.getResult());
-            rewriter.restoreInsertionPoint(originalInsertionPoint);
-            rewriter.replaceOp(op, sum.getResult());
-            AddUser.replaceAllUsesWith(ResultEnd.getResult());
-            rewriter.eraseOp(AddUser);
-        }
-        return success();
+    if (!result.hasOneUse())
+      return failure();
+    for (auto &use : result.getUses()) {
+      if (!dyn_cast<arith::AddFOp>(use.getOwner()))
+        return failure();
+      auto AddUser = dyn_cast<arith::AddFOp>(use.getOwner());
+      if (!(AddUser.getLhs() == op.getResult() &&
+            ((AddUser.getRhs().getDefiningOp<arith::ConstantOp>() &&
+              r.getDefiningOp<arith::ConstantOp>()) ||
+             (r == AddUser.getRhs()))))
+        return failure();
+      auto originalInsertionPoint = rewriter.saveInsertionPoint();
+      rewriter.setInsertionPointAfter(AddUser);
+      auto loc_add = AddUser.getLoc();
+      auto sum = rewriter.create<arith::AddFOp>(loc_add, r, AddUser.getRhs());
+      rewriter.setInsertionPointAfter(sum);
+      auto ResultEnd =
+          rewriter.create<arith::AddFOp>(loc_add, l, sum.getResult());
+      rewriter.restoreInsertionPoint(originalInsertionPoint);
+      rewriter.replaceOp(op, sum.getResult());
+      AddUser.replaceAllUsesWith(ResultEnd.getResult());
+      rewriter.eraseOp(AddUser);
     }
+    return success();
+  }
 };
 
-struct Sub2Add : public OpRewritePattern<arith::SubFOp>{
-    using OpRewritePattern<arith::SubFOp>::OpRewritePattern;
+struct Sub2Add : public OpRewritePattern<arith::SubFOp> {
+  using OpRewritePattern<arith::SubFOp>::OpRewritePattern;
 
-    LogicalResult matchAndRewrite(arith::SubFOp op, PatternRewriter &rewriter) const override{
-        Value result = op.getResult();
-        Value l = op.getLhs();
-        Value r = op.getRhs();
-        auto loc = op.getLoc();
+  LogicalResult matchAndRewrite(arith::SubFOp op,
+                                PatternRewriter &rewriter) const override {
+    Value result = op.getResult();
+    Value l = op.getLhs();
+    Value r = op.getRhs();
+    auto loc = op.getLoc();
 
-        if (!result.hasOneUse())
-            return failure();
-        for (auto &use : result.getUses()){
-            if(!dyn_cast<arith::SubFOp>(use.getOwner()))
-                return failure();
-            auto SubUser = dyn_cast<arith::SubFOp>(use.getOwner());
-            if(!(SubUser.getLhs() == op.getResult() && ((SubUser.getRhs().getDefiningOp<arith::ConstantOp>()&& r.getDefiningOp<arith::ConstantOp>())||(r == SubUser.getRhs()))))
-                return failure();
-            auto originalInsertionPoint = rewriter.saveInsertionPoint();
-            rewriter.setInsertionPointAfter(SubUser);
-            auto loc_sub = SubUser.getLoc();
-            auto sum = rewriter.create<arith::AddFOp>(loc_sub, r, SubUser.getRhs());
-            rewriter.setInsertionPointAfter(sum);
-            auto ResultEnd = rewriter.create<arith::SubFOp>(loc_sub, l, sum.getResult());
-            rewriter.restoreInsertionPoint(originalInsertionPoint);
-            rewriter.replaceOp(op, sum.getResult());
-            SubUser.replaceAllUsesWith(ResultEnd.getResult());
-            rewriter.eraseOp(SubUser);
-        }
-        return success();
+    if (!result.hasOneUse())
+      return failure();
+    for (auto &use : result.getUses()) {
+      if (!dyn_cast<arith::SubFOp>(use.getOwner()))
+        return failure();
+      auto SubUser = dyn_cast<arith::SubFOp>(use.getOwner());
+      if (!(SubUser.getLhs() == op.getResult() &&
+            ((SubUser.getRhs().getDefiningOp<arith::ConstantOp>() &&
+              r.getDefiningOp<arith::ConstantOp>()) ||
+             (r == SubUser.getRhs()))))
+        return failure();
+      auto originalInsertionPoint = rewriter.saveInsertionPoint();
+      rewriter.setInsertionPointAfter(SubUser);
+      auto loc_sub = SubUser.getLoc();
+      auto sum = rewriter.create<arith::AddFOp>(loc_sub, r, SubUser.getRhs());
+      rewriter.setInsertionPointAfter(sum);
+      auto ResultEnd =
+          rewriter.create<arith::SubFOp>(loc_sub, l, sum.getResult());
+      rewriter.restoreInsertionPoint(originalInsertionPoint);
+      rewriter.replaceOp(op, sum.getResult());
+      SubUser.replaceAllUsesWith(ResultEnd.getResult());
+      rewriter.eraseOp(SubUser);
     }
+    return success();
+  }
 };
 
-class ExpressionRestructingPass : public TritonExpressionRestructingBase<ExpressionRestructingPass>{
+class ExpressionRestructingPass
+    : public TritonExpressionRestructingBase<ExpressionRestructingPass> {
 public:
-    void runOnOperation() override{
-        MLIRContext *context = &getContext();
-        RewritePatternSet patterns(context);
-        ModuleOp m = getOperation();
-        patterns.add<Div2Mul>(context);
-        patterns.add<Mul2Mul>(context);
-        patterns.add<Add2Add>(context);
-        patterns.add<Sub2Add>(context);
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    ModuleOp m = getOperation();
+    patterns.add<Div2Mul>(context);
+    patterns.add<Mul2Mul>(context);
+    patterns.add<Add2Add>(context);
+    patterns.add<Sub2Add>(context);
 
-        if (applyPatternsAndFoldGreedily(m, std::move(patterns)).failed())
-            signalPassFailure();
-    }
+    if (applyPatternsAndFoldGreedily(m, std::move(patterns)).failed())
+      signalPassFailure();
+  }
 };
 
-
-std::unique_ptr<mlir::Pass> createExpressionRestructingPass(){
-    return std::make_unique<ExpressionRestructingPass>();
+std::unique_ptr<mlir::Pass> createExpressionRestructingPass() {
+  return std::make_unique<ExpressionRestructingPass>();
 }
 
-}
-
-
-
+} // namespace mlir::triton

--- a/lib/Dialect/Triton/Transforms/ExpressionRestructing.cpp
+++ b/lib/Dialect/Triton/Transforms/ExpressionRestructing.cpp
@@ -1,0 +1,175 @@
+#include <memory>
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/Transforms/Passes.h"
+
+
+#define GEN_PASS_CLASSES
+#include "triton/Dialect/Triton/Transforms/Passes.h.inc"
+
+using namespace mlir;
+using llvm::ArrayRef;
+namespace mlir::triton{
+
+
+struct Div2Mul : public OpRewritePattern<arith::DivFOp>{
+    using OpRewritePattern<arith::DivFOp>::OpRewritePattern;
+
+    LogicalResult matchAndRewrite(arith::DivFOp op, PatternRewriter &rewriter) const override{
+        Value result = op.getResult();
+        Value l = op.getLhs();
+        Value r = op.getRhs();
+        auto loc = op.getLoc();
+
+        if (!result.hasOneUse())
+            return failure();
+        for (auto &use : result.getUses()){
+            if(!dyn_cast<arith::DivFOp>(use.getOwner()))
+                return failure();
+            auto DivUser = dyn_cast<arith::DivFOp>(use.getOwner());
+            if(DivUser.getLhs()!= op.getResult())
+                return failure();
+            auto originalInsertionPoint = rewriter.saveInsertionPoint();
+            rewriter.setInsertionPointAfter(DivUser);
+            auto loc_div = DivUser.getLoc();
+            auto product = rewriter.create<arith::MulFOp>(loc_div, r, DivUser.getRhs());
+            rewriter.setInsertionPointAfter(product);
+            auto ResultEnd = rewriter.create<arith::DivFOp>(loc_div, l, product.getResult());
+            rewriter.restoreInsertionPoint(originalInsertionPoint);
+            rewriter.replaceOp(op, product.getResult());
+            DivUser.replaceAllUsesWith(ResultEnd.getResult());
+            rewriter.eraseOp(DivUser);
+        }
+        return success();
+    }
+};
+
+struct Mul2Mul : public OpRewritePattern<arith::MulFOp>{
+    using OpRewritePattern<arith::MulFOp>::OpRewritePattern;
+
+    LogicalResult matchAndRewrite(arith::MulFOp op, PatternRewriter &rewriter) const override{
+        Value result = op.getResult();
+        Value l = op.getLhs();
+        Value r = op.getRhs();
+        auto loc = op.getLoc();
+
+        if (!result.hasOneUse())
+            return failure();
+        for (auto &use : result.getUses()){
+            if(!dyn_cast<arith::MulFOp>(use.getOwner()))
+                return failure();
+            auto MulUser = dyn_cast<arith::MulFOp>(use.getOwner());
+            if(!(MulUser.getLhs() == op.getResult() && ((MulUser.getRhs().getDefiningOp<arith::ConstantOp>()&& r.getDefiningOp<arith::ConstantOp>())||(r == MulUser.getRhs()))))
+                return failure();
+            auto originalInsertionPoint = rewriter.saveInsertionPoint();
+            rewriter.setInsertionPointAfter(MulUser);
+            auto loc_mul = MulUser.getLoc();
+            auto product = rewriter.create<arith::MulFOp>(loc_mul, r, MulUser.getRhs());
+            rewriter.setInsertionPointAfter(product);
+            auto ResultEnd = rewriter.create<arith::MulFOp>(loc_mul, l, product.getResult());
+            rewriter.restoreInsertionPoint(originalInsertionPoint);
+            rewriter.replaceOp(op, product.getResult());
+            MulUser.replaceAllUsesWith(ResultEnd.getResult());
+            rewriter.eraseOp(MulUser);
+        }
+        return success();
+    }
+};
+
+struct Add2Add : public OpRewritePattern<arith::AddFOp>{
+    using OpRewritePattern<arith::AddFOp>::OpRewritePattern;
+
+    LogicalResult matchAndRewrite(arith::AddFOp op, PatternRewriter &rewriter) const override{
+        Value result = op.getResult();
+        Value l = op.getLhs();
+        Value r = op.getRhs();
+        auto loc = op.getLoc();
+
+        if (!result.hasOneUse())
+            return failure();
+        for (auto &use : result.getUses()){
+            if(!dyn_cast<arith::AddFOp>(use.getOwner()))
+                return failure();
+            auto AddUser = dyn_cast<arith::AddFOp>(use.getOwner());
+            if(!(AddUser.getLhs() == op.getResult() && ((AddUser.getRhs().getDefiningOp<arith::ConstantOp>()&& r.getDefiningOp<arith::ConstantOp>())||(r == AddUser.getRhs()))))
+                return failure();
+            auto originalInsertionPoint = rewriter.saveInsertionPoint();
+            rewriter.setInsertionPointAfter(AddUser);
+            auto loc_add = AddUser.getLoc();
+            auto sum = rewriter.create<arith::AddFOp>(loc_add, r, AddUser.getRhs());
+            rewriter.setInsertionPointAfter(sum);
+            auto ResultEnd = rewriter.create<arith::AddFOp>(loc_add, l, sum.getResult());
+            rewriter.restoreInsertionPoint(originalInsertionPoint);
+            rewriter.replaceOp(op, sum.getResult());
+            AddUser.replaceAllUsesWith(ResultEnd.getResult());
+            rewriter.eraseOp(AddUser);
+        }
+        return success();
+    }
+};
+
+struct Sub2Add : public OpRewritePattern<arith::SubFOp>{
+    using OpRewritePattern<arith::SubFOp>::OpRewritePattern;
+
+    LogicalResult matchAndRewrite(arith::SubFOp op, PatternRewriter &rewriter) const override{
+        Value result = op.getResult();
+        Value l = op.getLhs();
+        Value r = op.getRhs();
+        auto loc = op.getLoc();
+
+        if (!result.hasOneUse())
+            return failure();
+        for (auto &use : result.getUses()){
+            if(!dyn_cast<arith::SubFOp>(use.getOwner()))
+                return failure();
+            auto SubUser = dyn_cast<arith::SubFOp>(use.getOwner());
+            if(!(SubUser.getLhs() == op.getResult() && ((SubUser.getRhs().getDefiningOp<arith::ConstantOp>()&& r.getDefiningOp<arith::ConstantOp>())||(r == SubUser.getRhs()))))
+                return failure();
+            auto originalInsertionPoint = rewriter.saveInsertionPoint();
+            rewriter.setInsertionPointAfter(SubUser);
+            auto loc_sub = SubUser.getLoc();
+            auto sum = rewriter.create<arith::AddFOp>(loc_sub, r, SubUser.getRhs());
+            rewriter.setInsertionPointAfter(sum);
+            auto ResultEnd = rewriter.create<arith::SubFOp>(loc_sub, l, sum.getResult());
+            rewriter.restoreInsertionPoint(originalInsertionPoint);
+            rewriter.replaceOp(op, sum.getResult());
+            SubUser.replaceAllUsesWith(ResultEnd.getResult());
+            rewriter.eraseOp(SubUser);
+        }
+        return success();
+    }
+};
+
+class ExpressionRestructingPass : public TritonExpressionRestructingBase<ExpressionRestructingPass>{
+public:
+    void runOnOperation() override{
+        MLIRContext *context = &getContext();
+        RewritePatternSet patterns(context);
+        ModuleOp m = getOperation();
+        patterns.add<Div2Mul>(context);
+        patterns.add<Mul2Mul>(context);
+        patterns.add<Add2Add>(context);
+        patterns.add<Sub2Add>(context);
+
+        if (applyPatternsAndFoldGreedily(m, std::move(patterns)).failed())
+            signalPassFailure();
+    }
+};
+
+
+std::unique_ptr<mlir::Pass> createExpressionRestructingPass(){
+    return std::make_unique<ExpressionRestructingPass>();
+}
+
+}
+
+
+

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -37,7 +37,8 @@ void init_triton_passes_ttir(py::module &&m) {
   using namespace mlir::triton;
   ADD_PASS_WRAPPER_0("add_combine", createCombineOpsPass);
   ADD_PASS_WRAPPER_0("add_reorder_broadcast", createReorderBroadcastPass);
-  ADD_PASS_WRAPPER_0("add_expression_restructing", createExpressionRestructingPass);
+  ADD_PASS_WRAPPER_0("add_expression_restructing",
+                     createExpressionRestructingPass);
   ADD_PASS_WRAPPER_0("add_rewrite_tensor_pointer",
                      createRewriteTensorPointerPass);
   ADD_PASS_WRAPPER_4("add_convert_to_ttgpuir",

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -37,6 +37,7 @@ void init_triton_passes_ttir(py::module &&m) {
   using namespace mlir::triton;
   ADD_PASS_WRAPPER_0("add_combine", createCombineOpsPass);
   ADD_PASS_WRAPPER_0("add_reorder_broadcast", createReorderBroadcastPass);
+  ADD_PASS_WRAPPER_0("add_expression_restructing", createExpressionRestructingPass);
   ADD_PASS_WRAPPER_0("add_rewrite_tensor_pointer",
                      createRewriteTensorPointerPass);
   ADD_PASS_WRAPPER_4("add_convert_to_ttgpuir",

--- a/python/test/operators/test_expression_restructuring.py
+++ b/python/test/operators/test_expression_restructuring.py
@@ -4,7 +4,8 @@ import torch
 
 import pytest
 
-VEC_SHAPES = [[64, 640], [32,128], [128,256]]
+VEC_SHAPES = [[64, 640], [32, 128], [128, 256]]
+
 
 def custom_rand_strided(shape, strides, device, dtype, seed=0):
     torch.manual_seed(seed)
@@ -12,16 +13,18 @@ def custom_rand_strided(shape, strides, device, dtype, seed=0):
     storage = torch.randn(total_size, device=device, dtype=dtype)
     return torch.as_strided(storage, size=shape, stride=strides)
 
+
 def torch_equivalent(arg_0, arg_1, arg_2, arg_3):
-    reshaped_arg_0 = arg_0.view(arg_2.shape[0], arg_2.shape[0], arg_2.shape[2])  
-    reshaped_arg_3 = arg_3.squeeze(-1)     
-    tmp0 = -reshaped_arg_0                 
-    tmp4 = arg_1 * arg_2                   
-    tmp7 = reshaped_arg_3 + 1e-06          
-    tmp8 = tmp4 / tmp7.unsqueeze(-1)       
-    tmp9 = tmp8 / tmp7.unsqueeze(-1)       
+    reshaped_arg_0 = arg_0.view(arg_2.shape[0], arg_2.shape[0], arg_2.shape[2])
+    reshaped_arg_3 = arg_3.squeeze(-1)
+    tmp0 = -reshaped_arg_0
+    tmp4 = arg_1 * arg_2
+    tmp7 = reshaped_arg_3 + 1e-06
+    tmp8 = tmp4 / tmp7.unsqueeze(-1)
+    tmp9 = tmp8 / tmp7.unsqueeze(-1)
     result = tmp0 * tmp9
     return result
+
 
 @triton.jit
 def expression_restructuring_function_test(in_ptr0, in_ptr1, in_ptr2, in_ptr3, out_ptr2, rnumel):
@@ -50,16 +53,12 @@ def expression_restructuring_function_test(in_ptr0, in_ptr1, in_ptr2, in_ptr3, o
 def test_accruacy_kernel(vec_shape):
     x = vec_shape[0]
     y = vec_shape[1]
-    arg_0 = custom_rand_strided((x * x, y), (y, 1), dtype=torch.float32,device='cuda')
-    arg_1 = custom_rand_strided((y,), (1,), dtype=torch.float32,device='cuda')
-    arg_2 = custom_rand_strided((x, x, y), (x * y, y, 1), dtype=torch.float32,device='cuda')
-    arg_3 = custom_rand_strided((x, x, 1), (x, 1, 1), dtype=torch.float32,device='cuda')
-    triton_result = custom_rand_strided((x, x, y), (x * y, y, 1), dtype=torch.float32,device='cuda')
-    grid = lambda meta: (x*x, )
-    expression_restructuring_function_test[grid](arg_0, arg_1, arg_2, arg_3,  triton_result, y)
+    arg_0 = custom_rand_strided((x * x, y), (y, 1), dtype=torch.float32, device='cuda')
+    arg_1 = custom_rand_strided((y, ), (1, ), dtype=torch.float32, device='cuda')
+    arg_2 = custom_rand_strided((x, x, y), (x * y, y, 1), dtype=torch.float32, device='cuda')
+    arg_3 = custom_rand_strided((x, x, 1), (x, 1, 1), dtype=torch.float32, device='cuda')
+    triton_result = custom_rand_strided((x, x, y), (x * y, y, 1), dtype=torch.float32, device='cuda')
+    grid = lambda meta: (x * x, )
+    expression_restructuring_function_test[grid](arg_0, arg_1, arg_2, arg_3, triton_result, y)
     torch_result = torch_equivalent(arg_0, arg_1, arg_2, arg_3)
     torch.testing.assert_close(triton_result, torch_result)
-    
-
-    
-

--- a/python/test/operators/test_expression_restructuring.py
+++ b/python/test/operators/test_expression_restructuring.py
@@ -49,6 +49,7 @@ def expression_restructuring_function_test(in_ptr0, in_ptr1, in_ptr2, in_ptr3, o
     tmp10 = tmp1 * tmp9
     tl.store(out_ptr2 + (r1 + (rnumel * x0)), tmp10, rmask)
 
+
 @pytest.mark.parametrize("vec_shape", VEC_SHAPES)
 def test_accruacy_kernel(vec_shape):
     x = vec_shape[0]

--- a/python/test/operators/test_expression_restructuring.py
+++ b/python/test/operators/test_expression_restructuring.py
@@ -1,0 +1,65 @@
+import triton
+import triton.language as tl
+import torch
+
+import pytest
+
+VEC_SHAPES = [[64, 640], [32,128], [128,256]]
+
+def custom_rand_strided(shape, strides, device, dtype, seed=0):
+    torch.manual_seed(seed)
+    total_size = sum((s - 1) * st for s, st in zip(shape, strides)) + 1
+    storage = torch.randn(total_size, device=device, dtype=dtype)
+    return torch.as_strided(storage, size=shape, stride=strides)
+
+def torch_equivalent(arg_0, arg_1, arg_2, arg_3):
+    reshaped_arg_0 = arg_0.view(arg_2.shape[0], arg_2.shape[0], arg_2.shape[2])  
+    reshaped_arg_3 = arg_3.squeeze(-1)     
+    tmp0 = -reshaped_arg_0                 
+    tmp4 = arg_1 * arg_2                   
+    tmp7 = reshaped_arg_3 + 1e-06          
+    tmp8 = tmp4 / tmp7.unsqueeze(-1)       
+    tmp9 = tmp8 / tmp7.unsqueeze(-1)       
+    result = tmp0 * tmp9
+    return result
+
+@triton.jit
+def expression_restructuring_function_test(in_ptr0, in_ptr1, in_ptr2, in_ptr3, out_ptr2, rnumel):
+    XBLOCK: tl.constexpr = 1
+    xoffset = tl.program_id(0) * XBLOCK
+    RBLOCK: tl.constexpr = 1024
+    xindex = tl.full([1], xoffset, tl.int32)
+    rindex = tl.arange(0, RBLOCK)[:]
+    rmask = rindex < rnumel
+    r1 = rindex
+    x0 = xindex
+    tmp0 = tl.load(in_ptr0 + (r1 + (rnumel * x0)), rmask, other=0)
+    tmp2 = tl.load(in_ptr1 + (r1), rmask, eviction_policy='evict_last', other=0)
+    tmp3 = tl.load(in_ptr2 + (r1 + (rnumel * x0)), rmask, other=0)
+    tmp5 = tl.load(in_ptr3 + (x0), None, eviction_policy='evict_last')
+    tmp1 = -tmp0
+    tmp4 = tmp2 * tmp3
+    tmp6 = 1e-06
+    tmp7 = tmp5 + tmp6
+    tmp8 = tmp4 / tmp7
+    tmp9 = tmp8 / tmp7
+    tmp10 = tmp1 * tmp9
+    tl.store(out_ptr2 + (r1 + (rnumel * x0)), tmp10, rmask)
+
+@pytest.mark.parametrize("vec_shape", VEC_SHAPES)
+def test_accruacy_kernel(vec_shape):
+    x = vec_shape[0]
+    y = vec_shape[1]
+    arg_0 = custom_rand_strided((x * x, y), (y, 1), dtype=torch.float32,device='cuda')
+    arg_1 = custom_rand_strided((y,), (1,), dtype=torch.float32,device='cuda')
+    arg_2 = custom_rand_strided((x, x, y), (x * y, y, 1), dtype=torch.float32,device='cuda')
+    arg_3 = custom_rand_strided((x, x, 1), (x, 1, 1), dtype=torch.float32,device='cuda')
+    triton_result = custom_rand_strided((x, x, y), (x * y, y, 1), dtype=torch.float32,device='cuda')
+    grid = lambda meta: (x*x, )
+    expression_restructuring_function_test[grid](arg_0, arg_1, arg_2, arg_3,  triton_result, y)
+    torch_result = torch_equivalent(arg_0, arg_1, arg_2, arg_3)
+    torch.testing.assert_close(triton_result, torch_result)
+    
+
+    
+

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -144,6 +144,7 @@ class CUDABackend(BaseBackend):
         passes.common.add_canonicalizer(pm)
         passes.ttir.add_reorder_broadcast(pm)
         passes.common.add_cse(pm)
+        passes.ttir.add_expression_restructing(pm)
         passes.common.add_licm(pm)
         passes.common.add_symbol_dce(pm)
         pm.run(mod)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -324,4 +324,3 @@ class CUDABackend(BaseBackend):
     def hash(self):
         version = get_ptxas_version()
         return f'{version}-{self.capability}'
-

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -1,16 +1,16 @@
-from triton.backends.compiler import BaseBackend, GPUTarget
-from triton._C.libtriton import ir, passes, llvm, nvidia
-
-from dataclasses import dataclass
 import functools
-from typing import Any, Tuple, Optional
 import hashlib
-import re
-import tempfile
-import signal
 import os
+import re
+import signal
 import subprocess
+import tempfile
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Optional, Tuple
+
+from triton._C.libtriton import ir, llvm, nvidia, passes
+from triton.backends.compiler import BaseBackend, GPUTarget
 
 
 @functools.lru_cache()
@@ -22,9 +22,15 @@ def _path_to_binary(binary: str):
 
     for bin in paths:
         if os.path.exists(bin) and os.path.isfile(bin):
-            result = subprocess.check_output([bin, "--version"], stderr=subprocess.STDOUT)
+            result = subprocess.check_output(
+                [bin, "--version"], stderr=subprocess.STDOUT
+            )
             if result is not None:
-                version = re.search(r".*release (\d+\.\d+).*", result.decode("utf-8"), flags=re.MULTILINE)
+                version = re.search(
+                    r".*release (\d+\.\d+).*",
+                    result.decode("utf-8"),
+                    flags=re.MULTILINE,
+                )
                 if version is not None:
                     return bin, version.group(1)
     raise RuntimeError(f"Cannot find {binary}")
@@ -32,17 +38,19 @@ def _path_to_binary(binary: str):
 
 @functools.lru_cache()
 def get_ptxas_version():
-    version = subprocess.check_output([_path_to_binary("ptxas")[0], "--version"]).decode("utf-8")
+    version = subprocess.check_output(
+        [_path_to_binary("ptxas")[0], "--version"]
+    ).decode("utf-8")
     return version
 
 
 @functools.lru_cache()
 def ptx_get_version(cuda_version) -> int:
-    '''
+    """
     Get the highest PTX version supported by the current CUDA driver.
-    '''
+    """
     assert isinstance(cuda_version, str)
-    major, minor = map(int, cuda_version.split('.'))
+    major, minor = map(int, cuda_version.split("."))
     if major == 12:
         return 80 + minor
     if major == 11:
@@ -76,29 +84,33 @@ class CUDAOptions:
     max_num_imprecise_acc_default: bool = None
     extern_libs: dict = None
     debug: bool = False
-    backend_name: str = 'cuda'
+    backend_name: str = "cuda"
 
     def __post_init__(self):
-        default_libdir = Path(__file__).parent / 'lib'
+        default_libdir = Path(__file__).parent / "lib"
         extern_libs = {} if self.extern_libs is None else dict(self.extern_libs)
-        if not extern_libs.get('libdevice', None):
-            extern_libs['libdevice'] = os.getenv("TRITON_LIBDEVICE_PATH", str(default_libdir / 'libdevice.10.bc'))
-        object.__setattr__(self, 'extern_libs', tuple(extern_libs.items()))
-        assert self.num_warps > 0 and (self.num_warps & (self.num_warps - 1)) == 0, \
-               "num_warps must be a power of 2"
+        if not extern_libs.get("libdevice", None):
+            extern_libs["libdevice"] = os.getenv(
+                "TRITON_LIBDEVICE_PATH", str(default_libdir / "libdevice.10.bc")
+            )
+        object.__setattr__(self, "extern_libs", tuple(extern_libs.items()))
+        assert (
+            self.num_warps > 0 and (self.num_warps & (self.num_warps - 1)) == 0
+        ), "num_warps must be a power of 2"
 
     def hash(self):
         hash_dict = dict(self.__dict__)
-        hash_dict["extern_libs"] = tuple((k, file_hash(v)) for k, v in sorted(hash_dict["extern_libs"]))
+        hash_dict["extern_libs"] = tuple(
+            (k, file_hash(v)) for k, v in sorted(hash_dict["extern_libs"])
+        )
         key = "_".join([f"{name}-{val}" for name, val in sorted(hash_dict.items())])
         return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
 
 class CUDABackend(BaseBackend):
-
     @staticmethod
     def supports_target(target: GPUTarget):
-        return target.backend == 'cuda'
+        return target.backend == "cuda"
 
     def __init__(self, target: GPUTarget) -> None:
         super().__init__(target)
@@ -107,7 +119,9 @@ class CUDABackend(BaseBackend):
         self.binary_ext = "cubin"
 
     def parse_options(self, opts) -> Any:
-        args = {k: opts[k] for k in CUDAOptions.__dataclass_fields__.keys() if k in opts}
+        args = {
+            k: opts[k] for k in CUDAOptions.__dataclass_fields__.keys() if k in opts
+        }
         args["allow_fp8e4nv"] = self.capability >= 89
         args["allow_fp8e4b15"] = self.capability < 90
         args["max_num_imprecise_acc_default"] = 2**30 if self.capability == 90 else 0
@@ -125,9 +139,11 @@ class CUDABackend(BaseBackend):
 
     def get_codegen_implementation(self):
         import triton.language.extra.cuda as cuda
+
         codegen_fns = {
-            "convert_custom_types":
-            cuda.convert_custom_float8_sm80 if self.capability >= 80 else cuda.convert_custom_float8_sm70
+            "convert_custom_types": cuda.convert_custom_float8_sm80
+            if self.capability >= 80
+            else cuda.convert_custom_float8_sm70
         }
         return codegen_fns
 
@@ -144,6 +160,7 @@ class CUDABackend(BaseBackend):
         passes.common.add_canonicalizer(pm)
         passes.ttir.add_reorder_broadcast(pm)
         passes.common.add_cse(pm)
+
         passes.ttir.add_expression_restructing(pm)
         passes.common.add_licm(pm)
         passes.common.add_symbol_dce(pm)
@@ -160,7 +177,9 @@ class CUDABackend(BaseBackend):
         # TTIR -> TTGIR
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        passes.ttir.add_convert_to_ttgpuir(pm, f"cuda:{capability}", opt.num_warps, 32, opt.num_ctas)
+        passes.ttir.add_convert_to_ttgpuir(
+            pm, f"cuda:{capability}", opt.num_warps, 32, opt.num_ctas
+        )
         # optimize TTGIR
         passes.ttgpuir.add_coalesce(pm)
         if capability // 10 >= 8:
@@ -188,7 +207,11 @@ class CUDABackend(BaseBackend):
             nvidia.passes.ttnvgpuir.add_tma_lowering(pm)
         passes.common.add_canonicalizer(pm)
         pm.run(mod)
-        metadata["cluster_dims"] = (cluster_info.clusterDimX, cluster_info.clusterDimY, cluster_info.clusterDimZ)
+        metadata["cluster_dims"] = (
+            cluster_info.clusterDimX,
+            cluster_info.clusterDimY,
+            cluster_info.clusterDimZ,
+        )
         return mod
 
     @staticmethod
@@ -254,17 +277,27 @@ class CUDABackend(BaseBackend):
         # like "+ptx8.4 is not a recognized feature for this target".
         llvm_ptx_version = min(83, ptx_version)
 
-        triple = 'nvptx64-nvidia-cuda'
-        proc = 'sm_90a' if capability == 90 else f'sm_{capability}'
-        features = f'+ptx{llvm_ptx_version}'
-        ret = llvm.translate_to_asm(src, triple, proc, features, ['nvptx-short-ptr'], opt.enable_fp_fusion, False)
+        triple = "nvptx64-nvidia-cuda"
+        proc = "sm_90a" if capability == 90 else f"sm_{capability}"
+        features = f"+ptx{llvm_ptx_version}"
+        ret = llvm.translate_to_asm(
+            src,
+            triple,
+            proc,
+            features,
+            ["nvptx-short-ptr"],
+            opt.enable_fp_fusion,
+            False,
+        )
         # Find kernel names (there should only be one)
         names = re.findall(r".visible .entry ([a-zA-Z_][a-zA-Z0-9_]*)", ret)
         assert len(names) == 1
         metadata["name"] = names[0]
         # post-process
-        ptx_version = f'{ptx_version//10}.{ptx_version%10}'
-        ret = re.sub(r'\.version \d+\.\d+', f'.version {ptx_version}', ret, flags=re.MULTILINE)
+        ptx_version = f"{ptx_version//10}.{ptx_version%10}"
+        ret = re.sub(
+            r"\.version \d+\.\d+", f".version {ptx_version}", ret, flags=re.MULTILINE
+        )
         # Remove the debug flag that prevents ptxas from optimizing the code
         ret = re.sub(r",\s*debug|debug,\s*", "", ret)
         if os.environ.get("NVPTX_ENABLE_DUMP", "0") == "1":
@@ -275,19 +308,24 @@ class CUDABackend(BaseBackend):
     @staticmethod
     def make_cubin(src, metadata, opt, capability):
         ptxas, _ = _path_to_binary("ptxas")
-        with tempfile.NamedTemporaryFile(delete=False, mode='w', suffix='.ptx') as fsrc, \
-            tempfile.NamedTemporaryFile(delete=False, mode='r', suffix='.log') as flog:
+        with tempfile.NamedTemporaryFile(
+            delete=False, mode="w", suffix=".ptx"
+        ) as fsrc, tempfile.NamedTemporaryFile(
+            delete=False, mode="r", suffix=".log"
+        ) as flog:
             fsrc.write(src)
             fsrc.flush()
-            fbin = fsrc.name + '.o'
+            fbin = fsrc.name + ".o"
 
-            line_info = '' if os.environ.get('TRITON_DISABLE_LINE_INFO') else ' -lineinfo'
-            fmad = '' if opt.enable_fp_fusion else ' --fmad=false'
-            suffix = 'a ' if capability == 90 else ' '
+            line_info = (
+                "" if os.environ.get("TRITON_DISABLE_LINE_INFO") else " -lineinfo"
+            )
+            fmad = "" if opt.enable_fp_fusion else " --fmad=false"
+            suffix = "a " if capability == 90 else " "
             if os.environ.get("DISABLE_PTXAS_OPT", "0") == "1":
-                cmd = f'{ptxas}{line_info}{fmad} -v --opt-level 0 --gpu-name=sm_{capability}{suffix}{fsrc.name} -o {fbin} 2> {flog.name}'
+                cmd = f"{ptxas}{line_info}{fmad} -v --opt-level 0 --gpu-name=sm_{capability}{suffix}{fsrc.name} -o {fbin} 2> {flog.name}"
             else:
-                cmd = f'{ptxas}{line_info}{fmad} -v --gpu-name=sm_{capability}{suffix}{fsrc.name} -o {fbin} 2> {flog.name}'
+                cmd = f"{ptxas}{line_info}{fmad} -v --gpu-name=sm_{capability}{suffix}{fsrc.name} -o {fbin} 2> {flog.name}"
 
             try:
                 subprocess.run(cmd, shell=True, check=True)
@@ -295,19 +333,22 @@ class CUDABackend(BaseBackend):
                 with open(flog.name) as log_file:
                     log = log_file.read()
                 if e.returncode == 255:
-                    raise RuntimeError(f'Internal Triton PTX codegen error: \n{log}')
+                    raise RuntimeError(f"Internal Triton PTX codegen error: \n{log}")
                 elif e.returncode == 128 + signal.SIGSEGV:
                     raise RuntimeError(
-                        f'Please run `ptxas {fsrc.name}` to confirm that this is a bug in `ptxas`\n{log}')
+                        f"Please run `ptxas {fsrc.name}` to confirm that this is a bug in `ptxas`\n{log}"
+                    )
                 else:
-                    raise RuntimeError(f'`ptxas` failed with error code {e.returncode}: \n{log}')
+                    raise RuntimeError(
+                        f"`ptxas` failed with error code {e.returncode}: \n{log}"
+                    )
             finally:
                 if os.path.exists(fsrc.name):
                     os.remove(fsrc.name)
                 if os.path.exists(flog.name):
                     os.remove(flog.name)
 
-            with open(fbin, 'rb') as f:
+            with open(fbin, "rb") as f:
                 cubin = f.read()
             if os.path.exists(fbin):
                 os.remove(fbin)
@@ -315,12 +356,20 @@ class CUDABackend(BaseBackend):
 
     def add_stages(self, stages, options):
         stages["ttir"] = lambda src, metadata: self.make_ttir(src, metadata, options)
-        stages["ttgir"] = lambda src, metadata: self.make_ttgir(src, metadata, options, self.capability)
-        stages["llir"] = lambda src, metadata: self.make_llir(src, metadata, options, self.capability)
-        stages["ptx"] = lambda src, metadata: self.make_ptx(src, metadata, options, self.capability)
-        stages["cubin"] = lambda src, metadata: self.make_cubin(src, metadata, options, self.capability)
+        stages["ttgir"] = lambda src, metadata: self.make_ttgir(
+            src, metadata, options, self.capability
+        )
+        stages["llir"] = lambda src, metadata: self.make_llir(
+            src, metadata, options, self.capability
+        )
+        stages["ptx"] = lambda src, metadata: self.make_ptx(
+            src, metadata, options, self.capability
+        )
+        stages["cubin"] = lambda src, metadata: self.make_cubin(
+            src, metadata, options, self.capability
+        )
 
     @functools.lru_cache()
     def hash(self):
         version = get_ptxas_version()
-        return f'{version}-{self.capability}'
+        return f"{version}-{self.capability}"


### PR DESCRIPTION
<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->
**OTHER**
add common pass of expression restructuring
**Function Description**
After going through the PyTorch Inductor backend, the model generates multiple fusion operators. Inside these operators, there are often several consecutive divisions. Since division has a much longer instruction cycle than multiplication, we’ve restructured the expressions where dependency conditions are satisfied. For example:
a = b / c; d = a / e; ======> a = c * e; d = b / a
**Function Test**
test file path : /flagtree/python/test/operators/test_expression_restructuring.py

> ----Before TritonExpressionRestructing IR----

```
     ...
    %15 = tt.load %14, %3, %cst_0 : tensor<1024x!tt.ptr<f32>> loc(#loc12)
    %16 = tt.addptr %arg3, %0 : !tt.ptr<f32>, i32 loc(#loc13)
    %17 = tt.splat %16 : !tt.ptr<f32> -> tensor<1x!tt.ptr<f32>> loc(#loc13)
    %18 = tt.load %17 evictionPolicy = evict_last : tensor<1x!tt.ptr<f32>> loc(#loc14)
    %19 = arith.subf %cst_0, %9 : tensor<1024xf32> loc(#loc15)
    %20 = arith.mulf %12, %15 : tensor<1024xf32> loc(#loc16)
    %21 = arith.addf %18, %cst : tensor<1xf32> loc(#loc17)
    %22 = tt.broadcast %21 : tensor<1xf32> -> tensor<1024xf32> loc(#loc18)
    %23 = arith.divf %20, %22 : tensor<1024xf32> loc(#loc18)
    %24 = arith.divf %23, %22 : tensor<1024xf32> loc(#loc19)
    %25 = arith.mulf %19, %24 : tensor<1024xf32> loc(#loc20)
    %26 = tt.splat %arg5 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>> loc(#loc21)
    %27 = tt.addptr %26, %6 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32> loc(#loc21)
    ...
```
> ----After TritonExpressionRestructing IR----
```
    ...
    %15 = tt.load %14, %3, %cst_0 : tensor<1024x!tt.ptr<f32>> loc(#loc12)
    %16 = tt.addptr %arg3, %0 : !tt.ptr<f32>, i32 loc(#loc13)
    %17 = tt.splat %16 : !tt.ptr<f32> -> tensor<1x!tt.ptr<f32>> loc(#loc13)
    %18 = tt.load %17 evictionPolicy = evict_last : tensor<1x!tt.ptr<f32>> loc(#loc14)
    %19 = arith.subf %cst_0, %9 : tensor<1024xf32> loc(#loc15)
    %20 = arith.mulf %12, %15 : tensor<1024xf32> loc(#loc16)
    %21 = arith.addf %18, %cst : tensor<1xf32> loc(#loc17)
    %22 = tt.broadcast %21 : tensor<1xf32> -> tensor<1024xf32> loc(#loc18)
    %23 = arith.mulf %22, %22 : tensor<1024xf32> loc(#loc19)
    %24 = arith.divf %20, %23 : tensor<1024xf32> loc(#loc19)
    %25 = arith.mulf %19, %24 : tensor<1024xf32> loc(#loc20)
    %26 = tt.splat %arg5 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>> loc(#loc21)
    %27 = tt.addptr %26, %6 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32> loc(#loc21)
    ...
```
**optimization result**
For example BERT model, Verified on operators such as triton_per_fused_add_div_eq_masked_fill_mul_neg_sum_7 and triton_per_fused_add_div_eq_masked_fill_mul_neg_sum_15, the performance can be improved by 10% - 15%.





