### PR TITLE
[BACKEND] Update iluvatar backend, plugin and llvm

### DIFF
--- a/.github/workflows/iluvatar-build-and-test.yml
+++ b/.github/workflows/iluvatar-build-and-test.yml
@@ -57,4 +57,4 @@ jobs:
       - name: FlagTree Test on Iluvatar
         shell: bash
         run: |
-          CUDA_VISIBLE_DEVICES=15 pytest -s third_party/iluvatar/python/test/unit
+          CUDA_VISIBLE_DEVICES=13 pytest -s third_party/iluvatar/python/test/unit

--- a/.github/workflows/iluvatar-build-and-test.yml
+++ b/.github/workflows/iluvatar-build-and-test.yml
@@ -57,4 +57,4 @@ jobs:
       - name: FlagTree Test on Iluvatar
         shell: bash
         run: |
-          CUDA_VISIBLE_DEVICES=12 pytest -s third_party/iluvatar/python/test/unit
+          CUDA_VISIBLE_DEVICES=15 pytest -s third_party/iluvatar/python/test/unit

--- a/.github/workflows/iluvatar-build-and-test.yml
+++ b/.github/workflows/iluvatar-build-and-test.yml
@@ -57,4 +57,4 @@ jobs:
       - name: FlagTree Test on Iluvatar
         shell: bash
         run: |
-          CUDA_VISIBLE_DEVICES=13 pytest -s third_party/iluvatar/python/test/unit
+          CUDA_VISIBLE_DEVICES=12 pytest -s third_party/iluvatar/python/test/unit

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Complete build commands for each backend:
 ```shell
 # Recommended: Use Ubuntu 20.04
 mkdir -p ~/.flagtree/iluvatar; cd ~/.flagtree/iluvatar
-wget https://github.com/FlagTree/flagtree/releases/download/v0.1.0-build-deps/iluvatar-llvm18-x86_64.tar.gz
+wget https://github.com/FlagTree/flagtree/releases/download/v0.3.0-build-deps/iluvatar-llvm18-x86_64.tar.gz
 tar zxvf iluvatar-llvm18-x86_64.tar.gz
-wget https://github.com/FlagTree/flagtree/releases/download/v0.1.0-build-deps/iluvatarTritonPlugin-cpython3.10-glibc2.30-glibcxx3.4.28-cxxabi1.3.12-ubuntu-x86_64.tar.gz
+wget https://github.com/FlagTree/flagtree/releases/download/v0.3.0-build-deps/iluvatarTritonPlugin-cpython3.10-glibc2.30-glibcxx3.4.28-cxxabi1.3.12-ubuntu-x86_64.tar.gz
 tar zxvf iluvatarTritonPlugin-cpython3.10-glibc2.30-glibcxx3.4.28-cxxabi1.3.12-ubuntu-x86_64.tar.gz
 cd ${YOUR_CODE_DIR}/flagtree/python
 export FLAGTREE_BACKEND=iluvatar
@@ -40,9 +40,9 @@ python3 -m pip install . --no-build-isolation -v
 # Recommended: Use the Docker image (22GB) https://su.bcebos.com/klx-sdk-release-public/xpytorch/docker/ubuntu2004_v030/ubuntu_2004_x86_64_v30.tar
 # Contact kunlunxin-support@baidu.com for support
 mkdir -p ~/.flagtree/xpu; cd ~/.flagtree/xpu
-wget https://github.com/FlagTree/flagtree/releases/download/v0.1.0-build-deps/XTDK-llvm19-ubuntu2004_x86_64.tar.gz
+wget https://github.com/FlagTree/flagtree/releases/download/v0.3.0-build-deps/XTDK-llvm19-ubuntu2004_x86_64.tar.gz
 tar zxvf XTDK-llvm19-ubuntu2004_x86_64.tar.gz
-wget https://github.com/FlagTree/flagtree/releases/download/v0.1.0-build-deps/xre-Linux-x86_64.tar.gz
+wget https://github.com/FlagTree/flagtree/releases/download/v0.3.0-build-deps/xre-Linux-x86_64.tar.gz
 tar zxvf xre-Linux-x86_64.tar.gz
 cd ${YOUR_CODE_DIR}/flagtree/python
 export FLAGTREE_BACKEND=xpu

--- a/README_cn.md
+++ b/README_cn.md
@@ -27,9 +27,9 @@ python3 -m pip install . --no-build-isolation -v
 ```shell
 # 推荐使用镜像 Ubuntu 20.04
 mkdir -p ~/.flagtree/iluvatar; cd ~/.flagtree/iluvatar
-wget https://github.com/FlagTree/flagtree/releases/download/v0.1.0-build-deps/iluvatar-llvm18-x86_64.tar.gz
+wget https://github.com/FlagTree/flagtree/releases/download/v0.3.0-build-deps/iluvatar-llvm18-x86_64.tar.gz
 tar zxvf iluvatar-llvm18-x86_64.tar.gz
-wget https://github.com/FlagTree/flagtree/releases/download/v0.1.0-build-deps/iluvatarTritonPlugin-cpython3.10-glibc2.30-glibcxx3.4.28-cxxabi1.3.12-ubuntu-x86_64.tar.gz
+wget https://github.com/FlagTree/flagtree/releases/download/v0.3.0-build-deps/iluvatarTritonPlugin-cpython3.10-glibc2.30-glibcxx3.4.28-cxxabi1.3.12-ubuntu-x86_64.tar.gz
 tar zxvf iluvatarTritonPlugin-cpython3.10-glibc2.30-glibcxx3.4.28-cxxabi1.3.12-ubuntu-x86_64.tar.gz
 cd ${YOUR_CODE_DIR}/flagtree/python
 export FLAGTREE_BACKEND=iluvatar
@@ -40,9 +40,9 @@ python3 -m pip install . --no-build-isolation -v
 # 推荐使用镜像（22GB）https://su.bcebos.com/klx-sdk-release-public/xpytorch/docker/ubuntu2004_v030/ubuntu_2004_x86_64_v30.tar
 # 联系 kunlunxin-support@baidu.com 可获取进一步支持
 mkdir -p ~/.flagtree/xpu; cd ~/.flagtree/xpu
-wget https://github.com/FlagTree/flagtree/releases/download/v0.1.0-build-deps/XTDK-llvm19-ubuntu2004_x86_64.tar.gz
+wget https://github.com/FlagTree/flagtree/releases/download/v0.3.0-build-deps/XTDK-llvm19-ubuntu2004_x86_64.tar.gz
 tar zxvf XTDK-llvm19-ubuntu2004_x86_64.tar.gz
-wget https://github.com/FlagTree/flagtree/releases/download/v0.1.0-build-deps/xre-Linux-x86_64.tar.gz
+wget https://github.com/FlagTree/flagtree/releases/download/v0.3.0-build-deps/xre-Linux-x86_64.tar.gz
 tar zxvf xre-Linux-x86_64.tar.gz
 cd ${YOUR_CODE_DIR}/flagtree/python
 export FLAGTREE_BACKEND=xpu

--- a/python/setup_tools/setup_helper.py
+++ b/python/setup_tools/setup_helper.py
@@ -383,13 +383,13 @@ cache = FlagTreeCache()
 # iluvatar
 cache.store(
     file="iluvatarTritonPlugin.so", condition=("iluvatar" == flagtree_backend) and (flagtree_plugin == ''), url=
-    "https://github.com/FlagTree/flagtree/releases/download/v0.1.0-build-deps/iluvatarTritonPlugin-cpython3.10-glibc2.30-glibcxx3.4.28-cxxabi1.3.12-ubuntu-x86_64.tar.gz",
-    copy_dst_path="third_party/iluvatar", md5_digest="7d4e136c")
+    "https://github.com/FlagTree/flagtree/releases/download/v0.3.0-build-deps/iluvatarTritonPlugin-cpython3.10-glibc2.30-glibcxx3.4.28-cxxabi1.3.12-ubuntu-x86_64.tar.gz",
+    copy_dst_path="third_party/iluvatar", md5_digest="015b9af8")
 
 cache.store(
     file="iluvatar-llvm18-x86_64",
     condition=("iluvatar" == flagtree_backend),
-    url="https://github.com/FlagTree/flagtree/releases/download/v0.1.0-build-deps/iluvatar-llvm18-x86_64.tar.gz",
+    url="https://github.com/FlagTree/flagtree/releases/download/v0.3.0-build-deps/iluvatar-llvm18-x86_64.tar.gz",
     pre_hock=lambda: check_env('LLVM_SYSPATH'),
     post_hock=set_llvm_env,
 )

--- a/third_party/iluvatar/backend/compiler.py
+++ b/third_party/iluvatar/backend/compiler.py
@@ -39,8 +39,7 @@ class CUDAOptions:
     debug: bool = False
     backend_name: str = 'cuda'
     use_sme: int = 0
-    enable_sme: bool = True
-    num_vgpr: int = 0
+    hash_corex: str = ''
 
     def __post_init__(self):
         default_libdir = cuda_home_dirs() + "/nvvm/libdevice/"
@@ -117,7 +116,7 @@ class CUDABackend(BaseBackend):
         # TTIR -> TTGIR
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        passes.ttir.add_convert_to_ttgpuir(pm, f"cuda:{capability}", opt.num_warps, 64, opt.num_ctas)
+        passes.ttir.add_convert_to_ttgpuir(pm, f"cuda:{capability}", opt.num_warps, 64, opt.num_ctas, opt.num_stages)
         # optimize TTGIR
         passes.ttgpuir.add_coalesce(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)
@@ -134,6 +133,7 @@ class CUDABackend(BaseBackend):
         passes.ttgpuir.add_prefetch(pm)
         passes.ttgpuir.add_optimize_dot_operands(pm, True)
         passes.ttgpuir.add_remove_layout_conversions(pm)
+        iluvatar.passes.ttgpuir.add_matmul_mmaload(pm, capability)
         iluvatar.passes.ttgpuir.add_matmul_mmastore(pm, capability)
         passes.ttgpuir.add_remove_layout_conversions(pm)
         iluvatar.passes.ttgpuir.add_mmareduce(pm, capability)
@@ -185,8 +185,8 @@ class CUDABackend(BaseBackend):
         fns = [fn for fn in llvm_mod.get_functions() if not fn.is_declaration()]
         # The public kernel should be kernel 0.
         fns[0].set_calling_conv(iluvatar.CALLING_CONV_ILUVATAR_KERNEL)
-        if (options.num_vgpr > 0):
-            fns[0].add_fn_attr("iluvatar-num-vgpr", f"{options.num_vgpr}")
+        if options.maxnreg and options.maxnreg > 0:
+            fns[0].add_fn_attr("iluvatar-num-vgpr", f"{options.maxnreg}")
 
         if options.extern_libs:
             paths = [path for (name, path) in options.extern_libs]

--- a/third_party/iluvatar/backend/driver.c
+++ b/third_party/iluvatar/backend/driver.c
@@ -104,6 +104,7 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
   CUmodule mod;
   int32_t n_regs = 0;
   int32_t n_spills = 0;
+  int32_t n_threads = 0;
   // create driver handles
   CUcontext pctx = 0;
 
@@ -124,6 +125,8 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
   CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(
       cuFuncGetAttribute(&n_spills, CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES, fun));
   n_spills /= 4;
+  CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuFuncGetAttribute(
+      &n_threads, CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK, fun));
   // set dynamic shared memory if necessary
   int shared_optin;
   CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuDeviceGetAttribute(
@@ -147,8 +150,8 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
   if (PyErr_Occurred()) {
     return NULL;
   }
-  return Py_BuildValue("(KKii)", (uint64_t)mod, (uint64_t)fun, n_regs,
-                       n_spills);
+  return Py_BuildValue("(KKiii)", (uint64_t)mod, (uint64_t)fun, n_regs,
+                       n_spills, n_threads);
 }
 
 typedef CUresult (*cuOccupancyMaxActiveClusters_t)(

--- a/third_party/iluvatar/include/triton/Analysis/Membar.h
+++ b/third_party/iluvatar/include/triton/Analysis/Membar.h
@@ -43,6 +43,38 @@ struct BlockInfo {
     syncWriteIntervals.clear();
   }
 
+#ifdef __ILUVATAR__
+  // type: 0 all | 1 del W from other R |2 del R from other W
+  void erase(BlockInfo &other, int type = 0) {
+    if (type == 0) {
+      for (auto &sri : other.syncReadIntervals)
+        syncReadIntervals.erase(sri);
+      for (auto &swi : other.syncWriteIntervals)
+        syncWriteIntervals.erase(swi);
+    } else if (type == 1) {
+      for (auto &sri : other.syncReadIntervals)
+        syncWriteIntervals.erase(sri);
+    } else if (type == 2) {
+      for (auto &swi : other.syncWriteIntervals)
+        syncReadIntervals.erase(swi);
+    }
+  }
+
+  // for debug
+  void printIntervals() {
+    if (syncReadIntervals.size() > 0 || syncWriteIntervals.size() > 0) {
+      std::cout << " syncReadIntervals";
+      for (auto &lhs : syncReadIntervals)
+        std::cout << " [" << lhs.start() << ", " << lhs.end() << "] ";
+      std::cout << "" << std::endl;
+      std::cout << " syncWriteIntervals";
+      for (auto &lhs : syncWriteIntervals)
+        std::cout << " [" << lhs.start() << ", " << lhs.end() << "] ";
+      std::cout << "" << std::endl;
+    }
+  }
+#endif
+
   /// Compares two BlockInfo objects.
   bool operator==(const BlockInfo &other) const {
     return syncReadIntervals == other.syncReadIntervals &&

--- a/third_party/iluvatar/include/triton/Analysis/Utility.h
+++ b/third_party/iluvatar/include/triton/Analysis/Utility.h
@@ -212,8 +212,10 @@ bool shouldUseDistSmem(Attribute srcLayout, Attribute dstLayout);
 SetVector<Operation *>
 multiRootTopologicalSort(const SetVector<Operation *> &toSort);
 
+#ifdef __ILUVATAR__
+/// This function dones't use assertion check.
 void getBackwardSliceCorex(Operation *op, SetVector<Operation *> *backwardSlice,
-                           TransitiveFilter filter,
+                           TransitiveFilter filter = nullptr,
                            bool omitBlockArguments = false);
 
 void getBackwardSliceImplCorex(Operation *op,
@@ -221,10 +223,13 @@ void getBackwardSliceImplCorex(Operation *op,
                                TransitiveFilter filter,
                                bool omitBlockArguments = false);
 
+#endif
+
 /// This uses the toplogicalSort above
 SetVector<Operation *>
 multiRootGetSlice(Operation *op, TransitiveFilter backwardFilter = nullptr,
-                  TransitiveFilter forwardFilter = nullptr);
+                  TransitiveFilter forwardFilter = nullptr,
+                  bool omitBlockArguments = true);
 
 /// Create a basic DataFlowSolver with constant and dead code analysis included.
 std::unique_ptr<DataFlowSolver> createDataFlowSolver();

--- a/third_party/iluvatar/include/triton/Conversion/TritonToTritonGPU/Passes.td
+++ b/third_party/iluvatar/include/triton/Conversion/TritonToTritonGPU/Passes.td
@@ -30,7 +30,10 @@ def ConvertTritonToTritonGPU: Pass<"convert-triton-to-tritongpu", "mlir::ModuleO
               "number of ctas in a cga">,
         Option<"target", "target",
               "std::string", /*default*/"\"\"",
-              "the GPU target, e.g., cuda:80, hip:gfx942">
+              "the GPU target, e.g., cuda:80, hip:gfx942">,
+      Option<"numStages", "num-stages",
+              "int32_t", /*default*/"1",
+              "dot num_stages">
    ];
 }
 

--- a/third_party/iluvatar/include/triton/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.h
+++ b/third_party/iluvatar/include/triton/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.h
@@ -17,13 +17,18 @@ constexpr static char AttrTargetName[] = "triton_gpu.target";
 
 constexpr static char AttrNumThreadsPerWarp[] = "triton_gpu.threads-per-warp";
 
+#ifdef __ILUVATAR__
+constexpr static char AttrNumStagesForDot[] = "triton_gpu.dot.num-stages";
+#endif
+
 // Create the pass with numWarps passed from cl::opt.
 std::unique_ptr<OperationPass<ModuleOp>> createConvertTritonToTritonGPUPass();
 
 // Create the pass with numWarps set explicitly.
 std::unique_ptr<OperationPass<ModuleOp>>
 createConvertTritonToTritonGPUPass(const std::string &target, int numWarps,
-                                   int threadsPerWarp = 32, int numCTAs = 1);
+                                   int threadsPerWarp = 32, int numCTAs = 1,
+                                   int numStages = 1);
 
 } // namespace triton
 } // namespace mlir

--- a/third_party/iluvatar/include/triton/Dialect/Triton/IR/TritonAttrDefs.td
+++ b/third_party/iluvatar/include/triton/Dialect/Triton/IR/TritonAttrDefs.td
@@ -13,6 +13,7 @@ def TT_CacheModifierAttr : I32EnumAttr<
         I32EnumAttrCase<"WB", 4, "wb">,
         I32EnumAttrCase<"CS", 5, "cs">,
         I32EnumAttrCase<"WT", 6, "wt">,
+        I32EnumAttrCase<"CV", 7, "cv">,
     ]> {
     let cppNamespace = "::mlir::triton";
 }

--- a/third_party/iluvatar/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/third_party/iluvatar/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -114,10 +114,18 @@ bool isExpensiveCat(CatOp cat, Attribute targetEncoding);
 // Return true if a view between the two types cannot be implemented as a no-op.
 bool isExpensiveView(Type srcType, Type dstType);
 
+#ifdef __ILUVATAR__
+bool isMma(Attribute layout);
+
+bool isSliceMmaWithDim(Attribute layout, int targetDim);
+
+bool isMmaOrSliceMma(Attribute layout);
+
 bool isMmaConvertLayout(Operation *op);
 
 bool isSliceMmaConvertLayout(Operation *op, bool srcNoWarpReduce,
                              bool dstNoWarpReduce);
+#endif
 
 // Return a blocked encoding where the shape is distributed contiguously amongst
 // the threads, warps, CTAs with 1 element per threads.

--- a/third_party/iluvatar/include/triton/Dialect/TritonGPU/IR/TritonGPUDialect.td
+++ b/third_party/iluvatar/include/triton/Dialect/TritonGPU/IR/TritonGPUDialect.td
@@ -44,6 +44,15 @@ def TritonGPU_Dialect : Dialect {
       }
       return cast<IntegerAttr>(threadsPerWarp).getInt();
     }
+
+#ifdef __ILUVATAR__
+    static int getDotNumStages(ModuleOp mod) {
+      if(!mod->hasAttr("triton_gpu.dot.num-stages"))
+        llvm::report_fatal_error(
+            "TritonGPU module should contain a triton_gpu.dot.num-stages attribute");
+      return mod->getAttrOfType<IntegerAttr>("triton_gpu.dot.num-stages").getInt();
+    }
+#endif
   }];
 
   let useDefaultTypePrinterParser = 1;

--- a/third_party/iluvatar/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/third_party/iluvatar/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -75,14 +75,29 @@ def TTG_AsyncCommitGroupOp : TTG_Op<"async_commit_group"> {
 def TTG_AsyncCopyGlobalToLocalOp : TTG_Op<"async_copy_global_to_local", [
   AttrSizedOperandSegments,
   DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+
+  // Possible operand compositions, sorted by number of operands:
+  //   [src, result]
+  //   [src, result, mask]
+  //   [src, result, mask, other]
+  //   [src, result, inputStride, placeHolder0, placeHolder1]
+  //   [src, result, mask, inputStride, placeHolder0, placeHolder1]
+  //   [src, result, mask, other, inputStride, placeHolder0, placeHolder1]
   TypesMatchWith<"infer mask type from src type",
-                 "src", "mask", "getI1SameShape($_self)",
-                //  "($_op.getOperands().size() <= 3) || std::equal_to<>()">,
-                "($_op.getOperands().size() == 6) || ($_op.getOperands().size() <= 3) || std::equal_to<>()">,
+                "src", "mask", "getI1SameShape($_self)",
+                "($_op.getOperands().size() <= 2 || $_op.getOperands().size() == 5) || std::equal_to<>()">,
   TypesMatchWith<"infer other type from src type",
                  "src", "other", "getPointeeType($_self)",
-                //  "($_op.getOperands().size() <= 4) || std::equal_to<>()">
-                "($_op.getOperands().size() != 4) || std::equal_to<>()">
+                "($_op.getOperands().size() != 4 && $_op.getOperands().size() != 7) || std::equal_to<>()">,
+  TypesMatchWith<"inputStride type is i32 or i64 when operand count >=5",
+                "src", "inputStride", "getI32Type($_self)",
+                "($_op.getOperands().size() <= 4 || $inputStride.getType().isInteger(64)) || std::equal_to<>()">,
+  TypesMatchWith<"placeHolder0 type is i32 or i64 when operand count >=5",
+                "src", "placeHolder0", "getI32Type($_self)",
+                "($_op.getOperands().size() <= 4 || $placeHolder0.getType().isInteger(64)) || std::equal_to<>()">,
+  TypesMatchWith<"placeHolder1 type is i32 or i64 when operand count >=5",
+                "src", "placeHolder1", "getI32Type($_self)",
+                "($_op.getOperands().size() <= 4 || $placeHolder1.getType().isInteger(64)) || std::equal_to<>()">,
 ]> {
   let summary = "copy data from global memory to local memory asynchronously";
 
@@ -120,6 +135,9 @@ def TTG_AsyncCopyGlobalToLocalOp : TTG_Op<"async_copy_global_to_local", [
       }
       return validLoadBytes;
     }
+    static Type getI32Type(Type srcType) {
+      return IntegerType::get(srcType.getContext(), 32);
+    }
   }];
 
   // Specify cacheModifier and evictionPolicy explicitly, instead of leaving
@@ -128,12 +146,14 @@ def TTG_AsyncCopyGlobalToLocalOp : TTG_Op<"async_copy_global_to_local", [
   //
   // Note there are no commas between other, cacheModifier, and evictionPolicy,
   // due to limitations in MLIR's asm parser.
-  // let assemblyFormat = [{
-  //   $src `,` $result (`mask` $mask^)? (`other` $other^)?
-  //   oilist(`cacheModifier` `=` $cache | `evictionPolicy` `=` $evict)
-  //   attr-dict `:` type($src) `->` type($result)
-  // }];
-  let hasCustomAssemblyFormat = 1;
+    let assemblyFormat = [{
+     $src `,` $result (`mask` $mask^)? (`other` $other^)?
+     (`inputStride` $inputStride^)? (`placeHolder0` $placeHolder0^)? (`placeHolder1` $placeHolder1^)?
+     oilist(`cacheModifier` `=` $cache | `evictionPolicy` `=` $evict)
+     attr-dict `:` type($src) `->` type($result)
+    }];
+
+  //let hasCustomAssemblyFormat = 1;
 }
 
 

--- a/third_party/iluvatar/include/triton/Tools/Sys/GetEnv.hpp
+++ b/third_party/iluvatar/include/triton/Tools/Sys/GetEnv.hpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <assert.h>
 #include <cstdlib>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <string>

--- a/third_party/iluvatar/lib/Analysis/Allocation.cpp
+++ b/third_party/iluvatar/lib/Analysis/Allocation.cpp
@@ -662,6 +662,24 @@ private:
     }
   }
 
+  void dump() const {
+    llvm::outs() << "DUMP: "
+                 << "\n";
+    for (auto bufferIter : bufferRange) {
+      llvm::outs() << "ID= " << bufferIter.first->id << "\n";
+      if (bufferIter.first->kind == BufferT::BufferKind::Explicit)
+        llvm::outs() << "     Kind= Explict\n";
+      else if (bufferIter.first->kind == BufferT::BufferKind::Scratch)
+        llvm::outs() << "     Kind= Scratch\n";
+      else if (bufferIter.first->kind == BufferT::BufferKind::Virtual)
+        llvm::outs() << "     Kind= Virtual\n";
+      llvm::outs() << "     Size= " << bufferIter.first->size << "\n";
+      llvm::outs() << "     Offs= " << bufferIter.first->offset << "\n";
+      llvm::outs() << "     Interval= [" << bufferIter.second.start() << ", "
+                   << bufferIter.second.end() << ")\n";
+    }
+  }
+
 private:
   Operation *operation;
   Allocation::FuncAllocMapT *funcAllocMap;

--- a/third_party/iluvatar/lib/Analysis/Membar.cpp
+++ b/third_party/iluvatar/lib/Analysis/Membar.cpp
@@ -1,5 +1,6 @@
 #include "triton/Analysis/Membar.h"
 #include "triton/Analysis/Alias.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -7,6 +8,16 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include <deque>
+
+using getLoadIncNum_RankedTensorTypeFunc = unsigned (*)(
+    RankedTensorType &, int, int, llvm::ArrayRef<unsigned>, unsigned);
+
+using getLoadIncNum_MemDescTypeFunc = unsigned (*)(MemDescType &, int, int,
+                                                   llvm::ArrayRef<unsigned>,
+                                                   unsigned);
+
+DEFINE_LOAD_FUNC(getLoadIncNum_RankedTensorType)
+DEFINE_LOAD_FUNC(getLoadIncNum_MemDescType)
 
 namespace mlir {
 
@@ -106,6 +117,7 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
     return;
   }
 
+#ifndef __ILUVATAR__
   if (isa<triton::gpu::AsyncWaitOp>(op) &&
       !isa<gpu::BarrierOp>(op->getNextNode())) {
     // If the current op is an async wait and the next op is not a barrier we
@@ -115,6 +127,7 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
     blockInfo->sync();
     return;
   }
+#endif
 
   BlockInfo curBlockInfo;
   if (isa<triton::CallOp>(op)) {
@@ -166,10 +179,175 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
     }
   }
 
+#ifdef __ILUVATAR__
+  bool useBar = true;
+  int num_stages = triton::gpu::TritonGPUDialect::getDotNumStages(
+      op->getParentOfType<ModuleOp>());
+  if (num_stages > 1 && isa<triton::gpu::LocalLoadOp>(op)) {
+    auto localLoadOp = dyn_cast<triton::gpu::LocalLoadOp>(op);
+    Value src = localLoadOp.getSrc();
+    Value dst = localLoadOp.getResult();
+    auto srcTy = src.getType().cast<MemDescType>();
+    auto dstTy = dst.getType().cast<RankedTensorType>();
+    Attribute srcLayout = srcTy.getEncoding();
+    Attribute dstLayout = dstTy.getEncoding();
+    OpBuilder::InsertionGuard g(*builder);
+    auto cnt_ty = builder->getIntegerType(64);
+    auto insertBuffId = [](Value val, BlockInfo &tmpInfo,
+                           Allocation *allocation) {
+      for (auto bufferId : allocation->getBufferIds(val)) {
+        if (bufferId != Allocation::InvalidBufferId) {
+          tmpInfo.syncWriteIntervals.insert(
+              allocation->getAllocatedInterval(bufferId));
+        }
+      }
+    };
+    // a use inser but b use load, this should add alu.bar
+    if (srcLayout.isa<mlir::triton::gpu::BlockedEncodingAttr>() &&
+        dstLayout.isa<mlir::triton::gpu::SharedEncodingAttr>() &&
+        blockInfo->isIntersected(curBlockInfo)) {
+      builder->setInsertionPoint(op);
+      builder->create<LLVM::CallIntrinsicOp>(
+          op->getLoc(), void_ty(builder->getContext()),
+          "llvm.bi.sl.barrier.alu", ValueRange({}));
+      useBar = false;
+      blockInfo->syncReadIntervals.clear();
+    } else if (srcLayout.isa<mlir::triton::gpu::SharedEncodingAttr>() &&
+               dstLayout.isa<mlir::triton::gpu::DotOperandEncodingAttr>() &&
+               blockInfo->isIntersected(curBlockInfo)) {
+      builder->setInsertionPoint(op);
+      auto cnt_ty = builder->getIntegerType(64);
+      Value wait_cnt = nullptr;
+      BlockInfo tmpInfo;
+      auto capability =
+          getNVIDIAComputeCapability(op->getParentOfType<ModuleOp>());
+      if (capability < 80 || num_stages == 2) {
+        wait_cnt = builder->create<LLVM::ConstantOp>(
+            op->getLoc(), cnt_ty, IntegerAttr::get(cnt_ty, 12));
+        blockInfo->sync();
+      } else {
+        int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(
+            op->getParentOfType<ModuleOp>());
+        auto srcSharedLayout =
+            dyn_cast<mlir::triton::gpu::SharedEncodingAttr>(srcLayout);
+        auto dotOperandLayout =
+            dstLayout.cast<mlir::triton::gpu::DotOperandEncodingAttr>();
+        if (dotOperandLayout.getUseSme() > 0) {
+          Operation *tmp = nullptr;
+          unsigned asyncOrSmeNum = 0;
+          for (Operation *dop : dst.getUsers()) {
+            if (auto transOp = llvm::dyn_cast<triton::TransOp>(dop)) {
+              tmp = transOp.getSrc().getDefiningOp();
+            } else {
+              tmp = dop;
+            }
+            if (auto dotOp = llvm::dyn_cast<mlir::triton::DotOp>(tmp)) {
+              // check A & B use sme|async
+              if (dotOperandLayout.getOpIdx() == 0) {
+                insertBuffId(src, tmpInfo, allocation);
+                DEFINE_CALL_LOAD_FUNC(iluvatar, getLoadIncNum_RankedTensorType)
+                asyncOrSmeNum = func(dstTy, capability, numWarps,
+                                     srcSharedLayout.getOrder(), 0);
+                Value dotB = dotOp.getOperand(1);
+                Operation *bOp = dotB.getDefiningOp();
+                if (bOp) {
+                  if (auto convertBOp =
+                          dyn_cast<triton::gpu::LocalLoadOp>(bOp)) {
+                    Value dstB = convertBOp.getResult();
+                    auto dotBLayout =
+                        dstB.getType()
+                            .cast<RankedTensorType>()
+                            .getEncoding()
+                            .cast<mlir::triton::gpu::DotOperandEncodingAttr>();
+                    if (dotBLayout.getUseSme() > 0) {
+                      insertBuffId(convertBOp.getSrc(), tmpInfo, allocation);
+                      Value srcB = convertBOp.getSrc();
+                      auto srcBTy = srcB.getType().cast<MemDescType>();
+                      auto sharedBLayout =
+                          srcBTy.getEncoding()
+                              .cast<mlir::triton::gpu::SharedEncodingAttr>();
+                      DEFINE_CALL_LOAD_FUNC(iluvatar, getLoadIncNum_MemDescType)
+                      unsigned incBNum = func(srcBTy, capability, numWarps,
+                                              sharedBLayout.getOrder(), 1);
+                      asyncOrSmeNum += incBNum;
+                    }
+                  }
+                }
+              } else if (dotOperandLayout.getOpIdx() == 1) {
+                DEFINE_CALL_LOAD_FUNC(iluvatar, getLoadIncNum_RankedTensorType)
+                asyncOrSmeNum = func(dstTy, capability, numWarps,
+                                     srcSharedLayout.getOrder(), 1);
+                insertBuffId(src, tmpInfo, allocation);
+              }
+              break;
+            }
+          }
+          unsigned long long int waitCnt = 8;
+          int exponent = 23;
+          while (asyncOrSmeNum > 0) {
+            int tail = asyncOrSmeNum % 2;
+            if (tail > 0)
+              waitCnt += (1 << exponent);
+            asyncOrSmeNum = asyncOrSmeNum >> 1;
+            exponent++;
+          }
+          wait_cnt = builder->create<LLVM::ConstantOp>(
+              op->getLoc(), cnt_ty,
+              IntegerAttr::get(cnt_ty, waitCnt)); // only smem intrinsic
+        } else {
+          wait_cnt = builder->create<LLVM::ConstantOp>(
+              op->getLoc(), cnt_ty, IntegerAttr::get(cnt_ty, 4));
+          insertBuffId(src, tmpInfo, allocation);
+        }
+        blockInfo->erase(tmpInfo);
+      }
+      useBar = false;
+      builder->create<LLVM::CallIntrinsicOp>(
+          op->getLoc(), void_ty(builder->getContext()), "llvm.bi.sl.waitcnt",
+          ValueRange({wait_cnt}));
+      builder->create<LLVM::CallIntrinsicOp>(
+          op->getLoc(), void_ty(builder->getContext()),
+          "llvm.bi.sl.barrier.alu", ValueRange({}));
+    }
+  }
+#endif
+
   if (blockInfo->isIntersected(curBlockInfo)) {
     builder->setInsertionPoint(op);
+#if defined(__ILUVATAR__)
+    OpBuilder::InsertionGuard g(*builder);
+    if (isa<triton::gpu::AsyncCopyGlobalToLocalOp>(op)) {
+      // TODO: sl_wait not work for no_sme, may ixcc problem
+      auto asyncCopyGlobalToLocalOp =
+          dyn_cast<triton::gpu::AsyncCopyGlobalToLocalOp>(op);
+      Value buffer_idx = asyncCopyGlobalToLocalOp.getOperand(1)
+                             .getDefiningOp<triton::gpu::MemDescSubviewOp>()
+                             .getOffsets()[0];
+      if (auto constOp = buffer_idx.getDefiningOp<arith::ConstantOp>()) {
+        if (auto intAttr = dyn_cast<IntegerAttr>(constOp.getValue())) {
+          if (intAttr.getInt() == 0) {
+            auto cnt_ty = builder->getIntegerType(64);
+            Value wait_cnt = builder->create<LLVM::ConstantOp>(
+                op->getLoc(), cnt_ty, IntegerAttr::get(cnt_ty, 12));
+            builder->create<LLVM::CallIntrinsicOp>(
+                op->getLoc(), void_ty(builder->getContext()),
+                "llvm.bi.sl.waitcnt", ValueRange({wait_cnt}));
+            builder->create<LLVM::CallIntrinsicOp>(
+                op->getLoc(), void_ty(builder->getContext()),
+                "llvm.bi.sl.barrier.alu", ValueRange({}));
+            blockInfo->sync();
+          }
+        }
+      }
+      blockInfo->erase(curBlockInfo, 2);
+    } else if (useBar) {
+      auto barrierOp = builder->create<gpu::BarrierOp>(op->getLoc());
+      blockInfo->sync();
+    }
+#else
     insertBarrier(op, builder);
     blockInfo->sync();
+#endif
   }
   // Update the region info, even if barrier is inserted, we have to maintain
   // the current op's read/write buffers.

--- a/third_party/iluvatar/lib/Analysis/Utility.cpp
+++ b/third_party/iluvatar/lib/Analysis/Utility.cpp
@@ -860,8 +860,8 @@ void getBackwardSliceImplCorex(Operation *op,
       // blocks of parentOp, which are not technically backward unless they flow
       // into us. For now, just bail.
       if (parentOp && backwardSlice->count(parentOp) == 0) {
-        assert(parentOp->getNumRegions() == 1 &&
-               parentOp->getRegion(0).getBlocks().size() == 1);
+        // assert(parentOp->getNumRegions() == 1 &&
+        //        parentOp->getRegion(0).getBlocks().size() == 1);
         getBackwardSliceImplCorex(parentOp, backwardSlice, filter,
                                   omitBlockArguments);
       }
@@ -885,7 +885,8 @@ void getBackwardSliceCorex(Operation *op, SetVector<Operation *> *backwardSlice,
 
 SetVector<Operation *> multiRootGetSlice(Operation *op,
                                          TransitiveFilter backwardFilter,
-                                         TransitiveFilter forwardFilter) {
+                                         TransitiveFilter forwardFilter,
+                                         bool omitBlockArguments) {
   SetVector<Operation *> slice;
   slice.insert(op);
 

--- a/third_party/iluvatar/lib/Dialect/TritonGPU/Transforms/Pipeliner/Schedule.h
+++ b/third_party/iluvatar/lib/Dialect/TritonGPU/Transforms/Pipeliner/Schedule.h
@@ -10,13 +10,11 @@
 namespace mlir {
 namespace triton {
 
-#ifndef __ILUVATAR__
 /// This fill out the pipelining options including schedule and annotations
 /// for wait ops. This also does pre-processing by converting some of the
 /// loads into async loads so that the IR is ready to be pipelined.
 bool preProcessLoopAndGetSchedule(scf::ForOp &forOp, int numStages,
                                   mlir::triton::PipeliningOption &options);
-#endif
 
 /// Fills out pipelining options for an outer loop pipelining case. This
 /// schedules async copies to overlap with the epilogue of a loop.

--- a/third_party/iluvatar/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/third_party/iluvatar/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -464,6 +464,10 @@ std::optional<Attribute> inferSrcEncoding(Operation *op, Attribute encoding) {
     return inferSrcEncoding(trans, encoding);
   if (auto reshape = dyn_cast<triton::ReshapeOp>(op))
     return inferSrcEncoding(reshape, encoding);
+#ifdef __ILUVATAR__
+  if (auto load = dyn_cast<triton::LoadOp>(op))
+    return encoding;
+#endif
 
   return std::nullopt;
 }

--- a/third_party/iluvatar/python/src/ir.cc
+++ b/third_party/iluvatar/python/src/ir.cc
@@ -154,6 +154,7 @@ void init_triton_ir(py::module &&m) {
       .value("WB", CacheModifier::WB)
       .value("CS", CacheModifier::CS)
       .value("WT", CacheModifier::WT)
+      .value("CV", CacheModifier::CV)
       .export_values();
 
   py::enum_<MemSemantic>(m, "MEM_SEMANTIC", py::module_local())

--- a/third_party/iluvatar/python/src/llvm.cc
+++ b/third_party/iluvatar/python/src/llvm.cc
@@ -295,7 +295,7 @@ void init_triton_llvm(py::module &&m) {
         // should work on using NVPTX target instead and address the performance
         // regressions with some scheduling solution.
         // tuningOptions.SLPVectorization = true;
-        tuningOptions.SLPVectorization = true;
+        tuningOptions.SLPVectorization = false;
 
         if (!triple.empty())
           mod->setTargetTriple(triple.c_str());

--- a/third_party/iluvatar/python/src/passes.cc
+++ b/third_party/iluvatar/python/src/passes.cc
@@ -39,9 +39,9 @@ void init_triton_passes_ttir(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_reorder_broadcast", createReorderBroadcastPass);
   ADD_PASS_WRAPPER_0("add_rewrite_tensor_pointer",
                      createRewriteTensorPointerPass);
-  ADD_PASS_WRAPPER_4("add_convert_to_ttgpuir",
+  ADD_PASS_WRAPPER_5("add_convert_to_ttgpuir",
                      createConvertTritonToTritonGPUPass, const std::string &,
-                     int, int, int);
+                     int, int, int, int);
 }
 
 void init_triton_passes_ttgpuir(py::module &&m) {

--- a/third_party/iluvatar/python/src/passes.h
+++ b/third_party/iluvatar/python/src/passes.h
@@ -19,6 +19,11 @@
   m.def(name, [](mlir::PassManager &pm, ty0 val0, ty1 val1, ty2 val2,          \
                  ty3 val3) { pm.addPass(builder(val0, val1, val2, val3)); })
 
+#define ADD_PASS_WRAPPER_5(name, builder, ty0, ty1, ty2, ty3, ty4)             \
+  m.def(name,                                                                  \
+        [](mlir::PassManager &pm, ty0 val0, ty1 val1, ty2 val2, ty3 val3,      \
+           ty4 val4) { pm.addPass(builder(val0, val1, val2, val3, val4)); })
+
 #define ADD_PASS_OPTION_WRAPPER_1(name, builder, ty0)                          \
   m.def(name,                                                                  \
         [](mlir::PassManager &pm, ty0 val0) { pm.addPass(builder({val0})); })

--- a/third_party/iluvatar/python/test/unit/language/test_core.py
+++ b/third_party/iluvatar/python/test/unit/language/test_core.py
@@ -1324,6 +1324,7 @@ def noinline_multi_values_fn(x, y, Z):
     tl.store(Z, z)
 
 
+@pytest.mark.skip(reason="iluvatar, should export UMD_CUDAMODULELOADING=0 in 4.3.0 sdk")
 @pytest.mark.interpreter
 @pytest.mark.parametrize("mode", ["simple", "call_graph", "shared", "dynamic", "multi_values"])
 def test_noinline(mode, device):

--- a/third_party/iluvatar/python/test/unit/language/test_core.py
+++ b/third_party/iluvatar/python/test/unit/language/test_core.py
@@ -161,11 +161,14 @@ def check_type_supported(dtype, device):
     '''
     if device in ['cuda']:
         cc = torch.cuda.get_device_capability()
-        if not is_corex():
+        if is_corex():
+            if dtype in {tl.float8e4nv, "float8e4nv", "float8_e4m3fn", "float8e4b15", "float64"}:
+                pytest.skip(f"Skipping because {dtype} does not support")
+        else:
             if cc[0] < 8 and (dtype is tl.bfloat16 or dtype == "bfloat16" or dtype is torch.bfloat16):
                 pytest.skip("bfloat16 is only supported on NVGPU with cc >= 80")
-        if cc[0] < 9 and dtype in {tl.float8e4nv, "float8e4nv", "float8_e4m3fn"}:
-            pytest.skip("float8e4nv is only supported on NVGPU with cc >= 90")
+            if cc[0] < 9 and dtype in {tl.float8e4nv, "float8e4nv", "float8_e4m3fn"}:
+                pytest.skip("float8e4nv is only supported on NVGPU with cc >= 90")
     if is_interpreter():
         if dtype in [tl.bfloat16, "bfloat16", torch.bfloat16]:
             pytest.skip("bfloat16 is not supported in the interpreter")
@@ -240,7 +243,10 @@ def is_layout_applicable(layout) -> bool:
     if isinstance(layout, (BlockedLayout, SharedLayout)):
         return True
     elif is_cuda():
-        return isinstance(layout, MmaLayout)
+        if is_corex():
+            return False
+        else:
+            return isinstance(layout, MmaLayout)
     elif is_hip():
         target_arch = triton.runtime.driver.active.get_current_target().arch
         if "gfx11" in target_arch:
@@ -1041,7 +1047,10 @@ def test_precise_math(expr_prec, expr_ref, num_ctas, device):
     kernel = patch_kernel(kernel, {'PREC_CALC': expr_prec, 'REF_CALC': expr_ref})
 
     kernel[(1, )](x, y, out, out_ref, BLOCK=shape[0], num_ctas=num_ctas)
-    assert torch.all(out == out_ref)  # bitwise exact
+    if expr_prec == 'tl.math.sqrt_rn(x)' and expr_ref == 'tl.math.sqrt(x)':
+        torch.testing.assert_close(out, out_ref)
+    else:
+        assert torch.all(out == out_ref)  # bitwise exact
 
 
 # ----------------
@@ -1315,7 +1324,6 @@ def noinline_multi_values_fn(x, y, Z):
     tl.store(Z, z)
 
 
-@pytest.mark.skip(reason="compiler do not support func call in llvmir until 2025 Q2")
 @pytest.mark.interpreter
 @pytest.mark.parametrize("mode", ["simple", "call_graph", "shared", "dynamic", "multi_values"])
 def test_noinline(mode, device):
@@ -1532,25 +1540,20 @@ def test_atomic_cas(sem, num_ctas, device):
 @pytest.mark.interpreter
 @pytest.mark.parametrize("sem", [None, 'acquire', 'release', 'acq_rel', 'relaxed'])
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
-def test_tensor_atomic_cas(sem, num_ctas, device):
+@pytest.mark.parametrize("dtype", [torch.int64, torch.int32, torch.int16, torch.float32, torch.float16])
+def test_tensor_atomic_cas(sem, num_ctas, dtype, device):
+    if is_corex() and dtype is torch.int64:
+        pytest.skip("corex do not support 64bit atomic_cas")
 
     @triton.jit
     def change_value(X, BLOCK_SIZE: tl.constexpr, sem: tl.constexpr, USE_INT64: tl.constexpr = True):
         pid = tl.program_id(axis=0)
         block_start = pid * BLOCK_SIZE
         offsets = block_start + tl.arange(0, BLOCK_SIZE)
-        if USE_INT64:
-            dtype = tl.int64
-        else:
-            dtype = tl.int32
-        t1 = tl.full((BLOCK_SIZE, ), 0, dtype=dtype)
-        t2 = tl.full((BLOCK_SIZE, ), 2, dtype=dtype)
+        t1 = tl.full((BLOCK_SIZE, ), 0, dtype=X.dtype.element_ty)
+        t2 = tl.full((BLOCK_SIZE, ), 2, dtype=X.dtype.element_ty)
         tl.atomic_cas(X + offsets, t1, t2, sem=sem)
 
-    if is_corex():
-        dtype = torch.int32
-    else:
-        dtype = torch.int64
     X = torch.tensor([0, 1, 0, 1, 0, 1, 0, 1], device=device, dtype=dtype)
     Y = torch.tensor([2, 1, 2, 1, 2, 1, 2, 1], device=device, dtype=dtype)
 
@@ -1806,6 +1809,10 @@ def test_join_scalars(device):
 
 @pytest.mark.interpreter
 def test_join_with_mma(device):
+    if is_corex():
+        capability = torch.cuda.get_device_capability()
+        if capability[0] == 8:
+            pytest.skip("Skipping because QS does not support float32 mma now")
 
     @triton.jit
     def kernel(X, Z):
@@ -2485,7 +2492,7 @@ def test_scan_layouts(M, N, src_layout, axis, device):
 
     ir = f"""
     #blocked = {src_layout}
-    module attributes {{"triton_gpu.num-warps" = 4 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.threads-per-warp" = {THREADS_PER_WARP} : i32}} {{
+    module attributes {{"triton_gpu.dot.num-stages" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.threads-per-warp" = {THREADS_PER_WARP} : i32}} {{
     tt.func public @kernel_0d1d(%arg0: !tt.ptr<i32> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<i32> {{tt.divisibility = 16 : i32}}) {{
       %cst = arith.constant dense<{N}> : tensor<{M}x1xi32, #blocked>
       %0 = tt.make_range {{end = {M} : i32, start = 0 : i32}} : tensor<{M}xi32, #triton_gpu.slice<{{dim = 1, noWarpReduce=false, parent = #blocked}}>>
@@ -2640,7 +2647,7 @@ def test_reduce_layouts(M, N, src_layout, axis, epilogue_kind, dtype_str, reduce
     #blocked = {blocked}
     #src = {src_layout}
     #one_d_layout = {one_d_layout}
-    module attributes {{"triton_gpu.num-warps" = {num_warps} : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.threads-per-warp" = {THREADS_PER_WARP} : i32}} {{
+    module attributes {{"triton_gpu.dot.num-stages" = 1 : i32, "triton_gpu.num-warps" = {num_warps} : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.threads-per-warp" = {THREADS_PER_WARP} : i32}} {{
     tt.func public @kernel_0d1d2c3d4c(%arg0: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %arg1: i32 {{tt.divisibility = 16 : i32}}, %arg2: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}) {{
         %0 = tt.make_range {{end = {M} : i32, start = 0 : i32}} : tensor<{M}xi32, #{GPU_DIALECT}.slice<{{dim = 1, noWarpReduce=false, parent = #blocked}}>>
         %1 = tt.expand_dims %0 {{axis = 1 : i32}} : tensor<{M}xi32, #{GPU_DIALECT}.slice<{{dim = 1, noWarpReduce=false, parent = #blocked}}>> -> tensor<{M}x1xi32, #blocked>
@@ -2699,7 +2706,7 @@ def test_store_op(M, src_layout, device):
 
     ir = f"""
     #src = {src_layout}
-    module attributes {{"{GPU_DIALECT}.num-warps" = 4 : i32, "{GPU_DIALECT}.num-ctas" = 1 : i32, "{GPU_DIALECT}.threads-per-warp" = {THREADS_PER_WARP} : i32}} {{
+    module attributes {{"triton_gpu.dot.num-stages" = 1 : i32, "{GPU_DIALECT}.num-warps" = 4 : i32, "{GPU_DIALECT}.num-ctas" = 1 : i32, "{GPU_DIALECT}.threads-per-warp" = {THREADS_PER_WARP} : i32}} {{
         tt.func public @kernel(%arg0: !tt.ptr<f32> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<f32> {{tt.divisibility = 16 : i32}}) {{
             %0 = tt.make_range {{end = {M} : i32, start = 0 : i32}} : tensor<{M}xi32, #{GPU_DIALECT}.slice<{{dim = 1, noWarpReduce=false, parent = #src}}>>
             %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<{M}x!tt.ptr<f32>, #{GPU_DIALECT}.slice<{{dim = 1, noWarpReduce=false, parent = #src}}>>
@@ -2751,7 +2758,7 @@ def test_convert1d(M, src_layout, dst_layout, src_dim, dst_dim, device):
     ir = f"""
     #dst = {dst_layout}
     #src = {src_layout}
-    module attributes {{"{GPU_DIALECT}.num-warps" = 4 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.threads-per-warp" = {THREADS_PER_WARP} : i32}} {{
+    module attributes {{"triton_gpu.dot.num-stages" = 1 : i32, "{GPU_DIALECT}.num-warps" = 4 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.threads-per-warp" = {THREADS_PER_WARP} : i32}} {{
         tt.func public @kernel(%arg0: !tt.ptr<i32> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<i32> {{tt.divisibility = 16 : i32}}) {{
             %0 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<{M}x!tt.ptr<i32>, #{GPU_DIALECT}.slice<{{dim = {src_dim}, noWarpReduce=false, parent = #src}}>>
             %1 = tt.make_range {{end = {M} : i32, start = 0 : i32}} : tensor<{M}xi32, #{GPU_DIALECT}.slice<{{dim = {src_dim}, noWarpReduce=false, parent = #src}}>>
@@ -2821,7 +2828,7 @@ def test_chain_reduce(M, N, src_layout, op, device, first_axis):
         tt.reduce.return %14 : i32"""
     ir = f"""
     #src = {src_layout}
-    module attributes {{"{GPU_DIALECT}.num-warps" = 4 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.threads-per-warp" = {THREADS_PER_WARP} : i32}} {{
+    module attributes {{"triton_gpu.dot.num-stages" = 1 : i32, "{GPU_DIALECT}.num-warps" = 4 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.threads-per-warp" = {THREADS_PER_WARP} : i32}} {{
     tt.func public @sum_kernel_0d1d(%arg0: !tt.ptr<i32> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<i32> {{tt.divisibility = 16 : i32}}) {{
         %cst = arith.constant dense<{N}> : tensor<{M}x1xi32, #src>
         %0 = tt.make_range {{end = {M} : i32, start = 0 : i32}} : tensor<{M}xi32, #{GPU_DIALECT}.slice<{{dim = 1, noWarpReduce=false, parent = #src}}>>
@@ -3068,6 +3075,13 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
                     pytest.skip("float8e5/float8e4nv not supported on iluvatar devices")
                 if out_dtype != "float32":
                     pytest.skip("iluvatar devices only support out_dtype==float32")
+                if capability[0] == 8:
+                    if in_dtype == 'float32' or in_dtype == 'int8':
+                        pytest.skip("tl.dot do not support float32 or int8 on QS now")
+                    if out_dtype == 'float16':
+                        pytest.skip("tl.dot do not support out_dtype=float16 on QS now)")
+                    if in_dtype == 'bfloat16':
+                        pytest.skip("tl.dot do not support in_dtype=bfloat16(which will upcast to float32) on QS now)")
             else:
                 if capability[0] < 7:
                     pytest.skip("Only test tl.dot() on devices with sm >= 70")
@@ -3425,7 +3439,10 @@ def test_max_num_imprecise_acc(device):
 def test_dot_mulbroadcasted(in_dtype, device):
     if is_cuda():
         capability = torch.cuda.get_device_capability()
-        if not is_corex():
+        if is_corex():
+            if capability[0] == 8:
+                pytest.skip("tl.dot do not support float32 on QS now")
+        else:
             if capability[0] < 8:
                 pytest.skip("Requires sm >= 80 to run")
 
@@ -3711,7 +3728,10 @@ def test_masked_load_scalar(num_ctas, mask_val, other_val, device):
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
 def test_masked_load_shared_memory(dtype, device):
-
+    capability = torch.cuda.get_device_capability()
+    if capability[0] == 8:
+        if dtype == torch.float32:
+            pytest.skip("tl.dot do not support float32 on QS now")
     check_type_supported(dtype, device)  # bfloat16 on cc < 80 will not be tested
 
     M = 32
@@ -3850,9 +3870,10 @@ def test_store_cache_modifier(cache, device):
         x = tl.load(src + offsets)
         tl.store(dst + offsets, x, cache_modifier=CACHE)
 
+    pgm = _kernel[(1, )](dst, src, CACHE=cache)
+    torch.testing.assert_close(src, dst)
     if not is_cuda() or is_corex():
         return
-    pgm = _kernel[(1, )](dst, src, CACHE=cache)
     ptx = pgm.asm['ptx']
     if cache == '':
         assert 'st.global.wb' not in ptx
@@ -4247,7 +4268,6 @@ def test_num_warps_pow2(device):
     _kernel[(1, )](dst=dst, num_warps=4)
 
 
-@pytest.mark.skip
 @pytest.mark.interpreter
 @pytest.mark.parametrize("func_str", ['sqrt', 'rsqrt', 'exp', 'exp2', 'log', 'log2', 'sin', 'cos'])
 def test_unary_math(func_str, device):
@@ -4891,7 +4911,7 @@ def test_convert2d(M, N, src_layout, interm_layout, dst_layout, dtype, device):
         cc = torch.cuda.get_device_capability()
         CC_INT = cc[0] * 10 + cc[1]
         ir = layouts + f"""
-                module attributes {{"triton_gpu.num-warps" = 4 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.threads-per-warp" = {THREADS_PER_WARP} : i32, triton_gpu.target = "cuda:{CC_INT}"}} {{
+                module attributes {{"triton_gpu.dot.num-stages" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.threads-per-warp" = {THREADS_PER_WARP} : i32, triton_gpu.target = "cuda:{CC_INT}"}} {{
             tt.func public @kernel_0d1d(%arg0: !tt.ptr<f16> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<f16> {{tt.divisibility = 16 : i32}}) {{
                 %cst = arith.constant dense<{N}> : tensor<{M}x1xi32, #src>
                 %0 = tt.make_range {{end = {M} : i32, start = 0 : i32}} : tensor<{M}xi32, #triton_gpu.slice<{{dim = 1, noWarpReduce=false, parent = #src}}>>
@@ -4993,6 +5013,8 @@ mma_pairs = [
 def test_convertmma2mma(M, N, mma_pair, dtype, device):
     if is_hip():
         pytest.skip("test_mma2mma is not supported in HIP")
+    if is_corex():
+        pytest.skip("test_mma2mma is not supported in ILUVATAR")
 
     src_layout, _ = mma_pair
     num_warps = np.cumprod(src_layout.warps_per_cta)[-1]
@@ -5009,7 +5031,7 @@ def test_convertmma2mma(M, N, mma_pair, dtype, device):
         """
 
         ir = layouts + f"""
-        module attributes {{"triton_gpu.num-warps" = {num_warps} : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.threads-per-warp" = 32 : i32}} {{
+        module attributes {{"triton_gpu.dot.num-stages" = 1 : i32, "triton_gpu.num-warps" = {num_warps} : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.threads-per-warp" = 32 : i32}} {{
         tt.func public @kernel_0d1d(%arg0: !tt.ptr<f16> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<f16> {{tt.divisibility = 16 : i32}}) {{
         %cst = arith.constant dense<{N}> : tensor<{M}x1xi32, #src>
         %0 = tt.make_range {{end = {M} : i32, start = 0 : i32}} : tensor<{M}xi32, #triton_gpu.slice<{{dim = 1, noWarpReduce=false, parent = #src}}>>
@@ -5379,10 +5401,11 @@ def test_tl_range(device):
         torch.testing.assert_close(ref_out, c, rtol=1e-3, atol=1e-3)
     if device in ['cuda']:
         capability = torch.cuda.get_device_capability()
-        if capability[0] >= 8:
-            ptx = pgm.asm['ptx']
-            # check that the loop got pipelined with the right number of stages.
-            assert 'cp.async.wait_group 0x6' in ptx
+        if not is_corex():
+            if capability[0] >= 8:
+                ptx = pgm.asm['ptx']
+                # check that the loop got pipelined with the right number of stages.
+                assert 'cp.async.wait_group 0x6' in ptx
 
 
 @triton.jit(noinline=True)
@@ -5414,8 +5437,11 @@ def test_maxnreg(device):
     # Ensure that .maxnreg is set on the kernel function (marked with .entry)
     # and not on either of the noinline functions (marked with .func).
     try:
-        assert re.search(r'\.visible \.entry [^{;]*\.maxnreg 42', k.asm["ptx"])
-        assert not re.search(r'\.visible \.func [^{;]*\.maxnreg', k.asm["ptx"])
+        if is_corex():
+            assert re.search(r'!"maxnreg", i32 42', k.asm["llir"])
+        else:
+            assert re.search(r'\.visible \.entry [^{;]*\.maxnreg 42', k.asm["ptx"])
+            assert not re.search(r'\.visible \.func [^{;]*\.maxnreg', k.asm["ptx"])
     except AssertionError:
         print("Failing ptx:\n", k.asm["ptx"])
         raise

--- a/third_party/iluvatar/python/test/unit/language/test_subprocess.py
+++ b/third_party/iluvatar/python/test/unit/language/test_subprocess.py
@@ -6,6 +6,7 @@ from collections import Counter
 from triton.runtime.build import is_corex
 
 import pytest
+import torch
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 print_path = os.path.join(dir_path, "print_helper.py")
@@ -42,6 +43,9 @@ def is_interpreter():
     ("device_print_pointer", "int32"),
 ])
 def test_print(func_type: str, data_type: str):
+    capability = torch.cuda.get_device_capability()
+    if capability[0] == 8 and data_type in ["float16", "float32"]:
+        pytest.skip("QS need vprint3.")
     proc = subprocess.Popen([sys.executable, print_path, func_type, data_type], stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE, shell=False)
     outs, err = proc.communicate()

--- a/third_party/iluvatar/python/test/unit/operators/test_blocksparse.py
+++ b/third_party/iluvatar/python/test/unit/operators/test_blocksparse.py
@@ -126,11 +126,13 @@ def test_softmax(BLOCK, WIDTH, is_dense, device, Z=2, H=2, is_causal=True, scale
     # initialize data
     a_shape = (Z, H, M, N)
     a_ref, a_tri = make_pair(a_shape)
+    a_ref = a_ref.cpu()
     dout_ref, dout_tri = make_pair(a_shape)
+    dout_ref = dout_ref.cpu()
     # compute [torch]
     a_ref = mask_tensor(a_ref, layout, BLOCK, value=float("-inf"))
     a_ref.retain_grad()
-    at_mask = torch.ones((M, N), device=device)
+    at_mask = torch.ones((M, N), device=device).cpu()
     if is_causal:
         at_mask = torch.tril(at_mask)
     M = at_mask[None, None, :, :] + torch.zeros_like(a_ref)
@@ -148,6 +150,8 @@ def test_softmax(BLOCK, WIDTH, is_dense, device, Z=2, H=2, is_causal=True, scale
     out_tri.backward(dout_tri)
     da_tri = a_tri.grad
     # compare
+    out_tri = out_tri.cpu()
+    da_tri = da_tri.cpu()
     torch.testing.assert_close(out_tri, out_ref, equal_nan=True)
     torch.testing.assert_close(da_tri, da_ref, equal_nan=True)
 
@@ -167,6 +171,9 @@ def test_attention_fwd_bwd(
     capability = torch.cuda.get_device_capability()
     if capability[0] < 7:
         pytest.skip("Only test tl.dot() on devices with sm >= 70")
+    if capability[0] == 8:
+        if dtype == torch.float32:
+            pytest.skip("QS do not support float32 dot now.")
 
     # inputs
     qkv_shape = (batch_size, n_heads, n_ctx, 64)

--- a/third_party/iluvatar/python/test/unit/operators/test_dot_trans.py
+++ b/third_party/iluvatar/python/test/unit/operators/test_dot_trans.py
@@ -26,6 +26,9 @@ torch.manual_seed(0)
                           for disable_sme in ["0", "1"]
                           for dataType in ["float16", "bfloat16"]])
 def test_sme_and_swizzle_layout_trans(M, N, K, AT, BT, ACol, BCol, num_warps, disable_sme, dataType, device='cuda'):
+    capability = torch.cuda.get_device_capability()
+    if capability[0] == 8:
+        pytest.skip("Skipping on QS now)")
 
     @triton.jit
     def kernel(
@@ -104,6 +107,9 @@ def test_sme_and_swizzle_layout_trans(M, N, K, AT, BT, ACol, BCol, num_warps, di
                                                                       for num_warps in [1, 2, 4]
                                                                       for dataType in ["float16", "bfloat16"]])
 def test_multi_dot_trans(M, N, K, AT, BT, CT, num_warps, dataType, device='cuda'):
+    capability = torch.cuda.get_device_capability()
+    if capability[0] == 8:
+        pytest.skip("Skipping on QS now)")
 
     @triton.jit
     def kernel(

--- a/third_party/iluvatar/python/test/unit/operators/test_flash_attention.py
+++ b/third_party/iluvatar/python/test/unit/operators/test_flash_attention.py
@@ -19,9 +19,8 @@ from triton.runtime.build import is_corex
 @pytest.mark.parametrize('seq_par', [True, False])
 def test_op(Z, H, N_CTX, D_HEAD, dtype, causal, seq_par, device):
     capability = torch.cuda.get_device_capability()
-    if not is_corex():
-        if capability[0] < 8:
-            pytest.skip("Flash attention only supported for compute capability >= 80")
+    if capability[0] >= 8:
+        pytest.skip("Flash attention only supported for compute capability < 80")
     if dtype == torch.bfloat16 and os.environ.get("TRITON_INTERPRET", "0") == "1":
         pytest.skip("Flash attention bfloat16 not supported in interpreter mode")
     torch.manual_seed(20)

--- a/third_party/iluvatar/python/test/unit/operators/test_matmul.py
+++ b/third_party/iluvatar/python/test/unit/operators/test_matmul.py
@@ -122,6 +122,9 @@ def test_op(BLOCK_M, BLOCK_N, BLOCK_K, SPLIT_K, NWARP, NSTAGE, M, N, K, AT, BT, 
             pytest.skip("Iluvatar devices do not support float8 for now")
         if (ADTYPE == "int8" and BDTYPE == "bfloat16") or (ADTYPE == "float16" and BDTYPE == "int8"):
             pytest.skip("Iluvatar devices do not support this for now")
+        if capability[0] == 8:
+            if ADTYPE == "float32" or BDTYPE == "float32":
+                pytest.skip("matmuls do not support float32 on QS now")
     else:
         if capability[0] < 7:
             pytest.skip("Only test tl.dot() on devices with sm >= 70")

--- a/third_party/iluvatar/python/test/unit/operators/test_sme.py
+++ b/third_party/iluvatar/python/test/unit/operators/test_sme.py
@@ -639,7 +639,7 @@ def test_batch_mla():
 
 
 if __name__ == "__main__":
-    pytest.skip("iluvatar: ir.parse_mlir_module failed in CI.")
+    pass  # iluvatar: ir.parse_mlir_module failed in CI.
     test_16x32_f16_dot()
     test_16x32_i8_dot()
     test_16x32_f16_trans_dot()

--- a/third_party/iluvatar/python/test/unit/operators/test_sme.py
+++ b/third_party/iluvatar/python/test/unit/operators/test_sme.py
@@ -1,0 +1,655 @@
+# Copyright (c) 2025, Shanghai Iluvatar CoreX Semiconductor Co., Ltd.
+# All Rights Reserved.
+# Licensed under the MIT License
+
+import triton
+import triton.language as tl
+import torch
+import os
+from triton._C.libtriton import ir
+import re
+import inspect
+import random
+import math
+import pytest
+
+triton_cache_dir = os.environ.get('TRITON_CACHE_DIR', '/root/.triton/cache')
+
+
+def print_result_decorator(func):
+
+    def wrapper(*args, **kwargs):
+        is_close, is_sme = func(*args, **kwargs)
+        print(f"======> tests {func.__name__} results is close: {is_close}, sme result: {is_sme}")
+
+    return wrapper
+
+
+def get_ttgir_file(hash, name):
+    return triton_cache_dir + os.path.sep + hash + os.path.sep + name + ".ttgir"
+
+
+def check_dot_use_sme(lines, use_smes):
+    dot_cnt = 0
+    pattern = r"useSme = (\d+)"
+    for line in lines:
+        if "tt.dot" in line:
+            if dot_cnt >= len(use_smes):
+                return False
+            matches = re.findall(pattern, line)
+            matches = tuple([int(match) for match in matches])
+            if matches != use_smes[dot_cnt]:
+                print(f"expect {use_smes[dot_cnt]}, but got {matches}")
+                # print(use_smes, matches)
+                return False
+            dot_cnt += 1
+    return True
+
+
+def check_mlir(F, use_smes):
+    context = ir.context()
+    ir.load_dialects(context)
+    # backend.load_dialects(context)
+    # codegen_fns = backend.get_codegen_implementation()
+    path = get_ttgir_file(F.src.fn.hash_cache_file, F.src.fn.__name__)
+    print(path)
+    mod = ir.parse_mlir_module(path, context)
+    lines = mod.str().split("\n")
+    return check_dot_use_sme(lines, use_smes)
+
+
+@triton.jit
+def dot_kernel(A, B, C, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr):
+    M_offs = tl.arange(0, M)
+    N_offs = tl.arange(0, N)
+    K_offs = tl.arange(0, K)
+    A_vals = tl.load(A + M_offs[:, None] * K + K_offs[None, :])
+    B_vals = tl.load(B + K_offs[:, None] * N + N_offs[None, :])
+    C_vals = tl.dot(A_vals, B_vals)
+    tl.store(C + M_offs[:, None] * N + N_offs[None, :], C_vals)
+
+
+@triton.jit
+def dot_trans_kernel(A, B, C, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr):
+    M_offs = tl.arange(0, M)
+    N_offs = tl.arange(0, N)
+    K_offs = tl.arange(0, K)
+    A_vals = tl.load(A + M_offs[:, None] * K + K_offs[None, :])
+    B_vals = tl.load(B + N_offs[:, None] * K + K_offs[None, :])
+    B_vals = tl.trans(B_vals)
+    C_vals = tl.dot(A_vals, B_vals)
+    tl.store(C + M_offs[:, None] * N + N_offs[None, :], C_vals)
+
+
+@print_result_decorator
+def test_16x32_f16_dot():
+    A = torch.randn((16, 32), dtype=torch.half, device="cuda")
+    B = torch.randn((32, 16), dtype=torch.half, device="cuda")
+    C = torch.zeros((16, 16), dtype=torch.half, device="cuda")
+    F = dot_kernel[(1, )](A, B, C, 16, 16, 32)
+    D = A @ B
+    assert check_mlir(F, [(32, 0)])
+    return torch.allclose(C, D, atol=1e-3, rtol=1e-3), check_mlir(F, [(32, 0)])
+
+
+@print_result_decorator
+def test_16x32_i8_dot():
+    capability = torch.cuda.get_device_capability()
+    if capability[0] == 8:
+        pytest.skip("tl.dot do not support int8 on QS now")
+    A = torch.randint(-127, 127, (64, 64), dtype=torch.int8, device="cuda")
+    B = torch.randint(-127, 127, (64, 64), dtype=torch.int8, device="cuda")
+    C = torch.zeros((64, 64), dtype=torch.int32, device="cuda")
+    # A = torch.randn((16, 32), dtype=torch.half, device="cuda")
+    F = dot_kernel[(1, )](A, B, C, 64, 64, 64)
+    D = A.to(torch.float32) @ B.to(torch.float32)
+    assert check_mlir(F, [(64, 64)])
+    return torch.allclose(C.to(torch.float32), D, atol=1e-3, rtol=1e-3), check_mlir(F, [(64, 64)])
+
+
+@print_result_decorator
+def test_16x32_f16_trans_dot():
+    A = torch.randn((16, 32), dtype=torch.half, device="cuda")
+    B = torch.randn((16, 32), dtype=torch.half, device="cuda")
+    C = torch.zeros((16, 16), dtype=torch.half, device="cuda")
+    F = dot_trans_kernel[(1, )](A, B, C, 16, 16, 32)
+    D = A @ B.T
+    assert check_mlir(F, [(32, 32)])
+    return torch.allclose(C, D, atol=1e-3, rtol=1e-3), check_mlir(F, [(32, 32)])
+
+
+# @print_result_decorator
+# def test_16x32_i8_trans_dot():
+#     A = torch.randint(-127, 127, (64, 64), dtype=torch.int8, device="cuda")
+#     B = torch.randint(-127, 127, (64, 64), dtype=torch.int8, device="cuda")
+#     C = torch.zeros((64, 64), dtype=torch.int32, device="cuda")
+#     # A = torch.randn((16, 32), dtype=torch.half, device="cuda")
+#     F = dot_trans_kernel[(1, )](A, B, C, 64, 64, 64)
+#     D = A.to(torch.float32) @ B.T.to(torch.float32)
+#     return torch.allclose(C.to(torch.float32), D, atol=1e-3, rtol=1e-3),  check_mlir(F, [(1, 2)])
+
+
+@triton.jit
+def loop_k_dot_kernel(A, B, C, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr):
+    M_offs = tl.arange(0, M)
+    K_offs = tl.arange(0, 32)
+    N_offs = tl.arange(0, N)
+    K_ITER = K // 32
+    C_vals = tl.zeros((M, N), dtype=tl.float32)
+    for k_iter in range(K_ITER):
+        A_offs = A + k_iter * 32 + M_offs[:, None] * K + K_offs[None, :]
+        B_offs = B + (k_iter * 32 + K_offs[:, None]) * N + N_offs[None, :]
+        A_vals = tl.load(A_offs)
+        B_vals = tl.load(B_offs)
+        C_vals = tl.dot(A_vals, B_vals, C_vals)
+    tl.store(C + M_offs[:, None] * N + N_offs[None, :], C_vals)
+
+
+# @print_result_decorator
+# def test_loop_k_dot():
+#     A = torch.randn((32, 256), dtype=torch.float16, device="cuda")
+#     B = torch.randn((256, 32), dtype=torch.float16, device="cuda")
+#     C = torch.zeros((32, 32), dtype=torch.float16, device="cuda")
+#     D = A @ B
+#     F = loop_k_dot_kernel[(1, )](A, B, C, 32, 32, 256, num_warps=1, num_stages=1)
+#     # this case may get stride failed, cause can't get B stride
+#     return torch.allclose(C, D, atol=1e-3, rtol=1e-3),  check_mlir(F, [(1, 2)])
+
+
+@triton.jit
+def loop_k_dot_kernel2(A, B, C, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr):
+    M_offs = tl.arange(0, M)
+    K_offs = tl.arange(0, 32)
+    N_offs = tl.arange(0, N)
+    K_ITER = K // 32
+    C_vals = tl.zeros((M, N), dtype=tl.float32)
+    for k_iter in range(K_ITER):
+        A_offs = A + M_offs[:, None] * K + K_offs[None, :] + k_iter * 32
+        B_offs = B + k_iter * 32 * N + K_offs[:, None] * N + N_offs[None, :]
+        A_vals = tl.load(A_offs)
+        B_vals = tl.load(B_offs)
+        C_vals = tl.dot(A_vals, B_vals, C_vals)
+    tl.store(C + M_offs[:, None] * N + N_offs[None, :], C_vals)
+
+
+@print_result_decorator
+def test_loop_k_dot2():
+    A = torch.randn((32, 256), dtype=torch.float16, device="cuda")
+    B = torch.randn((256, 32), dtype=torch.float16, device="cuda")
+    C = torch.zeros((32, 32), dtype=torch.float16, device="cuda")
+    D = A @ B
+    F = loop_k_dot_kernel2[(1, )](A, B, C, 32, 32, 256, num_warps=1, num_stages=1)
+    # this case may get stride failed, cause can't get B stride
+    assert check_mlir(F, [(256, 32)])
+    return torch.allclose(C, D, atol=1e-3, rtol=1e-3), check_mlir(F, [(256, 32)])
+
+
+@triton.jit
+def loop_k_dot_kernel3(A, B, C, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr):
+    M_offs = tl.arange(0, M)
+    K_offs = tl.arange(0, 32)
+    N_offs = tl.arange(0, N)
+    K_ITER = K // 32
+    C_vals = tl.zeros((M, N), dtype=tl.float32)
+    A_base = A + M_offs[:, None] * K + K_offs[None, :]
+    B_base = B + K_offs[:, None] * N + N_offs[None, :]
+    for k_iter in range(K_ITER):
+        A_offs = A_base + k_iter * 32
+        B_offs = B_base + k_iter * 32 * N
+        A_vals = tl.load(A_offs)
+        B_vals = tl.load(B_offs)
+        C_vals = tl.dot(A_vals, B_vals, C_vals)
+    tl.store(C + M_offs[:, None] * N + N_offs[None, :], C_vals)
+
+
+@print_result_decorator
+def test_loop_k_dot3():
+    A = torch.randn((32, 256), dtype=torch.float16, device="cuda")
+    B = torch.randn((256, 32), dtype=torch.float16, device="cuda")
+    C = torch.zeros((32, 32), dtype=torch.float16, device="cuda")
+    D = A @ B
+    F = loop_k_dot_kernel3[(1, )](A, B, C, 32, 32, 256, num_warps=1, num_stages=1)
+    # this case may get stride failed, cause can't get B stride
+    assert check_mlir(F, [(256, 32)])
+    return torch.allclose(C, D, atol=1e-3, rtol=1e-3), check_mlir(F, [(256, 32)])
+
+
+@triton.jit
+def loop_n_dot_kernel(A, B, C, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr):
+    M_offs = tl.arange(0, M)
+    K_offs = tl.arange(0, K)
+    N_offs = tl.arange(0, 32)
+    N_ITER = N // 32
+    A_offs = A + M_offs[:, None] * K + K_offs[None, :]
+    A_vals = tl.load(A_offs)
+    B_base = B + K_offs[:, None] * N + N_offs[None, :]
+    for n_iter in range(N_ITER):
+        B_offs = B_base + n_iter * 32
+        B_vals = tl.load(B_offs)
+        C_vals = tl.dot(
+            A_vals,
+            B_vals,
+        )
+        tl.store(C + M_offs[:, None] * N + N_offs[None, :] + n_iter * 32, C_vals)
+
+
+@print_result_decorator
+def test_loop_n_dot():
+    A = torch.randn((32, 32), dtype=torch.float16, device="cuda")
+    B = torch.randn((32, 256), dtype=torch.float16, device="cuda")
+    C = torch.zeros((32, 256), dtype=torch.float16, device="cuda")
+    D = A @ B
+    F = loop_n_dot_kernel[(1, )](A, B, C, 32, 256, 32, num_warps=1, num_stages=1)
+    assert check_mlir(F, [(32, 256)])
+    return torch.allclose(C, D, atol=1e-3, rtol=1e-3), check_mlir(F, [(32, 256)])
+
+
+@triton.jit
+def dot_stride_kernel(A, B, C, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr):
+    M_offs = tl.arange(0, M)
+    N_offs = tl.arange(0, N)
+    K_offs = tl.arange(0, K)
+    A_vals = tl.load(A + M_offs[:, None] * K + K_offs[None, :] * 2)
+    B_vals = tl.load(B + K_offs[:, None] * N + N_offs[None, :] * 2)
+    C_vals = tl.dot(A_vals, B_vals)
+    tl.store(C + M_offs[:, None] * N + N_offs[None, :], C_vals)
+
+
+# @print_result_decorator
+# def test_dot_stride():
+#     A = torch.randn((32, 64), dtype=torch.float16, device="cuda")
+#     B = torch.randn((32, 64), dtype=torch.float16, device="cuda")
+#     C = torch.zeros((32, 32), dtype=torch.float16, device="cuda")
+#     D = A[:, ::2] @ B[:, ::2]
+#     F = dot_stride_kernel[(1, )](A, B, C, 32, 32, 32, num_warps=1, num_stages=1)
+#     return torch.allclose(C, D, atol=1e-3, rtol=1e-3),  check_mlir(F, [(0, 0)])
+
+
+@triton.jit
+def load_dot_kernel(A, B, C, R, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr):
+    M_offs = tl.arange(0, M)
+    N_offs = tl.arange(0, N)
+    K_offs = tl.arange(0, K)
+    K_vals = tl.load(R + K_offs)
+    A_offs = A + K_vals[:, None] * K + K_offs[None, :]
+    B_offs = B + K_offs[:, None] * N + K_vals[None, :]
+    A_vals = tl.load(A_offs)
+    B_vals = tl.load(B_offs)
+    C_vals = tl.dot(A_vals, B_vals)
+    tl.store(C + M_offs[:, None] * N + N_offs[None, :], C_vals)
+
+
+@print_result_decorator
+def test_load_dot():
+    R = torch.arange(0, 32, dtype=torch.int32, device="cuda")
+    A = torch.randn((32, 32), dtype=torch.float16, device="cuda")
+    B = torch.randn((32, 32), dtype=torch.float16, device="cuda")
+    C = torch.zeros((32, 32), dtype=torch.float16, device="cuda")
+    D = A @ B
+    F = load_dot_kernel[(1, )](A, B, C, R, 32, 32, 32)
+    assert check_mlir(F, [(0, 0)])
+    return torch.allclose(C, D, atol=1e-3, rtol=1e-3), check_mlir(F, [(0, 0)])
+
+
+@triton.jit
+def multi_use_kernel(A, B, C, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr):
+    M_offs = tl.arange(0, M)
+    N_offs = tl.arange(0, N)
+    K_offs = tl.arange(0, K)
+    A_offs = A + M_offs[:, None] * K + K_offs[None, :]
+    B_offs = B + K_offs[:, None] * N + N_offs[None, :]
+    A_vals = tl.load(A_offs)
+    B_vals = tl.load(B_offs)
+    C_vals = tl.dot(A_vals, B_vals)
+    C_vals += A_vals
+    tl.store(C + M_offs[:, None] * N + N_offs[None, :], C_vals)
+
+
+@print_result_decorator
+def test_multi_use_dot():
+    A = torch.randn((32, 32), dtype=torch.float16, device="cuda")
+    B = torch.randn((32, 32), dtype=torch.float16, device="cuda")
+    C = torch.zeros((32, 32), dtype=torch.float16, device="cuda")
+    D = A @ B + A
+    F = multi_use_kernel[(1, )](A, B, C, 32, 32, 32)
+    assert check_mlir(F, [(0, 32)])
+    return torch.allclose(C, D, atol=1e-3, rtol=1e-3), check_mlir(F, [(0, 32)])
+
+
+@triton.jit
+def vllm_paged_attention_fwd(
+    output,
+    query,
+    key_cache,
+    value_cahe,
+    block_tables,
+    context_lens,
+    query_stride,
+    block_tables_stride,
+    kv_block_stride,
+    kv_head_stride,
+    scale,
+    num_kv_group: tl.constexpr,
+    head_size: tl.constexpr,
+    block_size: tl.constexpr,
+):
+    batch_idx = tl.program_id(0)
+    kv_head_idx = tl.program_id(1)
+    head_offs = tl.arange(0, head_size)
+    kv_group_offs = tl.arange(0, 16)
+    block_offs = tl.arange(0, block_size)
+    context_len = tl.load(context_lens + batch_idx)
+    num_blocks = (context_len + block_size - 1) // block_size
+    # 16xhead_size
+    query_vals = tl.load(query + batch_idx * query_stride + kv_head_idx * num_kv_group * head_size +
+                         kv_group_offs[:, None] * head_size + head_offs[None, :])
+    block_tables_base = block_tables + batch_idx * block_tables_stride
+    key_cache = key_cache + kv_head_idx * kv_head_stride
+    value_cache = value_cahe + kv_head_idx * kv_head_stride
+    min_val = -float("inf")
+    qk_max = tl.full((16, ), min_val, dtype=tl.float32)
+    sum_exp = tl.zeros((16, block_size), dtype=tl.float32)
+    sum_exp_dot = tl.zeros((16, head_size), dtype=tl.float32)
+    key_base = key_cache + block_offs[:, None] * head_size + head_offs[None, :]
+    val_base = value_cache + block_offs[:, None] * head_size + head_offs[None, :]
+    # tl.store(output, num_blocks,)
+    for block_idx in range(num_blocks):
+        if block_idx == num_blocks - 1:
+            mask = block_size - 1
+            block_res = ((context_len - 1) & mask) + 1
+        else:
+            block_res = 16
+        physical_block_idx = tl.load(block_tables_base + block_idx)
+        key_offs = key_base + physical_block_idx * kv_block_stride
+        # block_size x head_size
+        # head_size x block_size
+        key_vals = tl.trans(tl.load(key_offs, ))
+        # 16 x head_size @ head_size x block_size = 16 x block_size
+        qk = tl.dot(query_vals, key_vals) * scale
+        qk = tl.where(block_offs[None, :] < block_res, qk, min_val)
+        # 16
+        new_max = tl.max(qk, axis=1)
+        new_max = tl.maximum(qk_max, new_max)
+        scale_factor = tl.exp(qk_max - new_max)
+        qk_max = new_max
+        sum_exp *= scale_factor[:, None]
+        sum_exp_dot *= scale_factor[:, None]
+        qk_exp = tl.exp(qk - qk_max[:, None])
+        sum_exp += qk_exp
+        val_offs = val_base + physical_block_idx * kv_block_stride
+        # block_size x head_size
+        val_vals = tl.load(val_offs)
+        sum_exp_dot = tl.dot(qk_exp.to(tl.float16), val_vals, sum_exp_dot)
+        # tl.store(output + kv_group_offs[:, None] * head_size + head_offs[None, :], sum_exp_dot)
+
+    # # tl.store(output + kv_group_offs[:, None] * head_size + head_offs[None, :], sum_exp_dot)
+    sum_exp_sum = tl.sum(sum_exp, axis=1)
+    # tl.store(output + kv_group_offs, sum_exp_sum)
+    sum_exp_dot /= sum_exp_sum[:, None]
+    # tl.store(output + kv_group_offs[:, None] * head_size + head_offs[None, :], sum_exp_dot)
+    tl.store(
+        output + batch_idx * query_stride + (kv_head_idx * num_kv_group + kv_group_offs[:, None]) * head_size +
+        head_offs[None, :], sum_exp_dot, mask=kv_group_offs[:, None] < num_kv_group)
+
+
+def vllm_paged_attention_triton(
+    output,
+    query,  # (batch_size, num_head, head_size)
+    key_cache,  # (num_blocks, num_kv_heads, block_size, head_size),
+    value_cache,  # (num_blocks, num_kv_heads, block_size, head_size),
+    num_kv_heads,  # (batch_size)
+    scale,  # (batch_size, )
+    block_tables,
+    context_lens,
+    block_size,
+    max_context_len,
+):
+    batch_size, num_heads, head_size = query.shape
+    _, num_kv_heads, block_size, _ = key_cache.shape
+    num_kv_group = num_heads // num_kv_heads
+    grid = [batch_size, num_kv_heads]
+    block_tables_stride = block_tables.stride(0)
+    kv_block_stride = key_cache.stride(0)
+    kv_head_stride = key_cache.stride(1)
+    query_stride = query.stride(0)
+    num_warps = 1
+    F = vllm_paged_attention_fwd[grid](output, query, key_cache, value_cache, block_tables, context_lens, query_stride,
+                                       block_tables_stride, kv_block_stride, kv_head_stride, scale, num_kv_group,
+                                       head_size, block_size, num_warps=num_warps, num_stages=1)
+    return F
+
+
+@print_result_decorator
+def test_vllm_paged_attention():
+    batch_size = 256
+    num_kv_heads = 2
+    num_heads = 32
+    block_size = 16
+    head_size = 128
+    num_blocks = 81920
+    scale = float(1.0 / (head_size**0.5))
+    query = torch.randn(batch_size, num_heads, head_size, dtype=torch.float16, device="cuda")
+    output = torch.empty_like(query)
+    key_block_shape = (num_kv_heads, block_size, head_size)
+    key_cache = torch.randn(size=(num_blocks, *key_block_shape), dtype=torch.float16, device="cuda")
+    value_block_shape = (num_kv_heads, block_size, head_size)
+    value_cache = torch.randn(size=(num_blocks, *value_block_shape), dtype=torch.float16, device="cuda")
+    context_len = 4096
+    block_tables = []
+
+    for _ in range(batch_size):
+        block_table = [random.randint(0, num_blocks - 1) for _ in range((context_len + block_size - 1) // block_size)]
+        block_tables.append(block_table)
+
+    block_tables = torch.tensor(block_tables, dtype=torch.int, device="cuda")
+    b_seq_len = torch.full((batch_size, ), context_len, dtype=torch.int32, device="cuda")
+    F = vllm_paged_attention_triton(
+        output,
+        query,
+        key_cache,
+        value_cache,
+        num_kv_heads,
+        scale,
+        block_tables,
+        b_seq_len,
+        block_size,
+        context_len,
+    )
+    assert check_mlir(F, [(128, 128), (0, 128)])
+    return True, check_mlir(F, [(128, 128), (0, 128)])
+
+
+@triton.jit
+def ceil_div(x, y):
+    return (x + y - 1) // y
+
+
+@triton.jit
+def _fwd_batch_mla_paged_attention_stage1(q_nope, q_pe, ckv_cache, kpe_cache, out, kv_indices, q_indptr, kv_indptr,
+                                          partial_indptr, q_start_ptr, kv_start_ptr, kv_end_ptr, work_indptr,
+                                          partial_o_ptr, partial_lse_ptr, page_size: tl.constexpr,
+                                          num_heads: tl.constexpr, head_dim_ckv: tl.constexpr,
+                                          head_dim_kpe: tl.constexpr, scale: tl.constexpr,
+                                          CTA_TILE_Q: tl.constexpr = 64, TILE_KV: tl.constexpr = 16):
+    bx = tl.program_id(0)
+    by = tl.program_id(1)
+    cta_tile_q_off = tl.arange(0, CTA_TILE_Q)
+    tile_kv_off = tl.arange(0, TILE_KV)
+    head_ckv_off = tl.arange(0, head_dim_ckv)
+    head_kpe_off = tl.arange(0, head_dim_kpe)
+    work_start = tl.load(work_indptr + by)
+    work_end = tl.load(work_indptr + by + 1)
+    mask = TILE_KV - 1
+    min_val = -float("inf")
+    for work_idx in range(work_start, work_end):
+        q_idx = tl.load(q_indptr + work_idx)
+        q_start = tl.load(q_start_ptr + work_idx)
+        kv_start = tl.load(kv_start_ptr + work_idx)
+        kv_end = tl.load(kv_end_ptr + work_idx)
+        ceil_kv_end = ceil_div(kv_end, TILE_KV) * TILE_KV
+        partial_idx = tl.load(partial_indptr + work_idx)
+        kv_idx = tl.load(kv_indptr + work_idx)
+        batch_q_nope = tl.load(q_nope + q_idx * num_heads * head_dim_ckv + (q_start + bx * CTA_TILE_Q) * head_dim_ckv +
+                               cta_tile_q_off[:, None] * head_dim_ckv + head_ckv_off[None, :])
+        batch_q_pe = tl.load(q_pe + q_idx * num_heads * head_dim_kpe + (q_start + bx * CTA_TILE_Q) * head_dim_kpe +
+                             cta_tile_q_off[:, None] * head_dim_kpe + head_kpe_off[None, :])
+        kv_load_cnt = (ceil_kv_end - kv_start) // TILE_KV
+        qk_max = tl.full(
+            (CTA_TILE_Q, ),
+            min_val,
+            dtype=tl.float32,
+        )
+        sum_exp = tl.zeros(
+            (CTA_TILE_Q, TILE_KV),
+            dtype=tl.float32,
+        )
+        sum_exp_dot = tl.zeros(
+            (CTA_TILE_Q, head_dim_ckv),
+            dtype=tl.float32,
+        )
+        log2e = 1.4426950408889634073599246810019
+        for kv_load_idx in range(kv_load_cnt):
+            if kv_load_idx == kv_load_cnt - 1:
+                block_res = ((kv_end - 1) & mask) + 1
+            else:
+                block_res = TILE_KV
+            kv_base_off = (kv_start + kv_load_idx * TILE_KV)
+            tile_loc = kv_base_off // page_size
+            kv_page_idx = kv_base_off % page_size
+            page_idx = tl.load(kv_indices + kv_idx + tile_loc)
+            # num_pages, pages_size, head_dim_ckv
+            tile_ckv = tl.load(ckv_cache + page_idx * page_size * head_dim_ckv + kv_page_idx * head_dim_ckv +
+                               tile_kv_off[None, :] * head_dim_ckv + head_ckv_off[:, None])
+            # num_pages, pages_size, head_dim_kpe
+            tile_kpe = tl.load(kpe_cache + page_idx * page_size * head_dim_kpe + kv_page_idx * head_dim_kpe +
+                               tile_kv_off[None, :] * head_dim_kpe + head_kpe_off[:, None])
+            qk = tl.dot(batch_q_nope, tile_ckv)
+            qk += tl.dot(batch_q_pe, tile_kpe)
+            qk *= scale
+            tmp = tile_kv_off[None, :] < block_res
+            qk = tl.where(tmp, qk, min_val)
+            new_max = tl.max(qk, axis=1)
+            new_max = tl.maximum(qk_max, new_max)
+            qk_diff = qk_max - new_max
+            scale_factor = tl.exp(qk_diff)
+            qk_max = new_max
+            sum_exp *= scale_factor[:, None]
+            sum_exp_dot *= scale_factor[:, None]
+            qk -= qk_max[:, None]
+            qk_exp = tl.exp(qk)
+            sum_exp += qk_exp
+            qk_exp = qk_exp.to(tile_ckv.dtype)
+            sum_exp_dot = tl.dot(qk_exp, tile_ckv.T, sum_exp_dot)
+        sum_exp_sum = tl.sum(sum_exp, axis=1)
+        sum_exp_dot /= sum_exp_sum[:, None]
+        if partial_idx == -1:
+            tl.store(
+                out + q_idx * num_heads * head_dim_ckv + (q_start + bx * CTA_TILE_Q) * head_dim_ckv +
+                cta_tile_q_off[:, None] * head_dim_ckv + head_ckv_off[None, :], sum_exp_dot)
+        else:
+            tl.store(
+                partial_o_ptr + partial_idx * head_dim_ckv + bx * CTA_TILE_Q * head_dim_ckv +
+                cta_tile_q_off[:, None] * head_dim_ckv + head_ckv_off[None, :], sum_exp_dot)
+            tl.store(partial_lse_ptr + partial_idx + bx * CTA_TILE_Q + cta_tile_q_off,
+                     qk_max * log2e + tl.log(sum_exp_sum) * log2e)
+
+
+@print_result_decorator
+def test_batch_mla():
+    kv_len = [128, 1275, 1275, 1273]
+    qo_len = [125, 1, 1, 1]
+    num_heads = 128
+    page_size = 256
+    head_dim_ckv = 512
+    head_dim_kpe = 64
+    dtype = torch.float16
+    batch_size = len(kv_len)
+    q_nope = torch.randn(sum(qo_len), num_heads, head_dim_ckv, dtype=torch.float16, device="cuda").to(dtype) * 0.1
+    q_pe = torch.randn(sum(qo_len), num_heads, head_dim_kpe, dtype=torch.float16, device="cuda").to(dtype) * 0.1
+    page_nums = [math.ceil(x / page_size) for x in kv_len]
+    total_pages = 128
+    ckv = torch.randn(
+        total_pages,
+        page_size,
+        head_dim_ckv,
+        dtype=torch.float16,
+        device="cuda",
+    ).to(dtype) * 0.1
+    kpe = torch.randn(
+        total_pages,
+        page_size,
+        head_dim_kpe,
+        dtype=torch.float16,
+        device="cuda",
+    ).to(dtype) * 0.1
+    sm_scale = 0.1352337788608801
+    q_indptr = torch.cumsum(torch.tensor([
+        0,
+    ] + qo_len, dtype=torch.int32, device="cuda"), dim=0).to(torch.int32)
+    kv_indptr = torch.cumsum(torch.tensor([
+        0,
+    ] + page_nums, dtype=torch.int32, device="cuda"), dim=0).to(torch.int32)
+    kv_indices = torch.randint(0, 1, (kv_indptr[-1].item(), ), dtype=torch.int32, device="cuda")
+    # kv_lens = torch.tensor(kv_len, dtype=torch.int32, device="cuda")
+    # bsz_tensor = torch.tensor([batch_size, ], dtype=torch.int32, device="cuda")
+    out = torch.empty_like(q_nope)
+    partial_indptr = torch.full((16384, ), -1, dtype=torch.int32, device="cuda")
+    q_start_ptr = torch.zeros((16384, ), dtype=torch.int32, device="cuda")
+    q_start_ptr[:128] = torch.tensor([
+        15872, 13952, 13440, 12288, 11776, 9856, 9344, 8192, 7680, 5760, 5248, 4096, 3584, 1664, 1152, 0, 15232, 14592,
+        13056, 12672, 11136, 10496, 8960, 8576, 7040, 6400, 4864, 4480, 2944, 2304, 768, 384, 15744, 14080, 13568,
+        12160, 11648, 9984, 9472, 8064, 7552, 5888, 5376, 3968, 3456, 1792, 1280, 0, 14976, 14848, 12928, 12800, 10880,
+        10752, 8832, 8704, 6784, 6656, 4736, 4608, 2688, 2560, 640, 512, 15104, 14720, 13184, 12544, 11008, 10624, 9088,
+        8448, 6912, 6528, 4992, 4352, 2816, 2432, 896, 256, 15360, 14464, 13312, 12416, 11264, 10368, 9216, 8320, 7168,
+        6272, 5120, 4224, 3072, 2176, 1024, 128, 15616, 14208, 13696, 12032, 11520, 10112, 9600, 7936, 7424, 6016, 5504,
+        3840, 3328, 1920, 1408, 0, 15488, 14336, 13824, 11904, 11392, 10240, 9728, 7808, 7296, 6144, 5632, 3712, 3200,
+        2048, 1536, 0
+    ], dtype=torch.int32, device="cuda")
+    kv_start_ptr = torch.zeros((16384, ), dtype=torch.int32, device="cuda")
+    kv_end_ptr = torch.zeros((16384, ), dtype=torch.int32, device="cuda")
+    kv_end_ptr[:128] = torch.tensor([
+        252, 237, 233, 224, 220, 205, 201, 192, 188, 173, 169, 160, 156, 141, 137, 128, 247, 242, 230, 227, 215, 210,
+        198, 195, 183, 178, 166, 163, 151, 146, 134, 131, 251, 238, 234, 223, 219, 206, 202, 191, 187, 174, 170, 159,
+        155, 142, 138, 1275, 245, 244, 229, 228, 213, 212, 197, 196, 181, 180, 165, 164, 149, 148, 133, 132, 246, 243,
+        231, 226, 214, 211, 199, 194, 182, 179, 167, 162, 150, 147, 135, 130, 248, 241, 232, 225, 216, 209, 200, 193,
+        184, 177, 168, 161, 152, 145, 136, 129, 250, 239, 235, 222, 218, 207, 203, 190, 186, 175, 171, 158, 154, 143,
+        139, 1275, 249, 240, 236, 221, 217, 208, 204, 189, 185, 176, 172, 157, 153, 144, 140, 1273
+    ], dtype=torch.int32, device="cuda")
+    work_indptr = torch.zeros((16384, ), dtype=torch.int32, device="cuda")
+    work_indptr[:9] = torch.tensor([
+        0,
+        16,
+        32,
+        48,
+        64,
+        80,
+        96,
+        112,
+        128,
+    ], dtype=torch.int32, device="cuda")
+    partial_o_ptr = torch.zeros((7077888, ), dtype=torch.float32, device="cuda")
+    partial_lse_ptr = torch.zeros((27000832, ), dtype=torch.float32, device="cuda")
+
+    F = _fwd_batch_mla_paged_attention_stage1[2, 8](q_nope, q_pe, ckv, kpe, out, kv_indices, q_indptr, kv_indptr,
+                                                    partial_indptr, q_start_ptr, kv_start_ptr, kv_end_ptr, work_indptr,
+                                                    partial_o_ptr, partial_lse_ptr, page_size, num_heads, head_dim_ckv,
+                                                    head_dim_kpe, sm_scale, num_warps=8, num_stages=1)
+    assert check_mlir(F, [(512, 512), (64, 64), (0, 512)])
+    return True, check_mlir(F, [(512, 512), (64, 64), (0, 512)])
+
+
+if __name__ == "__main__":
+    test_16x32_f16_dot()
+    test_16x32_i8_dot()
+    test_16x32_f16_trans_dot()
+    test_load_dot()
+    test_multi_use_dot()
+    # this two case may coredump
+    # test_16x32_i8_trans_dot()
+    # test_loop_k_dot()
+    test_loop_k_dot2()
+    test_loop_k_dot3()
+    test_loop_n_dot()
+    # test_dot_stride()
+    test_vllm_paged_attention()
+    test_batch_mla()

--- a/third_party/iluvatar/python/test/unit/operators/test_sme.py
+++ b/third_party/iluvatar/python/test/unit/operators/test_sme.py
@@ -639,6 +639,7 @@ def test_batch_mla():
 
 
 if __name__ == "__main__":
+    pytest.skip("iluvatar: ir.parse_mlir_module failed in CI.")
     test_16x32_f16_dot()
     test_16x32_i8_dot()
     test_16x32_f16_trans_dot()

--- a/third_party/iluvatar/python/test/unit/operators/test_sme.py
+++ b/third_party/iluvatar/python/test/unit/operators/test_sme.py
@@ -81,6 +81,7 @@ def dot_trans_kernel(A, B, C, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr)
     tl.store(C + M_offs[:, None] * N + N_offs[None, :], C_vals)
 
 
+@pytest.mark.skip(reason="iluvatar: ir.parse_mlir_module failed in CI")
 @print_result_decorator
 def test_16x32_f16_dot():
     A = torch.randn((16, 32), dtype=torch.half, device="cuda")
@@ -92,6 +93,7 @@ def test_16x32_f16_dot():
     return torch.allclose(C, D, atol=1e-3, rtol=1e-3), check_mlir(F, [(32, 0)])
 
 
+@pytest.mark.skip(reason="iluvatar: ir.parse_mlir_module failed in CI")
 @print_result_decorator
 def test_16x32_i8_dot():
     capability = torch.cuda.get_device_capability()
@@ -107,6 +109,7 @@ def test_16x32_i8_dot():
     return torch.allclose(C.to(torch.float32), D, atol=1e-3, rtol=1e-3), check_mlir(F, [(64, 64)])
 
 
+@pytest.mark.skip(reason="iluvatar: ir.parse_mlir_module failed in CI")
 @print_result_decorator
 def test_16x32_f16_trans_dot():
     A = torch.randn((16, 32), dtype=torch.half, device="cuda")
@@ -172,6 +175,7 @@ def loop_k_dot_kernel2(A, B, C, M: tl.constexpr, N: tl.constexpr, K: tl.constexp
     tl.store(C + M_offs[:, None] * N + N_offs[None, :], C_vals)
 
 
+@pytest.mark.skip(reason="iluvatar: ir.parse_mlir_module failed in CI")
 @print_result_decorator
 def test_loop_k_dot2():
     A = torch.randn((32, 256), dtype=torch.float16, device="cuda")
@@ -202,6 +206,7 @@ def loop_k_dot_kernel3(A, B, C, M: tl.constexpr, N: tl.constexpr, K: tl.constexp
     tl.store(C + M_offs[:, None] * N + N_offs[None, :], C_vals)
 
 
+@pytest.mark.skip(reason="iluvatar: ir.parse_mlir_module failed in CI")
 @print_result_decorator
 def test_loop_k_dot3():
     A = torch.randn((32, 256), dtype=torch.float16, device="cuda")
@@ -233,6 +238,7 @@ def loop_n_dot_kernel(A, B, C, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr
         tl.store(C + M_offs[:, None] * N + N_offs[None, :] + n_iter * 32, C_vals)
 
 
+@pytest.mark.skip(reason="iluvatar: ir.parse_mlir_module failed in CI")
 @print_result_decorator
 def test_loop_n_dot():
     A = torch.randn((32, 32), dtype=torch.float16, device="cuda")
@@ -279,6 +285,7 @@ def load_dot_kernel(A, B, C, R, M: tl.constexpr, N: tl.constexpr, K: tl.constexp
     tl.store(C + M_offs[:, None] * N + N_offs[None, :], C_vals)
 
 
+@pytest.mark.skip(reason="iluvatar: ir.parse_mlir_module failed in CI")
 @print_result_decorator
 def test_load_dot():
     R = torch.arange(0, 32, dtype=torch.int32, device="cuda")
@@ -305,6 +312,7 @@ def multi_use_kernel(A, B, C, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr)
     tl.store(C + M_offs[:, None] * N + N_offs[None, :], C_vals)
 
 
+@pytest.mark.skip(reason="iluvatar: ir.parse_mlir_module failed in CI")
 @print_result_decorator
 def test_multi_use_dot():
     A = torch.randn((32, 32), dtype=torch.float16, device="cuda")
@@ -419,6 +427,7 @@ def vllm_paged_attention_triton(
     return F
 
 
+@pytest.mark.skip(reason="iluvatar: ir.parse_mlir_module failed in CI")
 @print_result_decorator
 def test_vllm_paged_attention():
     batch_size = 256
@@ -554,6 +563,7 @@ def _fwd_batch_mla_paged_attention_stage1(q_nope, q_pe, ckv_cache, kpe_cache, ou
                      qk_max * log2e + tl.log(sum_exp_sum) * log2e)
 
 
+@pytest.mark.skip(reason="iluvatar: ir.parse_mlir_module failed in CI")
 @print_result_decorator
 def test_batch_mla():
     kv_len = [128, 1275, 1275, 1273]
@@ -639,7 +649,6 @@ def test_batch_mla():
 
 
 if __name__ == "__main__":
-    pass  # iluvatar: ir.parse_mlir_module failed in CI.
     test_16x32_f16_dot()
     test_16x32_i8_dot()
     test_16x32_f16_trans_dot()

--- a/third_party/iluvatar/python/test/unit/runtime/test_cache.py
+++ b/third_party/iluvatar/python/test/unit/runtime/test_cache.py
@@ -405,14 +405,21 @@ def test_jit_warmup_cache() -> None:
         torch.randn(32, dtype=torch.float32, device="cuda"),
         32,
     ]
+    only_save_best_config_cache = os.environ.get("TRITON_ONLY_SAVE_BEST_CONFIG_CACHE", "0") == "1"
     device = torch.cuda.current_device()
     assert len(kernel_add.cache[device]) == 0
     kernel_add.warmup(torch.float32, torch.float32, torch.float32, 32, grid=(1, ))
     assert len(kernel_add.cache[device]) == 1
     kernel_add.warmup(*args, grid=(1, ))
-    assert len(kernel_add.cache[device]) == 2
+    if only_save_best_config_cache:
+        assert len(kernel_add.cache[device]) == 2
+    else:
+        assert len(kernel_add.cache[device]) == 1
     kernel_add.warmup(*args, grid=(1, ))
-    assert len(kernel_add.cache[device]) == 2
+    if only_save_best_config_cache:
+        assert len(kernel_add.cache[device]) == 2
+    else:
+        assert len(kernel_add.cache[device]) == 1
 
 
 def test_jit_debug() -> None:

--- a/third_party/iluvatar/python/triton/compiler/code_generator.py
+++ b/third_party/iluvatar/python/triton/compiler/code_generator.py
@@ -1285,10 +1285,10 @@ def ast_to_ttir(fn, specialization, context, options, codegen_fns):
     function_name = fn.repr(specialization)
     tys = list(specialization.signature.values())
     new_constants = {k: True if k in tys and tys[k] == "i1" else 1 for k in attrs.equal_to_1}
-    new_attrs = {k: [("tt.divisibility", 16)] for k in attrs.divisible_by_16}
-    for k in attrs.divisible_by_8:
+    new_attrs = {k[0]: [("tt.corex_stride", k[1])] for k in attrs.corexLoad.items()}
+    for k in attrs.divisible_by_16:
         attr = new_attrs[k] if k in new_attrs else []
-        attr.append(("tt.max_divisibility", 8))
+        attr.append(("tt.divisibility", 16))
         new_attrs[k] = attr
 
     all_constants = constants.copy()

--- a/third_party/iluvatar/python/triton/language/semantic.py
+++ b/third_party/iluvatar/python/triton/language/semantic.py
@@ -853,6 +853,8 @@ def _str_to_load_cache_modifier(cache_modifier):
             cache = ir.CACHE_MODIFIER.CA
         elif cache_modifier == ".cg":
             cache = ir.CACHE_MODIFIER.CG
+        elif cache_modifier == ".cv":
+            cache = ir.CACHE_MODIFIER.CV
         else:
             raise ValueError(f"Cache modifier {cache_modifier} not supported")
     return cache

--- a/third_party/iluvatar/python/triton/ops/matmul_perf_model.py
+++ b/third_party/iluvatar/python/triton/ops/matmul_perf_model.py
@@ -172,7 +172,14 @@ def early_config_prune(configs, named_args, **kwargs):
                 for stage in range(len(v)):
                     random_config = v[stage][0]
                     random_config.num_stages = v[stage][1]
-                    pruned_configs.append(random_config)
+                    if (capability[0] < 8 and v[stage][1] < 3):
+                        pruned_configs.append(random_config)
+                    if capability[0] == 8:
+                        blocks = BLOCK_M + BLOCK_N + BLOCK_K
+                        if blocks <= 256:
+                            pruned_configs.append(random_config)
+                        elif v[stage][1] > 2 and blocks > 256:
+                            pruned_configs.append(random_config)
             else:
                 random_config = v[0][0]
                 random_config.num_stages = 2

--- a/third_party/iluvatar/python/triton/runtime/cache.py
+++ b/third_party/iluvatar/python/triton/runtime/cache.py
@@ -116,14 +116,18 @@ class FileCacheManager(CacheManager):
         rnd_id = str(uuid.uuid4())
         # we use the PID in case a bunch of these around so we can see what PID made it
         pid = os.getpid()
-        # use tempfile to be robust against program interruptions
-        temp_path = f"{filepath}.tmp.pid_{pid}_{rnd_id}"
+        # use temp dir to be robust against program interruptions
+        temp_dir = os.path.join(self.cache_dir, f"tmp.pid_{pid}_{rnd_id}")
+        os.makedirs(temp_dir, exist_ok=True)
+        temp_path = os.path.join(temp_dir, filename)
+
         mode = "wb" if binary else "w"
         with open(temp_path, mode) as f:
             f.write(data)
         # Replace is guaranteed to be atomic on POSIX systems if it succeeds
         # so filepath cannot see a partial write
         os.replace(temp_path, filepath)
+        os.removedirs(temp_dir)
         return filepath
 
 

--- a/third_party/iluvatar/python/triton/testing.py
+++ b/third_party/iluvatar/python/triton/testing.py
@@ -10,7 +10,10 @@ from triton.runtime.build import is_corex
 
 def nvsmi(attrs):
     attrs = ','.join(attrs)
-    cmd = ['nvidia-smi', '-i', '0', '--query-gpu=' + attrs, '--format=csv,noheader,nounits']
+    if is_corex():
+        cmd = ['ixsmi', '-i', '0', '--query-gpu=' + attrs, '--format=csv,noheader,nounits']
+    else:
+        cmd = ['nvidia-smi', '-i', '0', '--query-gpu=' + attrs, '--format=csv,noheader,nounits']
     out = subprocess.check_output(cmd)
     ret = out.decode(sys.stdout.encoding).split(',')
     ret = [int(x) for x in ret]

--- a/third_party/iluvatar/python/tutorials/fused_attention/fused-attention_0629.py
+++ b/third_party/iluvatar/python/tutorials/fused_attention/fused-attention_0629.py
@@ -1,0 +1,502 @@
+"""
+Fused Attention
+===============
+
+This is a Triton implementation of the Flash Attention algorithm
+(see: Dao et al., https://arxiv.org/pdf/2205.14135v2.pdf; Rabe and Staats https://arxiv.org/pdf/2112.05682v2.pdf)
+
+0629 version:
+https://github.com/ROCmSoftwarePlatform/triton/blob/a260b80a7d4059f0b577e395ccc2e29b1876580b/python/tutorials/06-fused-attention.py
+"""
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton.runtime.build import is_corex
+
+
+@triton.jit
+def _fwd_kernel(
+    Q,
+    K,
+    V,
+    sm_scale,
+    L,
+    M,
+    Out,
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vk,
+    stride_vn,
+    stride_oz,
+    stride_oh,
+    stride_om,
+    stride_on,
+    Z,
+    H,
+    N_CTX,
+    BLOCK_M: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+):
+    start_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    # initialize offsets
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    off_q = off_hz * stride_qh + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk
+    off_k = off_hz * stride_qh + offs_n[None, :] * stride_kn + offs_d[:, None] * stride_kk
+    off_v = off_hz * stride_qh + offs_n[:, None] * stride_qm + offs_d[None, :] * stride_qk
+    # Initialize pointers to Q, K, V
+    q_ptrs = Q + off_q
+    k_ptrs = K + off_k
+    v_ptrs = V + off_v
+    # initialize pointer to m and l
+    m_prev = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_prev = tl.zeros([BLOCK_M], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+    # load q: it will stay in SRAM throughout
+    q = tl.load(q_ptrs)
+    # loop over k, v and update accumulator
+    for start_n in range(0, (start_m + 1) * BLOCK_M, BLOCK_N):
+        # -- compute qk ----
+        k = tl.load(k_ptrs)
+        qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+        qk += tl.dot(q, k)
+        qk *= sm_scale
+        if IS_CAUSAL:
+            qk = tl.where(offs_m[:, None] >= (start_n + offs_n[None, :]), qk, float("-inf"))
+        # compute new m
+        m_curr = tl.maximum(tl.max(qk, 1), m_prev)
+        # correct old l
+        l_prev *= tl.exp(m_prev - m_curr)
+        # attention weights
+        p = tl.exp(qk - m_curr[:, None])
+        l_curr = tl.sum(p, 1) + l_prev
+        # rescale operands of matmuls
+        l_rcp = 1. / l_curr
+        p *= l_rcp[:, None]
+        acc *= (l_prev * l_rcp)[:, None]
+        # update acc
+        p = p.to(Q.dtype.element_ty)
+        v = tl.load(v_ptrs)
+        acc += tl.dot(p, v)
+        # update m_i and l_i
+        l_prev = l_curr
+        m_prev = m_curr
+        # update pointers
+        k_ptrs += BLOCK_N * stride_kn
+        v_ptrs += BLOCK_N * stride_vk
+    # rematerialize offsets to save registers
+    start_m = tl.program_id(0)
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    # write back l and m
+    l_ptrs = L + off_hz * N_CTX + offs_m
+    m_ptrs = M + off_hz * N_CTX + offs_m
+    tl.store(l_ptrs, l_prev)
+    tl.store(m_ptrs, m_prev)
+    # initialize pointers to output
+    offs_n = tl.arange(0, BLOCK_DMODEL)
+    off_o = off_hz * stride_oh + offs_m[:, None] * stride_om + offs_n[None, :] * stride_on
+    out_ptrs = Out + off_o
+    tl.store(out_ptrs, acc)
+
+
+@triton.jit
+def _bwd_preprocess(
+    Out,
+    DO,
+    L,
+    NewDO,
+    Delta,
+    BLOCK_M: tl.constexpr,
+    D_HEAD: tl.constexpr,
+):
+    off_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    off_n = tl.arange(0, D_HEAD)
+    # load
+    o = tl.load(Out + off_m[:, None] * D_HEAD + off_n[None, :]).to(tl.float32)
+    do = tl.load(DO + off_m[:, None] * D_HEAD + off_n[None, :]).to(tl.float32)
+    denom = tl.load(L + off_m).to(tl.float32)
+    # compute
+    do = do / denom[:, None]
+    delta = tl.sum(o * do, axis=1)
+    # write-back
+    tl.store(NewDO + off_m[:, None] * D_HEAD + off_n[None, :], do)
+    tl.store(Delta + off_m, delta)
+
+
+@triton.jit
+def _bwd_kernel(
+    Q,
+    K,
+    V,
+    sm_scale,
+    Out,
+    DO,
+    DQ,
+    DK,
+    DV,
+    L,
+    M,
+    D,
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vk,
+    stride_vn,
+    Z,
+    H,
+    N_CTX,
+    num_block,
+    BLOCK_M: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+):
+    off_hz = tl.program_id(0)
+    off_z = off_hz // H
+    off_h = off_hz % H
+    # offset pointers for batch/head
+    Q += off_z * stride_qz + off_h * stride_qh
+    K += off_z * stride_qz + off_h * stride_qh
+    V += off_z * stride_qz + off_h * stride_qh
+    DO += off_z * stride_qz + off_h * stride_qh
+    DQ += off_z * stride_qz + off_h * stride_qh
+    DK += off_z * stride_qz + off_h * stride_qh
+    DV += off_z * stride_qz + off_h * stride_qh
+    for start_n in range(0, num_block):
+        lo = start_n * BLOCK_M
+        # initialize row/col offsets
+        offs_qm = lo + tl.arange(0, BLOCK_M)
+        offs_n = start_n * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_m = tl.arange(0, BLOCK_N)
+        offs_k = tl.arange(0, BLOCK_DMODEL)
+        # initialize pointers to value-like data
+        q_ptrs = Q + (offs_qm[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+        k_ptrs = K + (offs_n[:, None] * stride_kn + offs_k[None, :] * stride_kk)
+        v_ptrs = V + (offs_n[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+        do_ptrs = DO + (offs_qm[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+        dq_ptrs = DQ + (offs_qm[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+        # pointer to row-wise quantities in value-like data
+        D_ptrs = D + off_hz * N_CTX
+        m_ptrs = M + off_hz * N_CTX
+        # initialize dv amd dk
+        dv = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+        dk = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+        # k and v stay in SRAM throughout
+        k = tl.load(k_ptrs)
+        v = tl.load(v_ptrs)
+        # loop over rows
+        for start_m in range(lo, num_block * BLOCK_M, BLOCK_M):
+            offs_m_curr = start_m + offs_m
+            # load q, k, v, do on-chip
+            q = tl.load(q_ptrs)
+            # recompute p = softmax(qk, dim=-1).T
+            # NOTE: `do` is pre-divided by `l`; no normalization here
+            qk = tl.dot(q, tl.trans(k))
+            if IS_CAUSAL:
+                qk = tl.where(offs_m_curr[:, None] >= (offs_n[None, :]), qk, float("-inf"))
+            m = tl.load(m_ptrs + offs_m_curr)
+            p = tl.exp(qk * sm_scale - m[:, None])
+            # compute dv
+            do = tl.load(do_ptrs)
+            dv += tl.dot(tl.trans(p.to(Q.dtype.element_ty)), do)
+            # compute dp = dot(v, do)
+            Di = tl.load(D_ptrs + offs_m_curr)
+            dp = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32) - Di[:, None]
+            dp += tl.dot(do, tl.trans(v))
+            # compute ds = p * (dp - delta[:, None])
+            ds = p * dp * sm_scale
+            # compute dk = dot(ds.T, q)
+            dk += tl.dot(tl.trans(ds.to(Q.dtype.element_ty)), q)
+            # compute dq
+            dq = tl.load(dq_ptrs)
+            dq += tl.dot(ds.to(Q.dtype.element_ty), k)
+            tl.store(dq_ptrs, dq)
+            # increment pointers
+            dq_ptrs += BLOCK_M * stride_qm
+            q_ptrs += BLOCK_M * stride_qm
+            do_ptrs += BLOCK_M * stride_qm
+        # write-back
+        dv_ptrs = DV + (offs_n[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+        dk_ptrs = DK + (offs_n[:, None] * stride_kn + offs_k[None, :] * stride_kk)
+        tl.store(dv_ptrs, dv)
+        tl.store(dk_ptrs, dk)
+
+
+empty = torch.empty(128, device="cuda")
+
+
+class _attention(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, q, k, v, causal, sm_scale):
+        # FIXME: currently BLOCK=128 has issues, BLOCK=64 works for common cases.
+        if torch.version.hip is not None or is_corex():
+            BLOCK = 64
+        else:
+            BLOCK = 128
+        # shape constraints
+        Lq, Lk, Lv = q.shape[-1], k.shape[-1], v.shape[-1]
+        assert Lq == Lk and Lk == Lv
+        assert Lk in {16, 32, 64, 128}
+        o = torch.empty_like(q)
+        grid = (triton.cdiv(q.shape[2], BLOCK), q.shape[0] * q.shape[1], 1)
+        L = torch.empty((q.shape[0] * q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+        m = torch.empty((q.shape[0] * q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+        # num_warps = 4 if Lk <= 64 else 8
+        num_warps = 4
+
+        _fwd_kernel[grid](
+            q,
+            k,
+            v,
+            sm_scale,
+            L,
+            m,
+            o,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            k.stride(0),
+            k.stride(1),
+            k.stride(2),
+            k.stride(3),
+            v.stride(0),
+            v.stride(1),
+            v.stride(2),
+            v.stride(3),
+            o.stride(0),
+            o.stride(1),
+            o.stride(2),
+            o.stride(3),
+            q.shape[0],
+            q.shape[1],
+            q.shape[2],
+            BLOCK_M=BLOCK,
+            BLOCK_N=BLOCK,
+            BLOCK_DMODEL=Lk,
+            IS_CAUSAL=causal,
+            num_warps=num_warps,
+            num_stages=2 if not is_corex() else 1,
+        )
+        # print(h.asm["ttgir"])
+
+        ctx.save_for_backward(q, k, v, o, L, m)
+        ctx.grid = grid
+        ctx.sm_scale = sm_scale
+        ctx.BLOCK_DMODEL = Lk
+        ctx.causal = causal
+        return o
+
+    @staticmethod
+    def backward(ctx, do):
+        # FIXME: currently BLOCK=128 has issues, BLOCK=64 works for common cases.
+        if torch.version.hip is not None or is_corex():
+            BLOCK = 64
+        else:
+            BLOCK = 128
+        q, k, v, o, l, m = ctx.saved_tensors
+        do = do.contiguous()
+        dq = torch.zeros_like(q, dtype=torch.float32)
+        dk = torch.empty_like(k)
+        dv = torch.empty_like(v)
+        do_scaled = torch.empty_like(do)
+        delta = torch.empty_like(l)
+        _bwd_preprocess[(ctx.grid[0] * ctx.grid[1], )](
+            o,
+            do,
+            l,
+            do_scaled,
+            delta,
+            BLOCK_M=BLOCK,
+            D_HEAD=ctx.BLOCK_DMODEL,
+        )
+        _bwd_kernel[(ctx.grid[1], )](
+            q,
+            k,
+            v,
+            ctx.sm_scale,
+            o,
+            do_scaled,
+            dq,
+            dk,
+            dv,
+            l,
+            m,
+            delta,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            k.stride(0),
+            k.stride(1),
+            k.stride(2),
+            k.stride(3),
+            v.stride(0),
+            v.stride(1),
+            v.stride(2),
+            v.stride(3),
+            q.shape[0],
+            q.shape[1],
+            q.shape[2],
+            ctx.grid[0],
+            BLOCK_M=BLOCK,
+            BLOCK_N=BLOCK,
+            BLOCK_DMODEL=ctx.BLOCK_DMODEL,
+            num_warps=8,
+            IS_CAUSAL=ctx.causal,
+            num_stages=1,
+        )
+        # print(h.asm["ttgir"])
+        return dq, dk, dv, None, None
+
+
+attention = _attention.apply
+
+
+@pytest.mark.parametrize('Z, H, N_CTX, D_HEAD', [(4, 48, 1024, 64)])
+@pytest.mark.parametrize('causal', [False, True])
+def test_op(Z, H, N_CTX, D_HEAD, causal, dtype=torch.float16):
+    torch.manual_seed(20)
+    q = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0.1, std=0.2).requires_grad_()
+    k = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0.4, std=0.2).requires_grad_()
+    v = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0.3, std=0.2).requires_grad_()
+    sm_scale = 0.2
+    dout = torch.randn_like(q)
+    # reference implementation
+    M = torch.tril(torch.ones((N_CTX, N_CTX), device="cuda"))
+    p = torch.matmul(q, k.transpose(2, 3)) * sm_scale
+    if causal:
+        p[:, :, M == 0] = float("-inf")
+    p = torch.softmax(p.float(), dim=-1).half()
+    # p = torch.exp(p)
+    ref_out = torch.matmul(p, v)
+    ref_out.backward(dout)
+    ref_dv, v.grad = v.grad.clone(), None
+    ref_dk, k.grad = k.grad.clone(), None
+    ref_dq, q.grad = q.grad.clone(), None
+    # triton implementation
+    tri_out = attention(q, k, v, causal, sm_scale)
+    # print(ref_out)
+    # print(tri_out)
+    tri_out.backward(dout)
+    tri_dv, v.grad = v.grad.clone(), None
+    tri_dk, k.grad = k.grad.clone(), None
+    tri_dq, q.grad = q.grad.clone(), None
+    # compare
+    # assert torch.allclose(ref_out, tri_out, atol=1e-2, rtol=0)
+    print("= " * 30)
+    print("CHECK RESULTS: TORCH vs TRITON")
+    print("o max diff = ", (ref_out - tri_out).to(torch.float32).abs().max())
+    print("dv max diff = ", (ref_dv - tri_dv).to(torch.float32).abs().max())
+    print("dk max diff = ", (ref_dk - tri_dk).to(torch.float32).abs().max())
+    print("dq max diff = ", (ref_dq - tri_dq).to(torch.float32).abs().max())
+    print("= " * 30)
+
+    atol = 1e-2
+    torch.testing.assert_allclose(ref_out, tri_out, atol=atol, rtol=0, equal_nan=True)
+    torch.testing.assert_allclose(ref_dv, tri_dv, atol=atol, rtol=0, equal_nan=True)
+    torch.testing.assert_allclose(ref_dk, tri_dk, atol=atol, rtol=0, equal_nan=True)
+    torch.testing.assert_allclose(ref_dq, tri_dq, atol=atol, rtol=0, equal_nan=True)
+
+
+try:
+    from flash_attn.flash_attn_interface import \
+        flash_attn_qkvpacked_func as flash_attn_func
+    FLASH_VER = 2
+except BaseException:
+    try:
+        from flash_attn.flash_attn_interface import flash_attn_func
+        FLASH_VER = 1
+    except BaseException:
+        FLASH_VER = None
+HAS_FLASH = FLASH_VER is not None
+
+# BATCH, N_HEADS, N_CTX, D_HEAD = 4, 48, 4096, 64
+BATCH, N_HEADS, N_CTX, D_HEAD = 1, 16, 4096, 128
+# vary seq length for fixed head and batch=4
+configs = [
+    triton.testing.Benchmark(
+        x_names=['N_CTX'], x_vals=[2**i
+                                   for i in range(10, 14)], line_arg='provider',
+        line_vals=['triton'] + (['flash'] if HAS_FLASH else []),
+        line_names=['Triton'] + ([f'Flash-{FLASH_VER}'] if HAS_FLASH else []), styles=[('red', '-'), ('blue', '-')],
+        ylabel='ms', plot_name=f'fused-attention-batch{BATCH}-head{N_HEADS}-d{D_HEAD}-{mode}--mask{causal}',
+        args={'H': N_HEADS, 'BATCH': BATCH, 'D_HEAD': D_HEAD, 'dtype': torch.float16, 'mode': mode, 'causal': causal})
+    for mode in ['fwd', 'bwd']
+    for causal in [False, True]
+]
+
+
+@triton.testing.perf_report(configs)
+def bench_flash_attention(BATCH, H, N_CTX, D_HEAD, causal, mode, provider, dtype=torch.float16, device="cuda"):
+    assert mode in ['fwd', 'bwd']
+    warmup = 25
+    rep = 100
+    if provider == "triton":
+        q = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        k = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        v = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        sm_scale = 1.3
+        fn = lambda: attention(q, k, v, causal, sm_scale)
+        if mode == 'bwd':
+            o = fn()
+            do = torch.randn_like(o)
+            fn = lambda: o.backward(do, retain_graph=True)
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    if provider == "flash":
+        qkv = torch.randn((BATCH, N_CTX, 3, H, D_HEAD), dtype=dtype, device=device, requires_grad=True)
+        if FLASH_VER == 1:
+            lengths = torch.full((BATCH, ), fill_value=N_CTX, device=device)
+            cu_seqlens = torch.zeros((BATCH + 1, ), device=device, dtype=torch.int32)
+            cu_seqlens[1:] = lengths.cumsum(0)
+            qkv = qkv.reshape(BATCH * N_CTX, 3, H, D_HEAD)
+            fn = lambda: flash_attn_func(qkv, cu_seqlens, 0., N_CTX, causal=causal)
+        elif FLASH_VER == 2:
+            fn = lambda: flash_attn_func(qkv, causal=causal)
+        else:
+            raise ValueError(f'unknown {FLASH_VER = }')
+        if mode == 'bwd':
+            o = fn()
+            do = torch.randn_like(o)
+            fn = lambda: o.backward(do, retain_graph=True)
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    flops_per_matmul = 2. * BATCH * H * N_CTX * N_CTX * D_HEAD
+    total_flops = 2 * flops_per_matmul
+    if causal:
+        total_flops *= 0.5
+    if mode == 'bwd':
+        total_flops *= 2.5  # 2.0(bwd) + 0.5(recompute)
+    # return total_flops / ms * 1e-9
+    return ms
+
+
+# # only works on post-Ampere GPUs right now
+# bench_flash_attention.run(save_path='.', print_data=True)
+
+if __name__ == "__main__":
+    Z, H, N_CTX, D_HEAD, causal = 1, 16, 4096, 128, True  #1, 1, 64, 64
+    # test_op(Z, H, N_CTX, D_HEAD, causal, dtype=torch.float16)
+    bench_flash_attention.run(save_path='.', print_data=True)

--- a/third_party/iluvatar/python/tutorials/fused_attention/fused-attention_0812.py
+++ b/third_party/iluvatar/python/tutorials/fused_attention/fused-attention_0812.py
@@ -1,0 +1,478 @@
+"""
+Fused Attention
+===============
+
+This is a Triton implementation of the Flash Attention v2 algorithm from Tri Dao (https://tridao.me/publications/flash2/flash2.pdf)
+
+Extra Credits:
+- Original flash attention paper (https://arxiv.org/abs/2205.14135)
+- Rabe and Staats (https://arxiv.org/pdf/2112.05682v2.pdf)
+- Adam P. Goucher for simplified vector math
+
+#TODO:
+Document the difference with respect to 0629 version.( Major improvements or issues/workaround on MR)
+
+0812 version:
+https://github.com/Jokeren/triton/blob/6ded143240099d37cb409805c7a01e2addf7b8ce/python/tutorials/06-fused-attention.py
+"""
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton.runtime.build import is_corex
+
+
+@triton.jit
+def max_fn(x, y):
+    return tl.maximum(x, y)
+
+
+@triton.jit
+def _fwd_kernel(
+    Q,
+    K,
+    V,
+    sm_scale,
+    L,
+    Out,
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vk,
+    stride_vn,
+    stride_oz,
+    stride_oh,
+    stride_om,
+    stride_on,
+    Z,
+    H,
+    N_CTX,
+    P_SEQ,
+    BLOCK_M: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+):
+    start_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    q_offset = off_hz * stride_qh
+    kv_offset = off_hz * stride_kh
+    Q_block_ptr = tl.make_block_ptr(base=Q + q_offset, shape=(N_CTX, BLOCK_DMODEL), strides=(stride_qm, stride_qk),
+                                    offsets=(start_m * BLOCK_M, 0), block_shape=(BLOCK_M, BLOCK_DMODEL), order=(1, 0))
+    K_block_ptr = tl.make_block_ptr(base=K + kv_offset, shape=(BLOCK_DMODEL, N_CTX + P_SEQ),
+                                    strides=(stride_kk, stride_kn), offsets=(0, 0), block_shape=(BLOCK_DMODEL, BLOCK_N),
+                                    order=(0, 1))
+    V_block_ptr = tl.make_block_ptr(base=V + kv_offset, shape=(N_CTX + P_SEQ, BLOCK_DMODEL),
+                                    strides=(stride_vk, stride_vn), offsets=(0, 0), block_shape=(BLOCK_N, BLOCK_DMODEL),
+                                    order=(1, 0))
+    # initialize offsets
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    # initialize pointer to m and l
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+    # scale sm_scale by log_2(e) and use
+    # 2^x instead of exp in the loop because CSE and LICM
+    # don't work as expected with `exp` in the loop
+    qk_scale = sm_scale * 1.44269504
+    # load q: it will stay in SRAM throughout
+    q = tl.load(Q_block_ptr)
+    q = (q * qk_scale).to(tl.float16)
+    # loop over k, v and update accumulator
+    lo = 0
+    hi = P_SEQ + (start_m + 1) * BLOCK_M if IS_CAUSAL else N_CTX + P_SEQ
+    for start_n in range(lo, hi, BLOCK_N):
+        # -- load k, v --
+        k = tl.load(K_block_ptr)
+        v = tl.load(V_block_ptr)
+        # -- compute qk ---
+        qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float16)
+        if IS_CAUSAL:
+            qk = tl.where(P_SEQ + offs_m[:, None] >= (start_n + offs_n[None, :]), qk, float("-inf"))
+        # qk += tl.dot(q, k, out_dtype=tl.float16)
+        qk += tl.dot(q, k).to(tl.float16)
+        # -- compute scaling constant ---
+        m_i_new = tl.maximum(m_i, tl.max(qk, 1))
+        alpha = tl.math.exp2(m_i - m_i_new)
+        p = tl.math.exp2(qk - m_i_new[:, None])
+        # -- scale and update acc --
+        acc *= alpha[:, None]
+        acc += tl.dot(p.to(tl.float16), v)
+        # -- update m_i and l_i --
+        l_i = l_i * alpha + tl.sum(p, 1)
+        m_i = m_i_new
+        # update pointers
+        K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+        V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
+    # write back l and m
+    acc = acc / l_i[:, None]
+    l_ptrs = L + off_hz * N_CTX + offs_m
+    tl.store(l_ptrs, m_i + tl.math.log2(l_i))
+    # write back O
+    O_block_ptr = tl.make_block_ptr(base=Out + q_offset, shape=(N_CTX, BLOCK_DMODEL), strides=(stride_om, stride_on),
+                                    offsets=(start_m * BLOCK_M, 0), block_shape=(BLOCK_M, BLOCK_DMODEL), order=(1, 0))
+    tl.store(O_block_ptr, acc.to(tl.float16))
+
+
+@triton.jit
+def _bwd_preprocess(
+    Out,
+    DO,
+    Delta,
+    BLOCK_M: tl.constexpr,
+    D_HEAD: tl.constexpr,
+):
+    off_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    off_n = tl.arange(0, D_HEAD)
+    # load
+    o = tl.load(Out + off_m[:, None] * D_HEAD + off_n[None, :]).to(tl.float32)
+    do = tl.load(DO + off_m[:, None] * D_HEAD + off_n[None, :]).to(tl.float32)
+    # compute
+    delta = tl.sum(o * do, axis=1)
+    # write-back
+    tl.store(Delta + off_m, delta)
+
+
+@triton.jit
+def _bwd_kernel(
+    Q,
+    K,
+    V,
+    sm_scale,
+    Out,
+    DO,
+    DQ,
+    DK,
+    DV,
+    L,
+    D,
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vk,
+    stride_vn,
+    Z,
+    H,
+    N_CTX,
+    P_SEQ,
+    num_block_q,
+    num_block_kv,
+    BLOCK_M: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    CAUSAL: tl.constexpr,
+):
+    off_hz = tl.program_id(0)
+    off_z = off_hz // H
+    off_h = off_hz % H
+    qk_scale = sm_scale * 1.44269504
+    # offset pointers for batch/head
+    Q += off_z * stride_qz + off_h * stride_qh
+    K += off_z * stride_kz + off_h * stride_kh
+    V += off_z * stride_vz + off_h * stride_vh
+    DO += off_z * stride_qz + off_h * stride_qh
+    DQ += off_z * stride_qz + off_h * stride_qh
+    DK += off_z * stride_kz + off_h * stride_kh
+    DV += off_z * stride_vz + off_h * stride_vh
+    for start_n in range(0, num_block_kv):
+        if CAUSAL:
+            lo = tl.maximum(start_n * BLOCK_M - P_SEQ, 0)
+        else:
+            lo = 0
+        # initialize row/col offsets
+        offs_qm = lo + tl.arange(0, BLOCK_M)
+        offs_n = start_n * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_m = tl.arange(0, BLOCK_N)
+        offs_k = tl.arange(0, BLOCK_DMODEL)
+        # initialize pointers to value-like data
+        q_ptrs = Q + (offs_qm[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+        k_ptrs = K + (offs_n[:, None] * stride_kn + offs_k[None, :] * stride_kk)
+        v_ptrs = V + (offs_n[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+        do_ptrs = DO + (offs_qm[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+        dq_ptrs = DQ + (offs_qm[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+        # pointer to row-wise quantities in value-like data
+        D_ptrs = D + off_hz * N_CTX
+        l_ptrs = L + off_hz * N_CTX
+        # initialize dk amd dv
+        dk = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+        dv = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+        # k and v stay in SRAM throughout
+        k = tl.load(k_ptrs)
+        v = tl.load(v_ptrs)
+        # loop over rows
+        for start_m in range(lo, num_block_q * BLOCK_M, BLOCK_M):
+            offs_m_curr = start_m + offs_m
+            # load q, k, v, do on-chip
+            q = tl.load(q_ptrs)
+            # recompute p = softmax(qk, dim=-1).T
+            if CAUSAL:
+                qk = tl.where(P_SEQ + offs_m_curr[:, None] >= (offs_n[None, :]), float(0.), float("-inf"))
+            else:
+                qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+            qk += tl.dot(q, tl.trans(k))
+            qk *= qk_scale
+            l_i = tl.load(l_ptrs + offs_m_curr)
+            p = tl.math.exp2(qk - l_i[:, None])
+            # compute dv
+            do = tl.load(do_ptrs)
+            dv += tl.dot(tl.trans(p.to(Q.dtype.element_ty)), do)
+            # compute dp = dot(v, do)
+            Di = tl.load(D_ptrs + offs_m_curr)
+            dp = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32) - Di[:, None]
+            dp += tl.dot(do, tl.trans(v))
+            # compute ds = p * (dp - delta[:, None])
+            ds = p * dp * sm_scale
+            # compute dk = dot(ds.T, q)
+            dk += tl.dot(tl.trans(ds.to(Q.dtype.element_ty)), q)
+            # compute dq
+            dq = tl.load(dq_ptrs)
+            dq += tl.dot(ds.to(Q.dtype.element_ty), k)
+            tl.store(dq_ptrs, dq)
+            # increment pointers
+            dq_ptrs += BLOCK_M * stride_qm
+            q_ptrs += BLOCK_M * stride_qm
+            do_ptrs += BLOCK_M * stride_qm
+        # write-back
+        dk_ptrs = DK + (offs_n[:, None] * stride_kn + offs_k[None, :] * stride_kk)
+        dv_ptrs = DV + (offs_n[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+        tl.store(dk_ptrs, dk)
+        tl.store(dv_ptrs, dv)
+
+
+empty = torch.empty(128, device="cuda")
+
+
+class _attention(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, q, k, v, causal, sm_scale):
+        # shape constraints
+        Lq, Lk, Lv = q.shape[-1], k.shape[-1], v.shape[-1]
+        assert Lq == Lk and Lk == Lv
+        assert Lk in {16, 32, 64, 128}
+        o = torch.empty_like(q)
+        if is_corex():
+            BLOCK_M = 64
+            BLOCK_N = 64 if Lk <= 64 else 32
+            num_stages = 1
+            num_warps = 4
+        else:
+            BLOCK_M = 128
+            BLOCK_N = 64 if Lk <= 64 else 32
+            num_stages = 4 if Lk <= 64 else 3
+            num_warps = 4
+
+        grid = (triton.cdiv(q.shape[2], BLOCK_M), q.shape[0] * q.shape[1], 1)
+        L = torch.empty((q.shape[0] * q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+        P_SEQ = 0 if q.shape[-2] == k.shape[-2] else k.shape[-2] - q.shape[-2]
+        _fwd_kernel[grid](q, k, v, sm_scale, L, o, q.stride(0), q.stride(1), q.stride(2), q.stride(3), k.stride(0),
+                          k.stride(1), k.stride(2), k.stride(3), v.stride(0), v.stride(1), v.stride(2), v.stride(3),
+                          o.stride(0), o.stride(1), o.stride(2), o.stride(3), q.shape[0], q.shape[1], q.shape[2], P_SEQ,
+                          BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_DMODEL=Lk, IS_CAUSAL=causal, num_warps=num_warps,
+                          num_stages=num_stages)
+
+        ctx.save_for_backward(q, k, v, o, L)
+        ctx.grid = grid
+        ctx.sm_scale = sm_scale
+        ctx.BLOCK_DMODEL = Lk
+        ctx.causal = causal
+        ctx.P_SEQ = P_SEQ
+        return o
+
+    @staticmethod
+    def backward(ctx, do):
+        BLOCK = 64 if is_corex() else 128
+        q, k, v, o, L = ctx.saved_tensors
+        do = do.contiguous()
+        dq = torch.zeros_like(q, dtype=torch.float32)
+        dk = torch.empty_like(k)
+        dv = torch.empty_like(v)
+        delta = torch.empty_like(L)
+        _bwd_preprocess[(ctx.grid[0] * ctx.grid[1], )](
+            o,
+            do,
+            delta,
+            BLOCK_M=BLOCK,
+            D_HEAD=ctx.BLOCK_DMODEL,
+        )
+        _bwd_kernel[(ctx.grid[1], )](
+            q,
+            k,
+            v,
+            ctx.sm_scale,
+            o,
+            do,
+            dq,
+            dk,
+            dv,
+            L,
+            delta,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            k.stride(0),
+            k.stride(1),
+            k.stride(2),
+            k.stride(3),
+            v.stride(0),
+            v.stride(1),
+            v.stride(2),
+            v.stride(3),
+            q.shape[0],
+            q.shape[1],
+            q.shape[2],
+            ctx.P_SEQ,
+            ctx.grid[0],
+            triton.cdiv(k.shape[2], BLOCK),
+            BLOCK_M=BLOCK,
+            BLOCK_N=BLOCK,
+            BLOCK_DMODEL=ctx.BLOCK_DMODEL,
+            num_warps=8,
+            CAUSAL=ctx.causal,
+            num_stages=1,
+        )
+        return dq, dk, dv, None, None
+
+
+attention = _attention.apply
+
+
+@pytest.mark.parametrize('Z, H, N_CTX, D_HEAD, P_SEQ', [(6, 9, 1024, 64, 128)])
+@pytest.mark.parametrize('causal', [False, True])
+def test_op(Z, H, N_CTX, D_HEAD, P_SEQ, causal, dtype=torch.float16):
+    torch.manual_seed(20)
+    q = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0.1, std=0.2).requires_grad_()
+    k = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0.4, std=0.2).requires_grad_()
+    v = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0.3, std=0.2).requires_grad_()
+    sm_scale = 0.2
+    dout = torch.randn_like(q)
+    # reference implementation
+    M = torch.tril(torch.ones((N_CTX, N_CTX + P_SEQ), device="cuda"), diagonal=P_SEQ)
+    p = torch.matmul(q, k.transpose(2, 3)) * sm_scale
+    if causal:
+        p[:, :, M == 0] = float("-inf")
+    p = torch.softmax(p.float(), dim=-1).half()
+    # p = torch.exp(p)
+    ref_out = torch.matmul(p, v)
+    ref_out.backward(dout)
+    ref_dv, v.grad = v.grad.clone(), None
+    ref_dk, k.grad = k.grad.clone(), None
+    ref_dq, q.grad = q.grad.clone(), None
+    # triton implementation
+    tri_out = attention(q, k, v, causal, sm_scale).half()
+    tri_out.backward(dout)
+    tri_dv, v.grad = v.grad.clone(), None
+    tri_dk, k.grad = k.grad.clone(), None
+    tri_dq, q.grad = q.grad.clone(), None
+    # compare
+    print("= " * 30)
+    print("CHECK RESULTS: TORCH vs TRITON")
+    print("o max diff = ", (ref_out - tri_out).to(torch.float32).abs().max())
+    print("dv max diff = ", (ref_dv - tri_dv).to(torch.float32).abs().max())
+    print("dk max diff = ", (ref_dk - tri_dk).to(torch.float32).abs().max())
+    print("dq max diff = ", (ref_dq - tri_dq).to(torch.float32).abs().max())
+    print("= " * 30)
+
+    atol = 1e-2
+    torch.testing.assert_close(ref_out, tri_out, atol=atol, rtol=0, equal_nan=True)
+    torch.testing.assert_close(ref_dv, tri_dv, atol=atol, rtol=0, equal_nan=True)
+    torch.testing.assert_close(ref_dk, tri_dk, atol=atol, rtol=0, equal_nan=True)
+    torch.testing.assert_close(ref_dq, tri_dq, atol=atol, rtol=0, equal_nan=True)
+
+
+try:
+    from flash_attn.flash_attn_interface import \
+        flash_attn_qkvpacked_func as flash_attn_func
+    FLASH_VER = 2
+except BaseException:
+    try:
+        from flash_attn.flash_attn_interface import flash_attn_func
+        FLASH_VER = 1
+    except BaseException:
+        FLASH_VER = None
+HAS_FLASH = FLASH_VER is not None
+
+# BATCH, N_HEADS, N_CTX, D_HEAD = 4, 48, 4096, 64
+BATCH, N_HEADS, N_CTX, D_HEAD = 1, 16, 4096, 128
+# vary seq length for fixed head and batch=4
+configs = [
+    triton.testing.Benchmark(
+        x_names=['N_CTX'], x_vals=[2**i
+                                   for i in range(10, 14)], line_arg='provider',
+        line_vals=['triton'] + (['flash'] if HAS_FLASH else []),
+        line_names=['Triton'] + ([f'Flash-{FLASH_VER}'] if HAS_FLASH else []), styles=[('red', '-'), ('blue', '-')],
+        ylabel='ms', plot_name=f'fused-attention-batch{BATCH}-head{N_HEADS}-d{D_HEAD}-{mode}--mask{causal}',
+        args={'H': N_HEADS, 'BATCH': BATCH, 'D_HEAD': D_HEAD, 'dtype': torch.float16, 'mode': mode, 'causal': causal})
+    for mode in ['fwd', 'bwd']
+    for causal in [False, True]
+]
+
+
+@triton.testing.perf_report(configs)
+def bench_flash_attention(BATCH, H, N_CTX, D_HEAD, causal, mode, provider, dtype=torch.float16, device="cuda"):
+    assert mode in ['fwd', 'bwd']
+    warmup = 25
+    rep = 100
+    if provider == "triton":
+        q = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        k = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        v = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        sm_scale = 1.3
+        fn = lambda: attention(q, k, v, causal, sm_scale)
+        if mode == 'bwd':
+            o = fn()
+            do = torch.randn_like(o)
+            fn = lambda: o.backward(do, retain_graph=True)
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    if provider == "flash":
+        qkv = torch.randn((BATCH, N_CTX, 3, H, D_HEAD), dtype=dtype, device=device, requires_grad=True)
+        if FLASH_VER == 1:
+            lengths = torch.full((BATCH, ), fill_value=N_CTX, device=device)
+            cu_seqlens = torch.zeros((BATCH + 1, ), device=device, dtype=torch.int32)
+            cu_seqlens[1:] = lengths.cumsum(0)
+            qkv = qkv.reshape(BATCH * N_CTX, 3, H, D_HEAD)
+            fn = lambda: flash_attn_func(qkv, cu_seqlens, 0., N_CTX, causal=causal)
+        elif FLASH_VER == 2:
+            fn = lambda: flash_attn_func(qkv, causal=causal)
+        else:
+            raise ValueError(f'unknown {FLASH_VER = }')
+        if mode == 'bwd':
+            o = fn()
+            do = torch.randn_like(o)
+            fn = lambda: o.backward(do, retain_graph=True)
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    flops_per_matmul = 2. * BATCH * H * N_CTX * N_CTX * D_HEAD
+    total_flops = 2 * flops_per_matmul
+    if causal:
+        total_flops *= 0.5
+    if mode == 'bwd':
+        total_flops *= 2.5  # 2.0(bwd) + 0.5(recompute)
+    # return total_flops / ms * 1e-9
+    return ms
+
+
+# # only works on post-Ampere GPUs right now
+# bench_flash_attention.run(save_path='.', print_data=True)
+
+if __name__ == "__main__":
+    Z, H, N_CTX, D_HEAD, P_SEQ, causal = 1, 16, 4096, 128, 0, True
+    # test_op(Z, H, N_CTX, D_HEAD, P_SEQ, causal, dtype=torch.float16)
+    bench_flash_attention.run(save_path='.', print_data=True)

--- a/third_party/iluvatar/python/tutorials/fused_attention/fused-attention_1113.py
+++ b/third_party/iluvatar/python/tutorials/fused_attention/fused-attention_1113.py
@@ -1,0 +1,688 @@
+"""
+Fused Attention
+===============
+
+This is a Triton implementation of the Flash Attention v2 algorithm from Tri Dao (https://tridao.me/publications/flash2/flash2.pdf)
+Credits: OpenAI kernel team
+
+Extra Credits:
+- Original flash attention paper (https://arxiv.org/abs/2205.14135)
+- Rabe and Staats (https://arxiv.org/pdf/2112.05682v2.pdf)
+
+1113 version:
+https://github.com/openai/triton/blob/0909c8a28d11831e348dfed08bea83e5687250a8/python/tutorials/06-fused-attention.py
+"""
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton.runtime.build import is_corex
+
+
+@triton.jit
+def _attn_fwd_inner(acc, l_i, m_i, q,  #
+                    K_block_ptr, V_block_ptr,  #
+                    start_m, qk_scale,  #
+                    BLOCK_M: tl.constexpr, BLOCK_DMODEL: tl.constexpr, BLOCK_N: tl.constexpr,  #
+                    STAGE: tl.constexpr, offs_m: tl.constexpr, offs_n: tl.constexpr,  #
+                    N_CTX: tl.constexpr):
+    # range of values handled by this stage
+    if STAGE == 1:
+        lo, hi = 0, start_m * BLOCK_M
+    elif STAGE == 2:
+        lo, hi = start_m * BLOCK_M, (start_m + 1) * BLOCK_M
+        lo = tl.multiple_of(lo, BLOCK_M)
+    # causal = False
+    else:
+        lo, hi = 0, N_CTX
+    K_block_ptr = tl.advance(K_block_ptr, (0, lo))
+    V_block_ptr = tl.advance(V_block_ptr, (lo, 0))
+    # loop over k, v and update accumulator
+    for start_n in range(lo, hi, BLOCK_N):
+        start_n = tl.multiple_of(start_n, BLOCK_N)
+        # -- compute qk ----
+        k = tl.load(K_block_ptr)
+        qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+        qk += tl.dot(q, k)
+        if STAGE == 2:
+            mask = offs_m[:, None] >= (start_n + offs_n[None, :])
+            qk = qk * qk_scale + tl.where(mask, 0, -1.0e6)
+            m_ij = tl.maximum(m_i, tl.max(qk, 1))
+            qk -= m_ij[:, None]
+        else:
+            m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+            qk = qk * qk_scale - m_ij[:, None]
+        p = tl.math.exp2(qk)
+        l_ij = tl.sum(p, 1)
+        # -- update m_i and l_i
+        alpha = tl.math.exp2(m_i - m_ij)
+        l_i = l_i * alpha + l_ij
+        # -- update output accumulator --
+        acc = acc * alpha[:, None]
+        # update acc
+        v = tl.load(V_block_ptr)
+        acc += tl.dot(p.to(tl.float16), v)
+        # update m_i and l_i
+        m_i = m_ij
+        V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
+        K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+    return acc, l_i, m_i
+
+
+# We don't run auto-tuning everytime to keep the tutorial fast. Uncommenting
+# the code below and commenting out the equivalent parameters is convenient for
+# re-tuning.
+# def get_corex_configs():
+#     configs = []
+#     if hasattr(torch, "corex"):
+#         for block_m in [32, 64, 128, 256]:
+#             for block_n in [32, 64, 128, 256]:
+#                 for num_warps in [8, 16, 32] if (block_m > 128 or block_n > 128) else [4, 8, 16]:
+#                     configs.append(
+#                             triton.Config({'BLOCK_M': block_m, 'BLOCK_N': block_n},
+#                                           num_stages = 1, num_warps=num_warps))
+#     return configs
+
+# @triton.autotune(
+#    configs=[
+#        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 64}, num_warps=8),
+#        triton.Config({'BLOCK_M': 256, 'BLOCK_N': 64}, num_warps=8),
+#        triton.Config({'BLOCK_M': 256, 'BLOCK_N': 32}, num_warps=8),
+#        triton.Config({'BLOCK_M': 256, 'BLOCK_N': 32}, num_warps=4),
+#        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 32}, num_warps=4),
+#        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 32}, num_warps=4),
+#        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 64}, num_warps=4),
+#        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 64}, num_warps=4),
+#        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 64}, num_warps=8),
+#        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 64}, num_warps=8),
+#        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 32}, num_warps=8),
+#        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 32}, num_warps=8),
+#        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 32}, num_warps=8),
+#        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 32}, num_warps=8),
+#        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 64}, num_warps=4),
+#    ],
+#    key=['N_CTX'],
+# )
+
+# @triton.autotune(
+#     configs=get_corex_configs(),
+#     key=['N_CTX']
+# )
+
+
+@triton.jit
+def _attn_fwd(Q, K, V, sm_scale, M, Out,  #
+              stride_qz, stride_qh, stride_qm, stride_qk,  #
+              stride_kz, stride_kh, stride_kn, stride_kk,  #
+              stride_vz, stride_vh, stride_vk, stride_vn,  #
+              stride_oz, stride_oh, stride_om, stride_on,  #
+              Z, H,  #
+              N_CTX: tl.constexpr,  #
+              BLOCK_M: tl.constexpr,  #
+              BLOCK_DMODEL: tl.constexpr,  #
+              BLOCK_N: tl.constexpr,  #
+              STAGE: tl.constexpr  #
+              ):
+    start_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    off_z = off_hz // H
+    off_h = off_hz % H
+    qvk_offset = off_z.to(tl.int64) * stride_qz + off_h.to(tl.int64) * stride_qh
+
+    # block pointers
+    Q_block_ptr = tl.make_block_ptr(
+        base=Q + qvk_offset,
+        shape=(N_CTX, BLOCK_DMODEL),
+        strides=(stride_qm, stride_qk),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, BLOCK_DMODEL),
+        order=(1, 0),
+    )
+    V_block_ptr = tl.make_block_ptr(
+        base=V + qvk_offset,
+        shape=(N_CTX, BLOCK_DMODEL),
+        strides=(stride_vk, stride_vn),
+        offsets=(0, 0),
+        block_shape=(BLOCK_N, BLOCK_DMODEL),
+        order=(1, 0),
+    )
+    K_block_ptr = tl.make_block_ptr(
+        base=K + qvk_offset,
+        shape=(BLOCK_DMODEL, N_CTX),
+        strides=(stride_kk, stride_kn),
+        offsets=(0, 0),
+        block_shape=(BLOCK_DMODEL, BLOCK_N),
+        order=(0, 1),
+    )
+    O_block_ptr = tl.make_block_ptr(
+        base=Out + qvk_offset,
+        shape=(N_CTX, BLOCK_DMODEL),
+        strides=(stride_om, stride_on),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, BLOCK_DMODEL),
+        order=(1, 0),
+    )
+    # initialize offsets
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    # initialize pointer to m and l
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32) + 1.0
+    acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+    # load scales
+    qk_scale = sm_scale
+    qk_scale *= 1.44269504  # 1/log(2)
+    # load q: it will stay in SRAM throughout
+    q = tl.load(Q_block_ptr)
+    # stage 1: off-band
+    # For causal = True, STAGE = 3 and _attn_fwd_inner gets 1 as its STAGE
+    # For causal = False, STAGE = 1, and _attn_fwd_inner gets 3 as its STAGE
+    if STAGE & 1:
+        acc, l_i, m_i = _attn_fwd_inner(acc, l_i, m_i, q, K_block_ptr, V_block_ptr,  #
+                                        start_m, qk_scale,  #
+                                        BLOCK_M, BLOCK_DMODEL, BLOCK_N,  #
+                                        4 - STAGE, offs_m, offs_n, N_CTX  #
+                                        )
+    # stage 2: on-band
+    if STAGE & 2:
+        # barrier makes it easier for compielr to schedule the
+        # two loops independently
+        tl.debug_barrier()
+        acc, l_i, m_i = _attn_fwd_inner(acc, l_i, m_i, q, K_block_ptr, V_block_ptr,  #
+                                        start_m, qk_scale,  #
+                                        BLOCK_M, BLOCK_DMODEL, BLOCK_N,  #
+                                        2, offs_m, offs_n, N_CTX  #
+                                        )
+    # epilogue
+    m_i += tl.math.log2(l_i)
+    acc = acc / l_i[:, None]
+    m_ptrs = M + off_hz * N_CTX + offs_m
+    tl.store(m_ptrs, m_i)
+    tl.store(O_block_ptr, acc.to(Out.type.element_ty))
+
+
+@triton.jit
+def _attn_bwd_preprocess(O, DO,  #
+                         Delta,  #
+                         Z, H, N_CTX,  #
+                         BLOCK_M: tl.constexpr, D_HEAD: tl.constexpr  #
+                         ):
+    off_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    off_hz = tl.program_id(1)
+    off_n = tl.arange(0, D_HEAD)
+    # load
+    o = tl.load(O + off_hz * D_HEAD * N_CTX + off_m[:, None] * D_HEAD + off_n[None, :])
+    do = tl.load(DO + off_hz * D_HEAD * N_CTX + off_m[:, None] * D_HEAD + off_n[None, :]).to(tl.float32)
+    delta = tl.sum(o * do, axis=1)
+    # write-back
+    tl.store(Delta + off_hz * N_CTX + off_m, delta)
+
+
+# The main inner-loop logic for computing dK and dV.
+@triton.jit
+def _attn_bwd_dkdv(dk, dv,  #
+                   Q, k, v, sm_scale,  #
+                   DO,  #
+                   M, D,  #
+                   # shared by Q/K/V/DO.
+                   stride_tok, stride_d,  #
+                   H, N_CTX, BLOCK_M1: tl.constexpr,  #
+                   BLOCK_N1: tl.constexpr,  #
+                   BLOCK_DMODEL: tl.constexpr,  #
+                   # Filled in by the wrapper.
+                   start_n, start_m, num_steps,  #
+                   MASK: tl.constexpr):
+    offs_m = start_m + tl.arange(0, BLOCK_M1)
+    offs_n = start_n + tl.arange(0, BLOCK_N1)
+    offs_k = tl.arange(0, BLOCK_DMODEL)
+    qT_ptrs = Q + offs_m[None, :] * stride_tok + offs_k[:, None] * stride_d
+    do_ptrs = DO + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d
+    # BLOCK_N1 must be a multiple of BLOCK_M1, otherwise the code wouldn't work.
+    tl.static_assert(BLOCK_N1 % BLOCK_M1 == 0)
+    curr_m = start_m
+    step_m = BLOCK_M1
+    for blk_idx in range(num_steps):
+        qT = tl.load(qT_ptrs)
+        # Load m before computing qk to reduce pipeline stall.
+        offs_m = curr_m + tl.arange(0, BLOCK_M1)
+        m = tl.load(M + offs_m)
+        qkT = tl.dot(k, qT)
+        pT = tl.math.exp2(qkT - m[None, :])
+        # Autoregressive masking.
+        if MASK:
+            mask = (offs_m[None, :] >= offs_n[:, None])
+            pT = tl.where(mask, pT, 0.0)
+        do = tl.load(do_ptrs)
+        # Compute dV.
+        ppT = pT
+        ppT = ppT.to(tl.float16)
+        dv += tl.dot(ppT, do)
+        # D (= delta) is pre-divided by ds_scale.
+        Di = tl.load(D + offs_m)
+        # Compute dP and dS.
+        dpT = tl.dot(v, tl.trans(do)).to(tl.float32)
+        dsT = pT * (dpT - Di[None, :])
+        dsT = dsT.to(tl.float16)
+        dk += tl.dot(dsT, tl.trans(qT))
+        # Increment pointers.
+        curr_m += step_m
+        qT_ptrs += step_m * stride_tok
+        do_ptrs += step_m * stride_tok
+    return dk, dv
+
+
+# the main inner-loop logic for computing dQ
+@triton.jit
+def _attn_bwd_dq(dq, q, K, V,  #
+                 do, m, D,
+                 # shared by Q/K/V/DO.
+                 stride_tok, stride_d,  #
+                 H, N_CTX,  #
+                 BLOCK_M2: tl.constexpr,  #
+                 BLOCK_N2: tl.constexpr,  #
+                 BLOCK_DMODEL: tl.constexpr,
+                 # Filled in by the wrapper.
+                 start_m, start_n, num_steps,  #
+                 MASK: tl.constexpr):
+    offs_m = start_m + tl.arange(0, BLOCK_M2)
+    offs_n = start_n + tl.arange(0, BLOCK_N2)
+    offs_k = tl.arange(0, BLOCK_DMODEL)
+    kT_ptrs = K + offs_n[None, :] * stride_tok + offs_k[:, None] * stride_d
+    vT_ptrs = V + offs_n[None, :] * stride_tok + offs_k[:, None] * stride_d
+    # D (= delta) is pre-divided by ds_scale.
+    Di = tl.load(D + offs_m)
+    # BLOCK_M2 must be a multiple of BLOCK_N2, otherwise the code wouldn't work.
+    tl.static_assert(BLOCK_M2 % BLOCK_N2 == 0)
+    curr_n = start_n
+    step_n = BLOCK_N2
+    for blk_idx in range(num_steps):
+        kT = tl.load(kT_ptrs)
+        vT = tl.load(vT_ptrs)
+        qk = tl.dot(q, kT)
+        p = tl.math.exp2(qk - m)
+        # Autoregressive masking.
+        if MASK:
+            offs_n = curr_n + tl.arange(0, BLOCK_N2)
+            mask = (offs_m[:, None] >= offs_n[None, :])
+            p = tl.where(mask, p, 0.0)
+        # Compute dP and dS.
+        dp = tl.dot(do, vT).to(tl.float32)
+        ds = p * (dp - Di[:, None])
+        ds = ds.to(tl.float16)
+        # Compute dQ.
+        # NOTE: We need to de-scale dq in the end, because kT was pre-scaled.
+        dq += tl.dot(ds, tl.trans(kT))
+        # Increment pointers.
+        curr_n += step_n
+        kT_ptrs += step_n * stride_tok
+        vT_ptrs += step_n * stride_tok
+    return dq
+
+
+@triton.jit
+def _attn_bwd(Q, K, V, sm_scale,  #
+              DO,  #
+              DQ, DK, DV,  #
+              M, D,
+              # shared by Q/K/V/DO.
+              stride_z, stride_h, stride_tok, stride_d,  #
+              H, N_CTX,  #
+              BLOCK_M1: tl.constexpr,  #
+              BLOCK_N1: tl.constexpr,  #
+              BLOCK_M2: tl.constexpr,  #
+              BLOCK_N2: tl.constexpr,  #
+              BLK_SLICE_FACTOR: tl.constexpr,  #
+              BLOCK_DMODEL: tl.constexpr):
+    LN2: tl.constexpr = 0.6931471824645996  # = ln(2)
+
+    bhid = tl.program_id(2)
+    off_chz = (bhid * N_CTX).to(tl.int64)
+    adj = (stride_h * (bhid % H) + stride_z * (bhid // H)).to(tl.int64)
+    pid = tl.program_id(0)
+
+    # offset pointers for batch/head
+    Q += adj
+    K += adj
+    V += adj
+    DO += adj
+    DQ += adj
+    DK += adj
+    DV += adj
+    M += off_chz
+    D += off_chz
+
+    # load scales
+    offs_k = tl.arange(0, BLOCK_DMODEL)
+
+    start_n = pid * BLOCK_N1
+    start_m = start_n
+
+    MASK_BLOCK_M1: tl.constexpr = BLOCK_M1 // BLK_SLICE_FACTOR
+    offs_n = start_n + tl.arange(0, BLOCK_N1)
+
+    dv = tl.zeros([BLOCK_N1, BLOCK_DMODEL], dtype=tl.float32)
+    dk = tl.zeros([BLOCK_N1, BLOCK_DMODEL], dtype=tl.float32)
+
+    # load K and V: they stay in SRAM throughout the inner loop.
+    k = tl.load(K + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d)
+    v = tl.load(V + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d)
+
+    num_steps = BLOCK_N1 // MASK_BLOCK_M1
+
+    dk, dv = _attn_bwd_dkdv(dk, dv,  #
+                            Q, k, v, sm_scale,  #
+                            DO,  #
+                            M, D,  #
+                            stride_tok, stride_d,  #
+                            H, N_CTX,  #
+                            MASK_BLOCK_M1, BLOCK_N1, BLOCK_DMODEL,  #
+                            start_n, start_m, num_steps,  #
+                            MASK=True  #
+                            )
+
+    start_m += num_steps * MASK_BLOCK_M1
+    num_steps = (N_CTX - start_m) // BLOCK_M1
+
+    # Compute dK and dV for non-masked blocks.
+    dk, dv = _attn_bwd_dkdv(  #
+        dk, dv,  #
+        Q, k, v, sm_scale,  #
+        DO,  #
+        M, D,  #
+        stride_tok, stride_d,  #
+        H, N_CTX,  #
+        BLOCK_M1, BLOCK_N1, BLOCK_DMODEL,  #
+        start_n, start_m, num_steps,  #
+        MASK=False  #
+    )
+
+    dv_ptrs = DV + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d
+    tl.store(dv_ptrs, dv)
+
+    # Write back dK.
+    dk *= sm_scale
+    dk_ptrs = DK + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d
+    tl.store(dk_ptrs, dk)
+
+    # THIS BLOCK DOES DQ:
+    start_m = pid * BLOCK_M2
+    end_n = start_m + BLOCK_M2
+
+    MASK_BLOCK_N2: tl.constexpr = BLOCK_N2 // BLK_SLICE_FACTOR
+    offs_m = start_m + tl.arange(0, BLOCK_M2)
+
+    q = tl.load(Q + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d)
+    dq = tl.zeros([BLOCK_M2, BLOCK_DMODEL], dtype=tl.float32)
+    do = tl.load(DO + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d)
+
+    m = tl.load(M + offs_m)
+    m = m[:, None]
+
+    # Compute dQ for masked (diagonal) blocks.
+    # NOTE: This code scans each row of QK^T backward (from right to left,
+    # but inside each call to _attn_bwd_dq, from left to right), but that's
+    # not due to anything important.  I just wanted to reuse the loop
+    # structure for dK & dV above as much as possible.
+    num_steps = BLOCK_M2 // MASK_BLOCK_N2
+    dq = _attn_bwd_dq(dq, q, K, V,  #
+                      do, m, D,  #
+                      stride_tok, stride_d,  #
+                      H, N_CTX,  #
+                      BLOCK_M2, MASK_BLOCK_N2, BLOCK_DMODEL,  #
+                      start_m, end_n - num_steps * MASK_BLOCK_N2, num_steps,  #
+                      MASK=True  #
+                      )
+    end_n -= num_steps * MASK_BLOCK_N2
+    # stage 2
+    num_steps = end_n // BLOCK_N2
+    dq = _attn_bwd_dq(dq, q, K, V,  #
+                      do, m, D,  #
+                      stride_tok, stride_d,  #
+                      H, N_CTX,  #
+                      BLOCK_M2, BLOCK_N2, BLOCK_DMODEL,  #
+                      start_m, end_n - num_steps * BLOCK_N2, num_steps,  #
+                      MASK=False  #
+                      )
+    # Write back dQ.
+    dq_ptrs = DQ + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d
+    dq *= LN2
+    tl.store(dq_ptrs, dq)
+
+
+empty = torch.empty(128, device="cuda")
+
+
+class _attention(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, q, k, v, causal, sm_scale):
+        # shape constraints
+        Lq, Lk, Lv = q.shape[-1], k.shape[-1], v.shape[-1]
+        assert Lq == Lk and Lk == Lv
+        assert Lk in {16, 32, 64, 128}
+        o = torch.empty_like(q)
+        if is_corex():
+            BLOCK_M = 64
+            BLOCK_N = 64 if Lk <= 64 else 32
+            num_stages = 1
+            num_warps = 4
+            stage = 3 if causal else 1
+        else:
+            BLOCK_M = 128
+            BLOCK_N = 64 if Lk <= 64 else 32
+            num_stages = 4 if Lk <= 64 else 3
+            num_warps = 4
+            stage = 3 if causal else 1
+
+        # Tuning for H100
+        if torch.cuda.get_device_capability()[0] == 9:
+            num_warps = 8
+            num_stages = 7 if Lk >= 64 else 3
+        # grid = (triton.cdiv(q.shape[2], BLOCK_M), q.shape[0] * q.shape[1], 1)
+        grid = lambda META: (triton.cdiv(q.shape[2], META['BLOCK_M']), q.shape[0] * q.shape[1], 1)
+        M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+        _attn_fwd[grid](
+            q, k, v, sm_scale, M, o,  #
+            q.stride(0), q.stride(1), q.stride(2), q.stride(3),  #
+            k.stride(0), k.stride(1), k.stride(2), k.stride(3),  #
+            v.stride(0), v.stride(1), v.stride(2), v.stride(3),  #
+            o.stride(0), o.stride(1), o.stride(2), o.stride(3),  #
+            q.shape[0], q.shape[1],  #
+            N_CTX=q.shape[2],  #
+            BLOCK_M=BLOCK_M,  #
+            BLOCK_N=BLOCK_N,  #
+            BLOCK_DMODEL=Lk,  #
+            STAGE=stage,  #
+            num_warps=num_warps,  #
+            num_stages=num_stages  #
+        )
+
+        ctx.save_for_backward(q, k, v, o, M)
+        ctx.grid = grid
+        ctx.sm_scale = sm_scale
+        ctx.BLOCK_DMODEL = Lk
+        ctx.causal = causal
+        return o
+
+    @staticmethod
+    def backward(ctx, do):
+        q, k, v, o, M = ctx.saved_tensors
+        assert do.is_contiguous()
+        assert q.stride() == k.stride() == v.stride() == o.stride() == do.stride()
+        dq = torch.empty_like(q)
+        dk = torch.empty_like(k)
+        dv = torch.empty_like(v)
+        BATCH, N_HEAD, N_CTX = q.shape[:3]
+        if is_corex():
+            #TODO: We need verify and tune these parameters
+            PRE_BLOCK = 64
+            NUM_WARPS, NUM_STAGES = 8, 1
+            BLOCK_M1, BLOCK_N1, BLOCK_M2, BLOCK_N2 = 64, 128, 128, 64
+        else:
+            PRE_BLOCK = 128
+            NUM_WARPS, NUM_STAGES = 4, 1
+            BLOCK_M1, BLOCK_N1, BLOCK_M2, BLOCK_N2 = 32, 128, 128, 32
+        if torch.cuda.get_device_capability()[0] == 9:
+            NUM_STAGES = 5
+        BLK_SLICE_FACTOR = 2
+        RCP_LN2 = 1.4426950408889634  # = 1.0 / ln(2)
+        arg_k = k
+        arg_k = arg_k * (ctx.sm_scale * RCP_LN2)
+        assert N_CTX % PRE_BLOCK == 0
+        pre_grid = (N_CTX // PRE_BLOCK, BATCH * N_HEAD)
+        delta = torch.empty_like(M)
+        _attn_bwd_preprocess[pre_grid](
+            o, do,  #
+            delta,  #
+            BATCH, N_HEAD, N_CTX,  #
+            BLOCK_M=PRE_BLOCK, D_HEAD=ctx.BLOCK_DMODEL  #
+        )
+        grid = (N_CTX // BLOCK_N1, 1, BATCH * N_HEAD)
+        _attn_bwd[grid](
+            q, arg_k, v, ctx.sm_scale, do, dq, dk, dv,  #
+            M, delta,  #
+            q.stride(0), q.stride(1), q.stride(2), q.stride(3),  #
+            N_HEAD, N_CTX,  #
+            BLOCK_M1=BLOCK_M1, BLOCK_N1=BLOCK_N1,  #
+            BLOCK_M2=BLOCK_M2, BLOCK_N2=BLOCK_N2,  #
+            BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
+            BLOCK_DMODEL=ctx.BLOCK_DMODEL,  #
+            num_warps=NUM_WARPS,  #
+            num_stages=NUM_STAGES  #
+        )
+        return dq, dk, dv, None, None
+
+
+attention = _attention.apply
+
+
+@pytest.mark.parametrize("Z, H, N_CTX, D_HEAD", [(1, 2, 1024, 64)])
+@pytest.mark.parametrize("causal", [True])
+def test_op(Z, H, N_CTX, D_HEAD, causal, dtype=torch.float16):
+    torch.manual_seed(20)
+    q = (torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0.0, std=0.5).requires_grad_())
+    k = (torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0.0, std=0.5).requires_grad_())
+    v = (torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0.0, std=0.5).requires_grad_())
+    sm_scale = 0.5
+    dout = torch.randn_like(q)
+    # reference implementation
+    M = torch.tril(torch.ones((N_CTX, N_CTX), device="cuda"))
+    p = torch.matmul(q, k.transpose(2, 3)) * sm_scale
+    if causal:
+        p[:, :, M == 0] = float("-inf")
+    p = torch.softmax(p.float(), dim=-1).half()
+    # p = torch.exp(p)
+    ref_out = torch.matmul(p, v)
+    ref_out.backward(dout)
+    ref_dv, v.grad = v.grad.clone(), None
+    ref_dk, k.grad = k.grad.clone(), None
+    ref_dq, q.grad = q.grad.clone(), None
+    # triton implementation
+    tri_out = attention(q, k, v, causal, sm_scale).half()
+    tri_out.backward(dout)
+    tri_dv, v.grad = v.grad.clone(), None
+    tri_dk, k.grad = k.grad.clone(), None
+    tri_dq, q.grad = q.grad.clone(), None
+    # compare
+    print("= " * 30)
+    print("CHECK RESULTS: TORCH vs TRITON")
+    print("o max diff = ", (ref_out - tri_out).to(torch.float32).abs().max())
+    print("dv max diff = ", (ref_dv - tri_dv).to(torch.float32).abs().max())
+    print("dk max diff = ", (ref_dk - tri_dk).to(torch.float32).abs().max())
+    print("dq max diff = ", (ref_dq - tri_dq).to(torch.float32).abs().max())
+    print(" =" * 30)
+
+    atol = 1e-2
+    torch.testing.assert_allclose(ref_out, tri_out, atol=atol, rtol=0, equal_nan=True)
+    torch.testing.assert_allclose(ref_dv, tri_dv, atol=atol, rtol=0, equal_nan=True)
+    torch.testing.assert_allclose(ref_dk, tri_dk, atol=atol, rtol=0, equal_nan=True)
+    torch.testing.assert_allclose(ref_dq, tri_dq, atol=atol, rtol=0, equal_nan=True)
+
+
+try:
+    from flash_attn.flash_attn_interface import \
+        flash_attn_qkvpacked_func as flash_attn_func
+    HAS_FLASH = True
+except BaseException:
+    HAS_FLASH = False
+
+if is_corex():
+    TORCH_HAS_FP8 = False
+else:
+    TORCH_HAS_FP8 = hasattr(torch, 'float8_e5m2')
+# BATCH, N_HEADS, N_CTX, D_HEAD = 4, 48, 4096, 64
+BATCH, N_HEADS, N_CTX, D_HEAD = 1, 16, 4096, 128
+# vary seq length for fixed head and batch=4
+configs = []
+for mode in ["fwd", "bwd"]:
+    # for mode in ["fwd"]:
+    for causal in [True, False]:
+        if mode == "bwd" and not causal:
+            continue
+        configs.append(
+            triton.testing.Benchmark(
+                x_names=["N_CTX"],
+                x_vals=[2**i for i in range(12, 13)],
+                line_arg="provider",
+                line_vals=["triton"] + (["flash"] if HAS_FLASH else []),
+                line_names=["Triton"] + (["Flash-2"] if HAS_FLASH else []),
+                styles=[("red", "-"), ("blue", "-")],
+                ylabel="ms",
+                plot_name=f"fused-attention-batch{BATCH}-head{N_HEADS}-d{D_HEAD}-{mode}-causal={causal}",
+                args={
+                    "H": N_HEADS,
+                    "BATCH": BATCH,
+                    "D_HEAD": D_HEAD,
+                    "dtype": torch.float16,
+                    "mode": mode,
+                    "causal": causal,
+                },
+            ))
+
+
+@triton.testing.perf_report(configs)
+def bench_flash_attention(BATCH, H, N_CTX, D_HEAD, causal, mode, provider, dtype=torch.float16, device="cuda"):
+    assert mode in ["fwd", "bwd"]
+    warmup = 25
+    rep = 100
+    if provider == "triton":
+        q = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        k = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        if mode == "fwd" and TORCH_HAS_FP8:
+            q = q.to(torch.float8_e5m2)
+            k = k.to(torch.float8_e5m2)
+        v = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        sm_scale = 1.3
+        fn = lambda: attention(q, k, v, causal, sm_scale)
+        if mode == "bwd":
+            o = fn()
+            do = torch.randn_like(o)
+            fn = lambda: o.backward(do, retain_graph=True)
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    if provider == "flash":
+        qkv = torch.randn((BATCH, N_CTX, 3, H, D_HEAD), dtype=dtype, device=device, requires_grad=True)
+        fn = lambda: flash_attn_func(qkv, causal=causal)
+        if mode == "bwd":
+            o = fn()
+            do = torch.randn_like(o)
+            fn = lambda: o.backward(do, retain_graph=True)
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    flops_per_matmul = 2.0 * BATCH * H * N_CTX * N_CTX * D_HEAD
+    total_flops = 2 * flops_per_matmul
+    if causal:
+        total_flops *= 0.5
+    if mode == "bwd":
+        total_flops *= 2.5  # 2.0(bwd) + 0.5(recompute)
+    # return total_flops / ms * 1e-9
+    return ms
+
+
+# only works on post-Ampere GPUs right now
+# bench_flash_attention.run(save_path=".", print_data=True)
+
+if __name__ == "__main__":
+    # Z, H, N_CTX, D_HEAD, causal = 1, 1, 4096, 64, True
+    # test_op(Z, H, N_CTX, D_HEAD, causal, dtype=torch.float16)
+    bench_flash_attention.run(save_path=".", print_data=True)

--- a/third_party/iluvatar/python/tutorials/fused_attention/fused-attention_lib.py
+++ b/third_party/iluvatar/python/tutorials/fused_attention/fused-attention_lib.py
@@ -1,0 +1,437 @@
+"""
+Fused Attention
+===============
+
+This is a Triton implementation of the Flash Attention algorithm
+(see: Dao et al., https://arxiv.org/pdf/2205.14135v2.pdf; Rabe and Staats https://arxiv.org/pdf/2112.05682v2.pdf)
+
+lib version:
+1) Only implemented fwd, no bwd yet. (# TODO)
+"""
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _fwd_kernel(Q, K, V, sm_scale, L, M, Out, stride_qz, stride_qh, stride_qm, stride_qk, stride_kz, stride_kh,
+                stride_kn, stride_kk, stride_vz, stride_vh, stride_vk, stride_vn, stride_oz, stride_oh, stride_om,
+                stride_on, Z, H, N_CTX, BLOCK_M: tl.constexpr, BLOCK_SK: tl.constexpr, BLOCK_SN: tl.constexpr,
+                BLOCK_OK: tl.constexpr, BLOCK_ON: tl.constexpr, BLOCK_DMODEL: tl.constexpr):
+    sm_scale *= 1.44269504  # 1/log(2)
+    start_m = tl.program_id(0)
+    start_z = tl.program_id(1)
+    start_h = tl.program_id(2)
+
+    # initialize offsets
+    offs_zh = ((start_z * H) + start_h)
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_k = tl.arange(0, BLOCK_SK)
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    offs_n = tl.arange(0, BLOCK_SN)
+    off_q = offs_zh * stride_qh + offs_m[:, None] * stride_qm + offs_k[None, :] * stride_qk
+    off_k = offs_zh * stride_kh + offs_n[None, :] * stride_kn + offs_k[:, None] * stride_kk
+    off_v = offs_zh * stride_vh + offs_n[:, None] * stride_vk + offs_d[None, :] * stride_vn
+    # Initialize pointers to Q, K, V
+    q_ptrs = Q + off_q
+    k_ptrs = K + off_k
+    v_ptrs = V + off_v
+    # initialize pointer to m and l
+    m_prev = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_prev = tl.zeros([BLOCK_M], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+
+    # loop over k, v and update accumulator
+    for start_n in range(0, N_CTX, BLOCK_SN):
+
+        # 1st Gemm using tiling K = BLOCK_K
+        qk = tl.zeros([BLOCK_M, BLOCK_SN], dtype=tl.float32)
+        q_ptrs_loop = q_ptrs
+        k_ptrs_loop = k_ptrs
+        for start_k in range(0, BLOCK_DMODEL, BLOCK_SK):
+            # -- compute qk ----
+            q = tl.load(q_ptrs_loop)
+            k = tl.load(k_ptrs_loop)
+            qk += tl.dot(q, k)
+            q_ptrs_loop += BLOCK_SK * stride_qk
+            k_ptrs_loop += BLOCK_SK * stride_kk
+        # compute scaling constant
+        qk *= sm_scale
+        m_curr = tl.maximum(tl.max(qk, 1), m_prev)
+        alpha = tl.math.exp2(m_prev - m_curr)
+        p = tl.math.exp2(qk - m_curr[:, None])
+
+        # scale and update acc
+        acc *= alpha[:, None]
+        v = tl.load(v_ptrs)
+        acc += tl.dot(p.to(Q.dtype.element_ty), v)
+        # update m_prev and l_prev
+        l_prev = l_prev * alpha + tl.sum(p, 1)
+        m_prev = m_curr
+
+        # update pointers (k_ptrs is already contiguous)
+        k_ptrs += BLOCK_SN * stride_kn
+        v_ptrs += BLOCK_SN * stride_vk
+    # rematerialize offsets to save registers
+    start_m = tl.program_id(0)
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    # write back l and m
+    acc = acc / l_prev[:, None]
+    l_ptrs = L + offs_zh * N_CTX + offs_m
+    tl.store(l_ptrs, m_prev + tl.math.log2(l_prev))
+
+    offs_n = tl.arange(0, BLOCK_DMODEL)
+    off_o = offs_zh * stride_oh + offs_m[:, None] * stride_om + offs_n[None, :] * stride_on
+    out_ptrs = Out + off_o
+    tl.store(out_ptrs, acc)
+
+
+@triton.jit
+def _bwd_preprocess(
+    Out,
+    DO,
+    L,
+    NewDO,
+    Delta,
+    BLOCK_M: tl.constexpr,
+    D_HEAD: tl.constexpr,
+):
+    off_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    off_n = tl.arange(0, D_HEAD)
+    # load
+    o = tl.load(Out + off_m[:, None] * D_HEAD + off_n[None, :]).to(tl.float32)
+    do = tl.load(DO + off_m[:, None] * D_HEAD + off_n[None, :]).to(tl.float32)
+    denom = tl.load(L + off_m).to(tl.float32)
+    # compute
+    do = do / denom[:, None]
+    delta = tl.sum(o * do, axis=1)
+    # write-back
+    tl.store(NewDO + off_m[:, None] * D_HEAD + off_n[None, :], do)
+    tl.store(Delta + off_m, delta)
+
+
+@triton.jit
+def _bwd_kernel(
+    Q,
+    K,
+    V,
+    sm_scale,
+    Out,
+    DO,
+    DQ,
+    DK,
+    DV,
+    L,
+    M,
+    D,
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vk,
+    stride_vn,
+    Z,
+    H,
+    N_CTX,
+    num_block,
+    BLOCK_M: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    off_hz = tl.program_id(0)
+    off_z = off_hz // H
+    off_h = off_hz % H
+    # offset pointers for batch/head
+    Q += off_z * stride_qz + off_h * stride_qh
+    K += off_z * stride_qz + off_h * stride_qh
+    V += off_z * stride_qz + off_h * stride_qh
+    DO += off_z * stride_qz + off_h * stride_qh
+    DQ += off_z * stride_qz + off_h * stride_qh
+    DK += off_z * stride_qz + off_h * stride_qh
+    DV += off_z * stride_qz + off_h * stride_qh
+    for start_n in range(0, num_block):
+        lo = start_n * BLOCK_M
+        # initialize row/col offsets
+        offs_qm = lo + tl.arange(0, BLOCK_M)
+        offs_n = start_n * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_m = tl.arange(0, BLOCK_N)
+        offs_k = tl.arange(0, BLOCK_DMODEL)
+        # initialize pointers to value-like data
+        q_ptrs = Q + (offs_qm[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+        k_ptrs = K + (offs_n[:, None] * stride_kn + offs_k[None, :] * stride_kk)
+        v_ptrs = V + (offs_n[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+        do_ptrs = DO + (offs_qm[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+        dq_ptrs = DQ + (offs_qm[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+        # pointer to row-wise quantities in value-like data
+        D_ptrs = D + off_hz * N_CTX
+        m_ptrs = M + off_hz * N_CTX
+        # initialize dv amd dk
+        dv = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+        dk = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+        # k and v stay in SRAM throughout
+        k = tl.load(k_ptrs)
+        v = tl.load(v_ptrs)
+        # loop over rows
+        for start_m in range(lo, num_block * BLOCK_M, BLOCK_M):
+            offs_m_curr = start_m + offs_m
+            # load q, k, v, do on-chip
+            q = tl.load(q_ptrs)
+            # recompute p = softmax(qk, dim=-1).T
+            # NOTE: `do` is pre-divided by `l`; no normalization here
+            qk = tl.dot(q, tl.trans(k))
+            qk = tl.where(offs_m_curr[:, None] >= (offs_n[None, :]), qk, float("-inf"))
+            m = tl.load(m_ptrs + offs_m_curr)
+            p = tl.exp(qk * sm_scale - m[:, None])
+            # compute dv
+            do = tl.load(do_ptrs)
+            dv += tl.dot(tl.trans(p.to(Q.dtype.element_ty)), do)
+            # compute dp = dot(v, do)
+            Di = tl.load(D_ptrs + offs_m_curr)
+            dp = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32) - Di[:, None]
+            dp += tl.dot(do, tl.trans(v))
+            # compute ds = p * (dp - delta[:, None])
+            ds = p * dp * sm_scale
+            # compute dk = dot(ds.T, q)
+            dk += tl.dot(tl.trans(ds.to(Q.dtype.element_ty)), q)
+            # compute dq
+            dq = tl.load(dq_ptrs)
+            dq += tl.dot(ds.to(Q.dtype.element_ty), k)
+            tl.store(dq_ptrs, dq)
+            # increment pointers
+            dq_ptrs += BLOCK_M * stride_qm
+            q_ptrs += BLOCK_M * stride_qm
+            do_ptrs += BLOCK_M * stride_qm
+        # write-back
+        dv_ptrs = DV + (offs_n[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+        dk_ptrs = DK + (offs_n[:, None] * stride_kn + offs_k[None, :] * stride_kk)
+        tl.store(dv_ptrs, dv)
+        tl.store(dk_ptrs, dk)
+
+
+empty = torch.empty(128, device="cuda")
+
+
+class _attention(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, q, k, v, sm_scale):
+        BLOCK_M = 256
+        BLOCK_SK = 32
+        BLOCK_SN = 128
+        BLOCK_OK = 128
+        BLOCK_ON = 128
+
+        # shape constraints
+        Lq, Lk, Lv = q.shape[-1], k.shape[-1], v.shape[-1]
+        assert Lq == Lk and Lk == Lv
+        assert Lk in {16, 32, 64, 128}
+        o = torch.empty_like(q)
+        grid = (triton.cdiv(q.shape[2], BLOCK_M), q.shape[0], q.shape[1])
+        L = torch.empty((q.shape[0] * q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+        m = torch.empty((q.shape[0] * q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+        num_warps = 16
+
+        _fwd_kernel[grid](q, k, v, sm_scale, L, m, o, q.stride(0), q.stride(1), q.stride(2), q.stride(3), k.stride(0),
+                          k.stride(1), k.stride(2), k.stride(3), v.stride(0), v.stride(1), v.stride(2), v.stride(3),
+                          o.stride(0), o.stride(1), o.stride(2), o.stride(3), q.shape[0], q.shape[1], q.shape[2],
+                          BLOCK_M=BLOCK_M, BLOCK_SK=BLOCK_SK, BLOCK_SN=BLOCK_SN, BLOCK_OK=BLOCK_OK, BLOCK_ON=BLOCK_ON,
+                          BLOCK_DMODEL=Lk, num_warps=num_warps, num_stages=2, maxnreg=128)
+
+        ctx.save_for_backward(q, k, v, o, L, m)
+        ctx.grid = grid
+        ctx.sm_scale = sm_scale
+        ctx.BLOCK_DMODEL = Lk
+        return o
+
+    @staticmethod
+    def backward(ctx, do):
+        # TODO: Not optimized yet.
+        if torch.version.hip is not None:
+            BLOCK = 64
+        else:
+            BLOCK = 128
+        q, k, v, o, l, m = ctx.saved_tensors
+        do = do.contiguous()
+        dq = torch.zeros_like(q, dtype=torch.float32)
+        dk = torch.empty_like(k)
+        dv = torch.empty_like(v)
+        do_scaled = torch.empty_like(do)
+        delta = torch.empty_like(l)
+        _bwd_preprocess[(ctx.grid[0] * ctx.grid[1], )](
+            o,
+            do,
+            l,
+            do_scaled,
+            delta,
+            BLOCK_M=BLOCK,
+            D_HEAD=ctx.BLOCK_DMODEL,
+        )
+        _bwd_kernel[(ctx.grid[1], )](
+            q,
+            k,
+            v,
+            ctx.sm_scale,
+            o,
+            do_scaled,
+            dq,
+            dk,
+            dv,
+            l,
+            m,
+            delta,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            k.stride(0),
+            k.stride(1),
+            k.stride(2),
+            k.stride(3),
+            v.stride(0),
+            v.stride(1),
+            v.stride(2),
+            v.stride(3),
+            q.shape[0],
+            q.shape[1],
+            q.shape[2],
+            ctx.grid[0],
+            BLOCK_M=BLOCK,
+            BLOCK_N=BLOCK,
+            BLOCK_DMODEL=ctx.BLOCK_DMODEL,
+            num_warps=8,
+            num_stages=1,
+        )
+        # print(h.asm["ttgir"])
+        return dq, dk, dv, None
+
+
+attention = _attention.apply
+
+
+@pytest.mark.parametrize('Z, H, N_CTX, D_HEAD', [(4, 48, 1024, 64)])
+def test_op(Z, H, N_CTX, D_HEAD, dtype=torch.float16, causal=False, test_backward=True):
+    torch.manual_seed(20)
+    q = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0.1, std=0.2).requires_grad_()
+    k = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0.4, std=0.2).requires_grad_()
+    v = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0.3, std=0.2).requires_grad_()
+    sm_scale = 0.2
+    dout = torch.randn_like(q)
+    # reference implementation
+    p = torch.matmul(q, k.transpose(2, 3)) * sm_scale
+    if causal:
+        M = torch.tril(torch.ones((N_CTX, N_CTX), device="cuda"))
+        p[:, :, M == 0] = float("-inf")
+    p = torch.softmax(p.float(), dim=-1).half()
+    # p = torch.exp(p)
+    ref_out = torch.matmul(p, v)
+    if test_backward:
+        ref_out.backward(dout)
+        ref_dv, v.grad = v.grad.clone(), None
+        ref_dk, k.grad = k.grad.clone(), None
+        ref_dq, q.grad = q.grad.clone(), None
+    # triton implementation
+    tri_out = attention(q, k, v, sm_scale)
+    # print(ref_out)
+    # print(tri_out)
+    if test_backward:
+        tri_out.backward(dout)
+        tri_dv, v.grad = v.grad.clone(), None
+        tri_dk, k.grad = k.grad.clone(), None
+        tri_dq, q.grad = q.grad.clone(), None
+
+    print("= " * 30)
+    print("CHECK RESULTS: TORCH vs TRITON")
+    print("o max diff = ", (ref_out - tri_out).to(torch.float32).abs().max())
+    if test_backward:
+        print("dv max diff = ", (ref_dv - tri_dv).to(torch.float32).abs().max())
+        print("dk max diff = ", (ref_dk - tri_dk).to(torch.float32).abs().max())
+        print("dq max diff = ", (ref_dq - tri_dq).to(torch.float32).abs().max())
+    print("= " * 30)
+
+    atol = 1e-2
+    torch.testing.assert_allclose(ref_out, tri_out, atol=atol, rtol=0, equal_nan=True)
+    if test_backward:
+        torch.testing.assert_allclose(ref_dv, tri_dv, atol=atol, rtol=0, equal_nan=True)
+        torch.testing.assert_allclose(ref_dk, tri_dk, atol=atol, rtol=0, equal_nan=True)
+        torch.testing.assert_allclose(ref_dq, tri_dq, atol=atol, rtol=0, equal_nan=True)
+
+
+try:
+    from flash_attn.flash_attn_interface import flash_attn_qkvpacked_func as flash_attn_func
+    FLASH_VER = 2
+except BaseException:
+    try:
+        from flash_attn.flash_attn_interface import flash_attn_func
+        FLASH_VER = 1
+    except BaseException:
+        FLASH_VER = None
+HAS_FLASH = FLASH_VER is not None
+
+# BATCH, N_HEADS, N_CTX, D_HEAD = 4, 48, 4096, 64
+BATCH, N_HEADS, N_CTX, D_HEAD = 1, 64, 4096, 128
+# vary seq length for fixed head and batch=4
+configs = [
+    triton.testing.Benchmark(
+        x_names=['N_CTX'], x_vals=[2**i for i in range(10, 14)], line_arg='provider',
+        line_vals=['triton'] + (['flash'] if HAS_FLASH else []),
+        line_names=['Triton'] + ([f'Flash-{FLASH_VER}'] if HAS_FLASH else []), styles=[('red', '-'), ('blue', '-')],
+        ylabel='ms', plot_name=f'fused-attention-batch{BATCH}-head{N_HEADS}-d{D_HEAD}-{mode}',
+        args={'H': N_HEADS, 'BATCH': BATCH, 'D_HEAD': D_HEAD, 'dtype': torch.float16, 'mode': mode}) for mode in [
+            'fwd',
+        ]
+]
+
+
+@triton.testing.perf_report(configs)
+def bench_flash_attention(BATCH, H, N_CTX, D_HEAD, mode, provider, dtype=torch.float16, device="cuda"):
+    assert mode in ['fwd', 'bwd']
+    warmup = 1000
+    rep = 1000
+    sm_scale = 1.3
+    if provider == "triton":
+        q = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        k = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        v = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        fn = lambda: attention(q, k, v, sm_scale)
+        if mode == 'bwd':
+            o = fn()
+            do = torch.randn_like(o)
+            fn = lambda: o.backward(do, retain_graph=True)
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    if provider == "flash":
+        qkv = torch.randn((BATCH, N_CTX, 3, H, D_HEAD), dtype=dtype, device=device, requires_grad=True)
+        if FLASH_VER == 1:
+            lengths = torch.full((BATCH, ), fill_value=N_CTX, device=device)
+            cu_seqlens = torch.zeros((BATCH + 1, ), device=device, dtype=torch.int32)
+            cu_seqlens[1:] = lengths.cumsum(0)
+            qkv = qkv.reshape(BATCH * N_CTX, 3, H, D_HEAD)
+            fn = lambda: flash_attn_func(qkv, cu_seqlens, 0., N_CTX, causal=False)
+        elif FLASH_VER == 2:
+            fn = lambda: flash_attn_func(qkv, softmax_scale=sm_scale, causal=False)
+        else:
+            raise ValueError(f'unknown {FLASH_VER = }')
+        if mode == 'bwd':
+            o = fn()
+            do = torch.randn_like(o)
+            fn = lambda: o.backward(do, retain_graph=True)
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    total_flops = 2. * BATCH * H * N_CTX * N_CTX * D_HEAD
+    if mode == 'bwd':
+        total_flops *= 2.5  # 2.0(bwd) + 0.5(recompute)
+    # return total_flops / ms * 1e-9
+    return ms
+
+
+if __name__ == "__main__":
+    Z, H, N_CTX, D_HEAD = 1, 1, 4096, 128
+    test_op(Z, H, N_CTX, D_HEAD, dtype=torch.float16, causal=False, test_backward=False)
+    bench_flash_attention.run(save_path='.', print_data=True)

--- a/third_party/iluvatar/python/tutorials/performance_test/01-vector-add.py
+++ b/third_party/iluvatar/python/tutorials/performance_test/01-vector-add.py
@@ -1,0 +1,133 @@
+"""
+Vector Addition
+===============
+
+In this tutorial, you will write a simple vector addition using Triton.
+
+In doing so, you will learn about:
+
+* The basic programming model of Triton.
+
+* The `triton.jit` decorator, which is used to define Triton kernels.
+
+* The best practices for validating and benchmarking your custom ops against native reference implementations.
+
+"""
+
+# %%
+# Compute Kernel
+# --------------
+
+import torch
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def add_kernel(x_ptr,  # *Pointer* to first input vector.
+               y_ptr,  # *Pointer* to second input vector.
+               output_ptr,  # *Pointer* to output vector.
+               n_elements,  # Size of the vector.
+               BLOCK_SIZE: tl.constexpr,  # Number of elements each program should process.
+               # NOTE: `constexpr` so it can be used as a shape value.
+               ):
+    # There are multiple 'programs' processing different data. We identify which program
+    # we are here:
+    pid = tl.program_id(axis=0)  # We use a 1D launch grid so axis is 0.
+    # This program will process inputs that are offset from the initial data.
+    # For instance, if you had a vector of length 256 and block_size of 64, the programs
+    # would each access the elements [0:64, 64:128, 128:192, 192:256].
+    # Note that offsets is a list of pointers:
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    # Create a mask to guard memory operations against out-of-bounds accesses.
+    mask = offsets < n_elements
+    # Load x and y from DRAM, masking out any extra elements in case the input is not a
+    # multiple of the block size.
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    output = x + y
+    # Write x + y back to DRAM.
+    tl.store(output_ptr + offsets, output, mask=mask)
+
+
+# %%
+# Let's also declare a helper function to (1) allocate the `z` tensor
+# and (2) enqueue the above kernel with appropriate grid/block sizes:
+
+
+def add(x: torch.Tensor, y: torch.Tensor):
+    # We need to preallocate the output.
+    output = torch.empty_like(x)
+    assert x.is_cuda and y.is_cuda and output.is_cuda
+    n_elements = output.numel()
+    # The SPMD launch grid denotes the number of kernel instances that run in parallel.
+    # It is analogous to CUDA launch grids. It can be either Tuple[int], or Callable(metaparameters) -> Tuple[int].
+    # In this case, we use a 1D grid where the size is the number of blocks:
+    grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']), )
+    # NOTE:
+    #  - Each torch.tensor object is implicitly converted into a pointer to its first element.
+    #  - `triton.jit`'ed functions can be indexed with a launch grid to obtain a callable GPU kernel.
+    #  - Don't forget to pass meta-parameters as keywords arguments.
+    add_kernel[grid](x, y, output, n_elements, BLOCK_SIZE=1024)
+    # We return a handle to z but, since `torch.cuda.synchronize()` hasn't been called, the kernel is still
+    # running asynchronously at this point.
+    return output
+
+
+# %%
+# We can now use the above function to compute the element-wise sum of two `torch.tensor` objects and test its correctness:
+
+torch.manual_seed(0)
+size = 98432
+x = torch.rand(size, device='cuda')
+y = torch.rand(size, device='cuda')
+output_torch = x + y
+output_triton = add(x, y)
+print(output_torch)
+print(output_triton)
+print(f'The maximum difference between torch and triton is '
+      f'{torch.max(torch.abs(output_torch - output_triton))}')
+
+# %%
+# Seems like we're good to go!
+
+# %%
+# Benchmark
+# ---------
+#
+# We can now benchmark our custom op on vectors of increasing sizes to get a sense of how it does relative to PyTorch.
+# To make things easier, Triton has a set of built-in utilities that allow us to concisely plot the performance of our custom ops.
+# for different problem sizes.
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=['size'],  # Argument names to use as an x-axis for the plot.
+        x_vals=[2**i for i in range(12, 28, 1)],  # Different possible values for `x_name`.
+        x_log=True,  # x axis is logarithmic.
+        line_arg='provider',  # Argument name whose value corresponds to a different line in the plot.
+        line_vals=['triton', 'torch'],  # Possible values for `line_arg`.
+        line_names=['Triton', 'Torch'],  # Label name for the lines.
+        styles=[('blue', '-'), ('green', '-')],  # Line styles.
+        ylabel='GB/s',  # Label name for the y-axis.
+        plot_name='vector-add-performance',  # Name for the plot. Used also as a file name for saving the plot.
+        args={},  # Values for function arguments not in `x_names` and `y_name`.
+    ))
+def benchmark(size, provider):
+    x = torch.rand(size, device='cuda', dtype=torch.float32)
+    y = torch.rand(size, device='cuda', dtype=torch.float32)
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == 'torch':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: x + y, quantiles=quantiles)
+    if provider == 'triton':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: add(x, y), quantiles=quantiles)
+    gbps = lambda ms: 12 * size / ms * 1e-6
+    return gbps(ms), gbps(max_ms), gbps(min_ms)
+
+
+# %%
+# We can now run the decorated function above. Pass `print_data=True` to see the performance number, `show_plots=True` to plot them, and/or
+# `save_path='/path/to/results/' to save them to disk along with raw CSV data:
+benchmark.run(print_data=True, show_plots=True, save_path='.')

--- a/third_party/iluvatar/python/tutorials/performance_test/02-fused-softmax.py
+++ b/third_party/iluvatar/python/tutorials/performance_test/02-fused-softmax.py
@@ -1,0 +1,208 @@
+"""
+Fused Softmax
+=============
+
+In this tutorial, you will write a fused softmax operation that is significantly faster
+than PyTorch's native op for a particular class of matrices: those whose rows can fit in
+the GPU's SRAM.
+
+In doing so, you will learn about:
+
+* The benefits of kernel fusion for bandwidth-bound operations.
+
+* Reduction operators in Triton.
+
+"""
+
+# %%
+# Motivations
+# -----------
+#
+# Custom GPU kernels for elementwise additions are educationally valuable but won't get you very far in practice.
+# Let us consider instead the case of a simple (numerically stabilized) softmax operation:
+
+import torch
+
+import triton
+import triton.language as tl
+from triton.common.build import is_corex
+
+
+@torch.jit.script
+def naive_softmax(x):
+    """Compute row-wise softmax of X using native pytorch
+
+    We subtract the maximum element in order to avoid overflows. Softmax is invariant to
+    this shift.
+    """
+    # read  MN elements ; write M  elements
+    x_max = x.max(dim=1)[0]
+    # read MN + M elements ; write MN elements
+    z = x - x_max[:, None]
+    # read  MN elements ; write MN elements
+    numerator = torch.exp(z)
+    # read  MN elements ; write M  elements
+    denominator = numerator.sum(dim=1)
+    # read MN + M elements ; write MN elements
+    ret = numerator / denominator[:, None]
+    # in total: read 5MN + 2M elements ; wrote 3MN + 2M elements
+    return ret
+
+
+# %%
+# When implemented naively in PyTorch, computing :code:`y = naive_softmax(x)` for :math:`x \in R^{M \times N}`
+# requires reading :math:`5MN + 2M` elements from DRAM and writing back :math:`3MN + 2M` elements.
+# This is obviously wasteful; we'd prefer to have a custom "fused" kernel that only reads
+# X once and does all the necessary computations on-chip.
+# Doing so would require reading and writing back only :math:`MN` bytes, so we could
+# expect a theoretical speed-up of ~4x (i.e., :math:`(8MN + 4M) / 2MN`).
+# The `torch.jit.script` flags aims to perform this kind of "kernel fusion" automatically
+# but, as we will see later, it is still far from ideal.
+
+# %%
+# Compute Kernel
+# --------------
+#
+# Our softmax kernel works as follows: each program loads a row of the input matrix X,
+# normalizes it and writes back the result to the output Y.
+#
+# Note that one important limitation of Triton is that each block must have a
+# power-of-two number of elements, so we need to internally "pad" each row and guard the
+# memory operations properly if we want to handle any possible input shapes:
+
+
+@triton.jit
+def softmax_kernel(output_ptr, input_ptr, input_row_stride, output_row_stride, n_cols, BLOCK_SIZE: tl.constexpr):
+    # The rows of the softmax are independent, so we parallelize across those
+    row_idx = tl.program_id(0)
+    # The stride represents how much we need to increase the pointer to advance 1 row
+    row_start_ptr = input_ptr + row_idx * input_row_stride
+    # The block size is the next power of two greater than n_cols, so we can fit each
+    # row in a single block
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    input_ptrs = row_start_ptr + col_offsets
+    # Load the row into SRAM, using a mask since BLOCK_SIZE may be > than n_cols
+    row = tl.load(input_ptrs, mask=col_offsets < n_cols, other=-float('inf'))
+    # Subtract maximum for numerical stability
+    row_minus_max = row - tl.max(row, axis=0)
+    # Note that exponentiation in Triton is fast but approximate (i.e., think __expf in CUDA)
+    numerator = tl.exp(row_minus_max)
+    denominator = tl.sum(numerator, axis=0)
+    softmax_output = numerator / denominator
+    # Write back output to DRAM
+    output_row_start_ptr = output_ptr + row_idx * output_row_stride
+    output_ptrs = output_row_start_ptr + col_offsets
+    tl.store(output_ptrs, softmax_output, mask=col_offsets < n_cols)
+
+
+# %%
+# We can create a helper function that enqueues the kernel and its (meta-)arguments for any given input tensor.
+
+
+def softmax(x):
+    n_rows, n_cols = x.shape
+    # The block size is the smallest power of two greater than the number of columns in `x`
+    BLOCK_SIZE = triton.next_power_of_2(n_cols)
+    # Another trick we can use is to ask the compiler to use more threads per row by
+    # increasing the number of warps (`num_warps`) over which each row is distributed.
+    # You will see in the next tutorial how to auto-tune this value in a more natural
+    # way so you don't have to come up with manual heuristics yourself.
+    # change the num_warps when testing on Iluvatar device
+    if is_corex():
+        num_warps = 1
+        if BLOCK_SIZE >= 2048:
+            num_warps = 2
+        if BLOCK_SIZE >= 4096:
+            num_warps = 4
+        if BLOCK_SIZE >= 8192:
+            num_warps = 8
+    else:
+        num_warps = 2
+        if BLOCK_SIZE >= 2048:
+            num_warps = 4
+        if BLOCK_SIZE >= 4096:
+            num_warps = 8
+    # Allocate output
+    y = torch.empty_like(x)
+    # Enqueue kernel. The 1D launch grid is simple: we have one kernel instance per row o
+    # f the input matrix
+    softmax_kernel[(n_rows, )](
+        y,
+        x,
+        x.stride(0),
+        y.stride(0),
+        n_cols,
+        num_warps=num_warps,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return y
+
+
+# %%
+# Unit Test
+# ---------
+
+# %%
+# We make sure that we test our kernel on a matrix with an irregular number of rows and columns.
+# This will allow us to verify that our padding mechanism works.
+
+torch.manual_seed(0)
+x = torch.randn(1823, 781, device='cuda')
+y_triton = softmax(x)
+y_torch = torch.softmax(x, axis=1)
+assert torch.allclose(y_triton, y_torch), (y_triton, y_torch)
+
+# %%
+# As expected, the results are identical.
+
+# %%
+# Benchmark
+# ---------
+#
+# Here we will benchmark our operation as a function of the number of columns in the input matrix -- assuming 4096 rows.
+# We will then compare its performance against (1) :code:`torch.softmax` and (2) the :code:`naive_softmax` defined above.
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=['N'],  # argument names to use as an x-axis for the plot
+        x_vals=[128 * i for i in range(2, 100)],  # different possible values for `x_name`
+        line_arg='provider',  # argument name whose value corresponds to a different line in the plot
+        line_vals=[
+            'triton',
+            'torch-native',
+            'torch-jit',
+        ],  # possible values for `line_arg``
+        line_names=[
+            "Triton",
+            "Torch (native)",
+            "Torch (jit)",
+        ],  # label name for the lines
+        styles=[('blue', '-'), ('green', '-'), ('green', '--')],  # line styles
+        ylabel="GB/s",  # label name for the y-axis
+        plot_name="softmax-performance",  # name for the plot. Used also as a file name for saving the plot.
+        args={'M': 4096},  # values for function arguments not in `x_names` and `y_name`
+    ))
+def benchmark(M, N, provider):
+    x = torch.randn(M, N, device='cuda', dtype=torch.float32)
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == 'torch-native':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.softmax(x, axis=-1), quantiles=quantiles)
+    if provider == 'triton':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: softmax(x), quantiles=quantiles)
+    if provider == 'torch-jit':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: naive_softmax(x), quantiles=quantiles)
+    gbps = lambda ms: 2 * x.nelement() * x.element_size() * 1e-9 / (ms * 1e-3)
+    return gbps(ms), gbps(max_ms), gbps(min_ms)
+
+
+import pandas as pd
+
+pd.set_option('display.max_rows', 500)
+benchmark.run(show_plots=True, print_data=True, save_path='.')
+
+# %%
+# In the above plot, we can see that:
+#  - Triton is 4x faster than the Torch JIT. This confirms our suspicions that the Torch JIT does not do any fusion here.
+#  - Triton is noticeably faster than :code:`torch.softmax` -- in addition to being **easier to read, understand and maintain**.
+#    Note however that the PyTorch `softmax` operation is more general and will work on tensors of any shape.

--- a/third_party/iluvatar/python/tutorials/performance_test/03-matrix-multiplication-autotune.py
+++ b/third_party/iluvatar/python/tutorials/performance_test/03-matrix-multiplication-autotune.py
@@ -1,0 +1,113 @@
+import os
+
+import triton
+import torch
+from triton.ops import matmul as triton_mm
+from triton.ops import bmm as triton_bmm
+from utils import PERF_MM_SHAPES, PERF_BMM_SHAPES, IXBLAS_SHAPES_FP32, IXBLAS_SHAPES_FP16
+
+DTYPE = torch.float16
+TRITON_PERF_WITH_FULL_MODE = (os.getenv("TRITON_PERF_WITH_FULL_MODE", default='0') == '1')
+
+print(f"==================== 1. square shapes matmul performance ====================")
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=['M', 'N', 'K'],  # Argument names to use as an x-axis for the plot
+        x_vals=[128 * i for i in range(2, 33)],  # Different possible values for `x_name`
+        line_arg='provider',  # Argument name whose value corresponds to a different line in the plot
+        # Possible values for `line_arg`
+        line_vals=['ixblas', 'triton'],
+        # Label name for the lines
+        line_names=["ixBLAS", "Triton"],
+        # Line styles
+        styles=[('green', '-'), ('blue', '-')],
+        ylabel="TFLOPS",  # Label name for the y-axis
+        plot_name="square-shapes-matmul-performance",  # Name for the plot, used also as a file name for saving the plot.
+        args={},
+    ))
+def benchmark_square_shapes_mm_fp16(M, N, K, provider):
+    a = torch.randn((M, K), device='cuda', dtype=DTYPE)
+    b = torch.randn((K, N), device='cuda', dtype=DTYPE)
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == 'ixblas':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), quantiles=quantiles)
+    if provider == 'triton':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: triton_mm(a, b), quantiles=quantiles)
+    perf = lambda ms: 2 * M * N * K * 1e-12 / (ms * 1e-3)
+    return perf(ms), perf(max_ms), perf(min_ms)
+
+
+benchmark_square_shapes_mm_fp16.run(show_plots=True, print_data=True, save_path='.')
+
+print(f"==================== 2. model shapes matmul performance ====================")
+MODEL_SHAPES = sorted(set(PERF_MM_SHAPES + IXBLAS_SHAPES_FP16))
+if not TRITON_PERF_WITH_FULL_MODE:
+    import random
+    random.seed(123)
+    perf_nums = 20
+    random_numbers = random.sample(range(0, len(MODEL_SHAPES)), perf_nums)
+    MODEL_SHAPES = sorted([MODEL_SHAPES[idx] for idx in random_numbers])
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=['M', 'N', 'K'],  # Argument names to use as an x-axis for the plot
+        x_vals=[(m, n, k) for m, n, k in MODEL_SHAPES],  # Different possible values for `x_name`
+        line_arg='provider',  # Argument name whose value corresponds to a different line in the plot
+        # Possible values for `line_arg`
+        line_vals=['ixblas', 'triton'],
+        # Label name for the lines
+        line_names=["ixBLAS", "Triton"],
+        # Line styles
+        styles=[('green', '-'), ('blue', '-')],
+        ylabel="TFLOPS",  # Label name for the y-axis
+        plot_name="model-shapes-matmul-performance",  # Name for the plot, used also as a file name for saving the plot.
+        args={},
+    ))
+def benchmark_model_shapes_mm_fp16(M, N, K, provider):
+    a = torch.randn((M, K), device='cuda', dtype=DTYPE)
+    b = torch.randn((K, N), device='cuda', dtype=DTYPE)
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == 'ixblas':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), quantiles=quantiles)
+    if provider == 'triton':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: triton_mm(a, b), quantiles=quantiles)
+    perf = lambda ms: 2 * M * N * K * 1e-12 / (ms * 1e-3)
+    return perf(ms), perf(max_ms), perf(min_ms)
+
+
+benchmark_model_shapes_mm_fp16.run(show_plots=True, print_data=True, save_path='.')
+
+print(f"==================== 3. model shapes bmm performance ====================")
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=['B', 'M', 'N', 'K'],  # Argument names to use as an x-axis for the plot
+        x_vals=[(b, m, n, k) for b, m, n, k in sorted(set(PERF_BMM_SHAPES))],  # Different possible values for `x_name`
+        line_arg='provider',  # Argument name whose value corresponds to a different line in the plot
+        # Possible values for `line_arg`
+        line_vals=['ixblas', 'triton'],
+        # Label name for the lines
+        line_names=["ixBLAS", "Triton"],
+        # Line styles
+        styles=[('green', '-'), ('blue', '-')],
+        ylabel="TFLOPS",  # Label name for the y-axis
+        plot_name="model-shapes-bmm-performance",  # Name for the plot, used also as a file name for saving the plot.
+        args={},
+    ))
+def benchmark_model_shapes_bmm_fp16(B, M, N, K, provider):
+    a = torch.randn((B, M, K), device='cuda', dtype=DTYPE)
+    b = torch.randn((B, K, N), device='cuda', dtype=DTYPE)
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == 'ixblas':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.bmm(a, b), quantiles=quantiles)
+    if provider == 'triton':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: triton_bmm(a, b), quantiles=quantiles)
+    perf = lambda ms: 2 * M * N * K * B * 1e-12 / (ms * 1e-3)
+    return perf(ms), perf(max_ms), perf(min_ms)
+
+
+benchmark_model_shapes_bmm_fp16.run(show_plots=True, print_data=True, save_path='.')

--- a/third_party/iluvatar/python/tutorials/performance_test/05-layer-norm-autotune.py
+++ b/third_party/iluvatar/python/tutorials/performance_test/05-layer-norm-autotune.py
@@ -1,0 +1,342 @@
+"""
+Layer Normalization
+====================
+In this tutorial, you will write a high-performance layer normalization
+kernel that runs faster than the PyTorch implementation.
+
+In doing so, you will learn about:
+
+* Implementing backward pass in Triton.
+
+* Implementing parallel reduction in Triton.
+
+"""
+
+# %%
+# Motivations
+# -----------
+#
+# The *LayerNorm* operator was first introduced in [BA2016]_ as a way to improve the performance
+# of sequential models (e.g., Transformers) or neural networks with small batch size.
+# It takes a vector :math:`x` as input and produces a vector :math:`y` of the same shape as output.
+# The normalization is performed by subtracting the mean and dividing by the standard deviation of :math:`x`.
+# After the normalization, a learnable linear transformation with weights :math:`w` and biases :math:`b` is applied.
+# The forward pass can be expressed as follows:
+#
+# .. math::
+#    y = \frac{ x - \text{E}[x] }{ \sqrt{\text{Var}(x) + \epsilon} } * w + b
+#
+# where :math:`\epsilon` is a small constant added to the denominator for numerical stability.
+# Let’s first take a look at the forward pass implementation.
+
+import torch
+
+import triton
+import triton.language as tl
+from triton.common.build import is_corex
+
+try:
+    # This is https://github.com/NVIDIA/apex, NOT the apex on PyPi, so it
+    # should not be added to extras_require in setup.py.
+    import apex
+    HAS_APEX = True
+except ModuleNotFoundError:
+    HAS_APEX = False
+
+
+def simple_configs():
+    configs = []
+    BLOCK_SIZES = [128, 256, 512, 1024, 2048, 4096, 8192]
+    warps = warps = [1, 2, 4, 8, 16, 32]
+    for bs in BLOCK_SIZES:
+        for w in warps:
+            config = triton.Config({"BLOCK_SIZE": bs}, num_warps=w, num_stages=1)
+            configs.append(config)
+    return configs
+
+
+configs = simple_configs()
+
+
+@triton.autotune(configs=configs, key=['N'])
+@triton.jit
+def _layer_norm_fwd_fused(
+    X,  # pointer to the input
+    Y,  # pointer to the output
+    W,  # pointer to the weights
+    B,  # pointer to the biases
+    Mean,  # pointer to the mean
+    Rstd,  # pointer to the 1/std
+    stride,  # how much to increase the pointer when moving by 1 row
+    N,  # number of columns in X
+    eps,  # epsilon to avoid division by zero
+    BLOCK_SIZE: tl.constexpr,
+):
+    # Map the program id to the row of X and Y it should compute.
+    row = tl.program_id(0)
+    Y += row * stride
+    X += row * stride
+    # Compute mean
+    mean = 0
+    _mean = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+    # let idle threads do at least x times add
+    for off in range(0, N, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        a = tl.load(X + cols, mask=cols < N, other=0.).to(tl.float32)
+        _mean += a
+    mean = tl.sum(_mean, axis=0) / N
+    # Compute variance
+    _var = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+    for off in range(0, N, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        x = tl.load(X + cols, mask=cols < N, other=0.).to(tl.float32)
+        x = tl.where(cols < N, x - mean, 0.)
+        _var += x * x
+    var = tl.sum(_var, axis=0) / N
+    rstd = 1 / tl.sqrt(var + eps)
+    # Write mean / rstd
+    tl.store(Mean + row, mean)
+    tl.store(Rstd + row, rstd)
+    # Normalize and apply linear transformation
+    for off in range(0, N, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < N
+        w = tl.load(W + cols, mask=mask)
+        b = tl.load(B + cols, mask=mask)
+        x = tl.load(X + cols, mask=mask, other=0.).to(tl.float32)
+        x_hat = (x - mean) * rstd
+        y = x_hat * w + b
+        # Write output
+        tl.store(Y + cols, y, mask=mask)
+
+
+# %%
+# Backward pass
+# -------------
+#
+# The backward pass for the layer normalization operator is a bit more involved than the forward pass.
+# Let :math:`\hat{x}` be the normalized inputs :math:`\frac{ x - \text{E}[x] }{ \sqrt{\text{Var}(x) + \epsilon} }` before the linear transformation,
+# the Vector-Jacobian Products (VJP) :math:`\nabla_{x}` of :math:`x` are given by:
+#
+# .. math::
+#    \nabla_{x} = \frac{1}{\sigma}\Big( \nabla_{y} \odot w - \underbrace{ \big( \frac{1}{N} \hat{x} \cdot (\nabla_{y} \odot w) \big) }_{c_1} \odot \hat{x} - \underbrace{ \frac{1}{N} \nabla_{y} \cdot w }_{c_2} \Big)
+#
+# where :math:`\odot` denotes the element-wise multiplication, :math:`\cdot` denotes the dot product, and :math:`\sigma` is the standard deviation.
+# :math:`c_1` and :math:`c_2` are intermediate constants that improve the readability of the following implementation.
+#
+# For the weights :math:`w` and biases :math:`b`, the VJPs :math:`\nabla_{w}` and :math:`\nabla_{b}` are more straightforward:
+#
+# .. math::
+#    \nabla_{w} = \nabla_{y} \odot \hat{x} \quad \text{and} \quad \nabla_{b} = \nabla_{y}
+#
+# Since the same weights :math:`w` and biases :math:`b` are used for all rows in the same batch, their gradients need to sum up.
+# To perform this step efficiently, we use a parallel reduction strategy: each kernel instance accumulates
+# partial :math:`\nabla_{w}` and :math:`\nabla_{b}` across certain rows into one of :math:`\text{GROUP_SIZE_M}` independent buffers.
+# These buffers stay in the L2 cache and then are further reduced by another function to compute the actual :math:`\nabla_{w}` and :math:`\nabla_{b}`.
+#
+# Let the number of input rows :math:`M = 4` and :math:`\text{GROUP_SIZE_M} = 2`,
+# here's a diagram of the parallel reduction strategy for :math:`\nabla_{w}` (:math:`\nabla_{b}` is omitted for brevity):
+#
+#   .. image:: parallel_reduction.png
+#
+# In Stage 1, the rows of X that have the same color share the same buffer and thus a lock is used to ensure that only one kernel instance writes to the buffer at a time.
+# In Stage 2, the buffers are further reduced to compute the final :math:`\nabla_{w}` and :math:`\nabla_{b}`.
+# In the following implementation, Stage 1 is implemented by the function :code:`_layer_norm_bwd_dx_fused` and Stage 2 is implemented by the function :code:`_layer_norm_bwd_dwdb`.
+
+
+@triton.jit
+def _layer_norm_bwd_dx_fused(DX,  # pointer to the input gradient
+                             DY,  # pointer to the output gradient
+                             DW,  # pointer to the partial sum of weights gradient
+                             DB,  # pointer to the partial sum of biases gradient
+                             X,  # pointer to the input
+                             W,  # pointer to the weights
+                             B,  # pointer to the biases
+                             Mean,  # pointer to the mean
+                             Rstd,  # pointer to the 1/std
+                             Lock,  # pointer to the lock
+                             stride,  # how much to increase the pointer when moving by 1 row
+                             N,  # number of columns in X
+                             eps,  # epsilon to avoid division by zero
+                             GROUP_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr):
+    # Map the program id to the elements of X, DX, and DY it should compute.
+    row = tl.program_id(0)
+    cols = tl.arange(0, BLOCK_SIZE_N)
+    mask = cols < N
+    X += row * stride
+    DY += row * stride
+    DX += row * stride
+    # Offset locks and weights/biases gradient pointer for parallel reduction
+    lock_id = row % GROUP_SIZE_M
+    Lock += lock_id
+    Count = Lock + GROUP_SIZE_M
+    DW = DW + lock_id * N + cols
+    DB = DB + lock_id * N + cols
+    # Load data to SRAM
+    x = tl.load(X + cols, mask=mask, other=0).to(tl.float32)
+    dy = tl.load(DY + cols, mask=mask, other=0).to(tl.float32)
+    w = tl.load(W + cols, mask=mask).to(tl.float32)
+    mean = tl.load(Mean + row)
+    rstd = tl.load(Rstd + row)
+    # Compute dx
+    xhat = (x - mean) * rstd
+    wdy = w * dy
+    xhat = tl.where(mask, xhat, 0.)
+    wdy = tl.where(mask, wdy, 0.)
+    c1 = tl.sum(xhat * wdy, axis=0) / N
+    c2 = tl.sum(wdy, axis=0) / N
+    dx = (wdy - (xhat * c1 + c2)) * rstd
+    # Write dx
+    tl.store(DX + cols, dx, mask=mask)
+    # Accumulate partial sums for dw/db
+    partial_dw = (dy * xhat).to(w.dtype)
+    partial_db = (dy).to(w.dtype)
+    while tl.atomic_cas(Lock, 0, 1) == 1:
+        pass
+    count = tl.load(Count)
+    # First store doesn't accumulate
+    if count == 0:
+        tl.atomic_xchg(Count, 1)
+    else:
+        partial_dw += tl.load(DW, mask=mask)
+        partial_db += tl.load(DB, mask=mask)
+    tl.store(DW, partial_dw, mask=mask)
+    tl.store(DB, partial_db, mask=mask)
+    # Release the lock
+    tl.atomic_xchg(Lock, 0)
+
+
+@triton.jit
+def _layer_norm_bwd_dwdb(DW,  # pointer to the partial sum of weights gradient
+                         DB,  # pointer to the partial sum of biases gradient
+                         FINAL_DW,  # pointer to the weights gradient
+                         FINAL_DB,  # pointer to the biases gradient
+                         M,  # GROUP_SIZE_M
+                         N,  # number of columns
+                         BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr):
+    # Map the program id to the elements of DW and DB it should compute.
+    pid = tl.program_id(0)
+    cols = pid * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    dw = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    db = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    # Iterate through the rows of DW and DB to sum the partial sums.
+    for i in range(0, M, BLOCK_SIZE_M):
+        rows = i + tl.arange(0, BLOCK_SIZE_M)
+        mask = (rows[:, None] < M) & (cols[None, :] < N)
+        offs = rows[:, None] * N + cols[None, :]
+        dw += tl.load(DW + offs, mask=mask, other=0.)
+        db += tl.load(DB + offs, mask=mask, other=0.)
+    # Write the final sum to the output.
+    sum_dw = tl.sum(dw, axis=0)
+    sum_db = tl.sum(db, axis=0)
+    tl.store(FINAL_DW + cols, sum_dw, mask=cols < N)
+    tl.store(FINAL_DB + cols, sum_db, mask=cols < N)
+
+
+# %%
+# Benchmark
+# ---------
+#
+# We can now compare the performance of our kernel against that of PyTorch.
+# Here we focus on inputs that have Less than 64KB per feature.
+# Specifically, one can set :code:`'mode': 'backward'` to benchmark the backward pass.
+
+
+class LayerNorm(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, x, normalized_shape, weight, bias, eps):
+        # allocate output
+        y = torch.empty_like(x)
+        # reshape input data into 2D tensor
+        x_arg = x.reshape(-1, x.shape[-1])
+        M, N = x_arg.shape
+        mean = torch.empty((M, ), dtype=torch.float32, device='cuda')
+        rstd = torch.empty((M, ), dtype=torch.float32, device='cuda')
+        # enqueue kernel
+        _layer_norm_fwd_fused[(M, )](x_arg, y, weight, bias, mean, rstd, x_arg.stride(0), N, eps)
+        # print("best config when n = ", N, _layer_norm_fwd_fused.best_config)
+        ctx.save_for_backward(x, weight, bias, mean, rstd)
+        ctx.BLOCK_SIZE = _layer_norm_fwd_fused.best_config.kwargs['BLOCK_SIZE']
+        ctx.num_warps = _layer_norm_fwd_fused.best_config.num_warps
+        ctx.eps = eps
+        return y
+
+    @staticmethod
+    def backward(ctx, dy):
+        x, w, b, m, v = ctx.saved_tensors
+        # heuristics for amount of parallel reduction stream for DW/DB
+        N = w.shape[0]
+        GROUP_SIZE_M = 64
+        if N <= 8192: GROUP_SIZE_M = 96
+        if N <= 4096: GROUP_SIZE_M = 128
+        if N <= 1024: GROUP_SIZE_M = 256
+        # allocate output
+        locks = torch.zeros(2 * GROUP_SIZE_M, dtype=torch.int32, device='cuda')
+        _dw = torch.empty((GROUP_SIZE_M, w.shape[0]), dtype=x.dtype, device=w.device)
+        _db = torch.empty((GROUP_SIZE_M, w.shape[0]), dtype=x.dtype, device=w.device)
+        dw = torch.empty((w.shape[0], ), dtype=w.dtype, device=w.device)
+        db = torch.empty((w.shape[0], ), dtype=w.dtype, device=w.device)
+        dx = torch.empty_like(dy)
+        # enqueue kernel using forward pass heuristics
+        # also compute partial sums for DW and DB
+        x_arg = x.reshape(-1, x.shape[-1])
+        M, N = x_arg.shape
+        _layer_norm_bwd_dx_fused[(M, )](dx, dy, _dw, _db, x, w, b, m, v, locks, x_arg.stride(0), N, ctx.eps,
+                                        BLOCK_SIZE_N=ctx.BLOCK_SIZE, GROUP_SIZE_M=GROUP_SIZE_M, num_warps=ctx.num_warps)
+        grid = lambda meta: [triton.cdiv(N, meta['BLOCK_SIZE_N'])]
+        # accumulate partial sums in separate kernel
+        _layer_norm_bwd_dwdb[grid](_dw, _db, dw, db, GROUP_SIZE_M, N, BLOCK_SIZE_M=32, BLOCK_SIZE_N=128)
+        return dx, None, dw, db, None
+
+
+layer_norm = LayerNorm.apply
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=['N'], x_vals=[512 * i for i in range(2, 32)], line_arg='provider',
+        line_vals=['triton', 'torch'] + (['apex'] if HAS_APEX else []),
+        line_names=['Triton', 'Torch'] + (['Apex'] if HAS_APEX else []), styles=[('blue', '-'), ('green', '-'),
+                                                                                 ('orange', '-')], ylabel='GB/s',
+        # plot_name='layer-norm-forward-autotune',
+        # args={'M': 4096, 'dtype': torch.float16, 'mode': 'forward'}
+        plot_name='layer-norm-backward-autotune', args={'M': 4096, 'dtype': torch.float16, 'mode': 'backward'}))
+def bench_layer_norm(M, N, dtype, provider, mode='backward', eps=1e-5, device='cuda'):
+    # create data
+    x_shape = (M, N)
+    w_shape = (x_shape[-1], )
+    weight = torch.rand(w_shape, dtype=dtype, device='cuda', requires_grad=True)
+    bias = torch.rand(w_shape, dtype=dtype, device='cuda', requires_grad=True)
+    x = -2.3 + 0.5 * torch.randn(x_shape, dtype=dtype, device='cuda')
+    dy = .1 * torch.randn_like(x)
+    x.requires_grad_(True)
+    quantiles = [0.5, 0.2, 0.8]
+    # utility functions
+    if provider == 'triton':
+        y_fwd = lambda: layer_norm(x, w_shape, weight, bias, eps)
+    if provider == 'torch':
+        y_fwd = lambda: torch.nn.functional.layer_norm(x, w_shape, weight, bias, eps)
+    if provider == 'apex':
+        apex_layer_norm = apex.normalization.FusedLayerNorm(w_shape).to(x.device).to(x.dtype)
+        y_fwd = lambda: apex_layer_norm(x)
+    # forward pass
+    if mode == 'forward':
+        gbps = lambda ms: 2 * x.numel() * x.element_size() / ms * 1e-6
+        ms, min_ms, max_ms = triton.testing.do_bench(y_fwd, quantiles=quantiles, rep=500)
+    # backward pass
+    if mode == 'backward':
+        gbps = lambda ms: 3 * x.numel() * x.element_size() / ms * 1e-6
+        y = y_fwd()
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: y.backward(dy, retain_graph=True), quantiles=quantiles,
+                                                     grad_to_none=[x], rep=500)
+    return gbps(ms), gbps(max_ms), gbps(min_ms)
+
+
+bench_layer_norm.run(save_path='.', print_data=True)
+
+# %%
+# References
+# ----------
+#
+# .. [BA2016] Jimmy Lei Ba and Jamie Ryan Kiros and Geoffrey E. Hinton, "Layer Normalization", Arxiv 2016

--- a/third_party/iluvatar/python/tutorials/performance_test/08-experimental-block-pointer-autotune.py
+++ b/third_party/iluvatar/python/tutorials/performance_test/08-experimental-block-pointer-autotune.py
@@ -1,0 +1,273 @@
+"""
+Block Pointer (Experimental)
+============================
+This tutorial will guide you through writing a matrix multiplication algorithm that utilizes block pointer semantics.
+These semantics are more friendly for Triton to optimize and can result in better performance on specific hardware.
+Note that this feature is still experimental and may change in the future.
+
+"""
+
+# %%
+# Motivations
+# -----------
+# In the previous matrix multiplication tutorial, we constructed blocks of values by de-referencing blocks of pointers,
+# i.e., :code:`load(block<pointer_type<element_type>>) -> block<element_type>`, which involved loading blocks of
+# elements from memory. This approach allowed for flexibility in using hardware-managed cache and implementing complex
+# data structures, such as tensors of trees or unstructured look-up tables.
+#
+# However, the drawback of this approach is that it relies heavily on complex optimization passes by the compiler to
+# optimize memory access patterns. This can result in brittle code that may suffer from performance degradation when the
+# optimizer fails to perform adequately. Additionally, as memory controllers specialize to accommodate dense spatial
+# data structures commonly used in machine learning workloads, this problem is likely to worsen.
+#
+# To address this issue, we will use block pointers :code:`pointer_type<block<element_type>>` and load them into
+# :code:`block<element_type>`, in which way gives better friendliness for the compiler to optimize memory access
+# patterns.
+#
+# Let's start with the previous matrix multiplication example and demonstrate how to rewrite it to utilize block pointer
+# semantics.
+
+# %%
+# Make a Block Pointer
+# --------------------
+# A block pointer pointers to a block in a parent tensor and is constructed by :code:`make_block_ptr` function,
+# which takes the following information as arguments:
+#
+# * :code:`base`: the base pointer to the parent tensor;
+#
+# * :code:`shape`: the shape of the parent tensor;
+#
+# * :code:`strides`: the strides of the parent tensor, which means how much to increase the pointer by when moving by 1 element in a specific axis;
+#
+# * :code:`offsets`: the offsets of the block;
+#
+# * :code:`block_shape`: the shape of the block;
+#
+# * :code:`order`: the order of the block, which means how the block is laid out in memory.
+#
+# For example, to a block pointer to a :code:`BLOCK_SIZE_M * BLOCK_SIZE_K` block in a row-major 2D matrix A by
+# offsets :code:`(pid_m * BLOCK_SIZE_M, 0)` and strides :code:`(stride_am, stride_ak)`, we can use the following code
+# (exactly the same as the previous matrix multiplication tutorial):
+#
+# .. code-block:: python
+#
+#     a_block_ptr = tl.make_block_ptr(base=a_ptr, shape=(M, K), strides=(stride_am, stride_ak),
+#                                     offsets=(pid_m * BLOCK_SIZE_M, 0), block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_K),
+#                                     order=(1, 0))
+#
+# Note that the :code:`order` argument is set to :code:`(1, 0)`, which means the second axis is the inner dimension in
+# terms of storage, and the first axis is the outer dimension. This information may sound redundant, but it is necessary
+# for some hardware backends to optimize for better performance.
+
+# %%
+# Load/Store a Block Pointer
+# --------------------------
+# To load/store a block pointer, we can use :code:`load/store` function, which takes a block pointer as an argument,
+# de-references it, and loads/stores a block. You may mask some values in the block, here we have an extra argument
+# :code:`boundary_check` to specify whether to check the boundary of each axis for the block pointer. With check on,
+# out-of-bound values will be masked according to the :code:`padding_option` argument (load only), which can be
+# :code:`zero` or :code:`nan`. Temporarily, we do not support other values due to some hardware limitations. In this
+# mode of block pointer load/store does not support :code:`mask` or :code:`other` arguments in the legacy mode.
+#
+# So to load the block pointer of A in the previous section, we can simply write
+# :code:`a = tl.load(a_block_ptr, boundary_check=(0, 1))`. Boundary check may cost extra performance, so if you can
+# guarantee that the block pointer is always in-bound in some axis, you can turn off the check by not passing the index
+# into the :code:`boundary_check` argument. For example, if we know that :code:`M` is a multiple of
+# :code:`BLOCK_SIZE_M`, we can replace with :code:`a = tl.load(a_block_ptr, boundary_check=(1, ))`, since axis 0 is
+# always in bound.
+
+# %%
+# Advance a Block Pointer
+# -----------------------
+# To advance a block pointer, we can use :code:`advance` function, which takes a block pointer and the increment for
+# each axis as arguments and returns a new block pointer with the same shape and strides as the original one,
+# but with the offsets advanced by the specified amount.
+#
+# For example, to advance the block pointer by :code:`BLOCK_SIZE_K` in the second axis
+# (no need to multiply with strides), we can write :code:`a_block_ptr = tl.advance(a_block_ptr, (0, BLOCK_SIZE_K))`.
+
+# %%
+# Final Result
+# ------------
+
+import torch
+
+import triton
+import triton.language as tl
+
+
+def get_configs_compute_bound():
+    configs = []
+    if hasattr(torch, "corex"):
+        for block_m in [32, 64, 128, 256]:
+            for block_n in [32, 64, 128, 256]:
+                for block_k in [32, 64, 128, 256]:
+                    num_warps = 16 if block_m >= 128 or block_n >= 128 or block_k >= 128 else 8
+                    configs.append(
+                        triton.Config(
+                            {
+                                'BLOCK_SIZE_M': block_m, 'BLOCK_SIZE_N': block_n, 'BLOCK_SIZE_K': block_k,
+                                'GROUP_SIZE_M': 8
+                            }, num_stages=1, num_warps=num_warps))
+    return configs
+
+
+configs = get_configs_compute_bound()
+
+
+@triton.autotune(
+    configs=configs,
+    key=['M', 'N', 'K'],
+)
+@triton.jit
+def matmul_kernel_with_block_pointers(
+        # Pointers to matrices
+        a_ptr, b_ptr, c_ptr,
+        # Matrix dimensions
+        M, N, K,
+        # The stride variables represent how much to increase the ptr by when moving by 1
+        # element in a particular dimension. E.g. `stride_am` is how much to increase `a_ptr`
+        # by to get the element one row down (A has M rows).
+        stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
+        # Meta-parameters
+        BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr, GROUP_SIZE_M: tl.constexpr):
+    # print("###", BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K)
+    """Kernel for computing the matmul C = A x B.
+    A has shape (M, K), B has shape (K, N) and C has shape (M, N)
+    """
+    # -----------------------------------------------------------
+    # Map program ids `pid` to the block of C it should compute.
+    # This is done in a grouped ordering to promote L2 data reuse.
+    # See the matrix multiplication tutorial for details.
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # ----------------------------------------------------------
+    # Create block pointers for the first blocks of A and B.
+    # We will advance this pointer as we move in the K direction and accumulate.
+    # See above `Make a Block Pointer` section for details.
+    a_block_ptr = tl.make_block_ptr(base=a_ptr, shape=(M, K), strides=(stride_am, stride_ak),
+                                    offsets=(pid_m * BLOCK_SIZE_M, 0), block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_K),
+                                    order=(1, 0))
+    b_block_ptr = tl.make_block_ptr(base=b_ptr, shape=(K, N), strides=(stride_bk, stride_bn),
+                                    offsets=(0, pid_n * BLOCK_SIZE_N), block_shape=(BLOCK_SIZE_K, BLOCK_SIZE_N),
+                                    order=(1, 0))
+
+    # -----------------------------------------------------------
+    # Iterate to compute a block of the C matrix.
+    # We accumulate into a `[BLOCK_SIZE_M, BLOCK_SIZE_N]` block.
+    # of fp32 values for higher accuracy.
+    # `accumulator` will be converted back to fp16 after the loop.
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, K, BLOCK_SIZE_K):
+        # Load with boundary checks, no need to calculate the mask manually.
+        # For better performance, you may remove some axis from the boundary
+        # check, if you can guarantee that the access is always in-bound in
+        # that axis.
+        # See above `Load/Store a Block Pointer` section for details.
+        # a = tl.load(a_block_ptr, boundary_check=(0, 1))
+        # b = tl.load(b_block_ptr, boundary_check=(0, 1))
+        a = tl.load(a_block_ptr)
+        b = tl.load(b_block_ptr)
+        # We accumulate along the K dimension.
+        accumulator += tl.dot(a, b)
+        # Advance the block pointer to the next K block.
+        # See above `Advance a Block Pointer` section for details.
+        a_block_ptr = tl.advance(a_block_ptr, (0, BLOCK_SIZE_K))
+        b_block_ptr = tl.advance(b_block_ptr, (BLOCK_SIZE_K, 0))
+    c = accumulator.to(tl.float16)
+
+    # ----------------------------------------------------------------
+    # Write back the block of the output matrix C with boundary checks.
+    # See above `Load/Store a Block Pointer` section for details.
+    c_block_ptr = tl.make_block_ptr(base=c_ptr, shape=(M, N), strides=(stride_cm, stride_cn),
+                                    offsets=(pid_m * BLOCK_SIZE_M, pid_n * BLOCK_SIZE_N),
+                                    block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_N), order=(1, 0))
+    tl.store(c_block_ptr, c, boundary_check=(0, 1))
+
+
+# We can now create a convenience wrapper function that only takes two input tensors,
+# and (1) checks any shape constraint; (2) allocates the output; (3) launches the above kernel.
+def matmul(a, b):
+    # Check constraints.
+    assert a.shape[1] == b.shape[0], "Incompatible dimensions"
+    assert a.is_contiguous(), "Matrix A must be contiguous"
+    assert b.is_contiguous(), "Matrix B must be contiguous"
+    M, K = a.shape
+    K, N = b.shape
+    # Allocates output.
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    # 1D launch kernel where each block gets its own program.
+    grid = lambda META: (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']), )
+    matmul_kernel_with_block_pointers[grid](
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+    )
+    # print("best config when M=N=K = ", M, matmul_kernel_with_block_pointers.best_config)
+    return c
+
+
+# %%
+# Unit Test
+# ---------
+#
+# Still we can test our matrix multiplication with block pointers against a native torch implementation (i.e., cuBLAS).
+
+# torch.manual_seed(0)
+# a = torch.randn((512, 512), device='cuda', dtype=torch.float16)
+# b = torch.randn((512, 512), device='cuda', dtype=torch.float16)
+# triton_output = matmul(a, b)
+# torch_output = torch.matmul(a, b)
+# print(f"triton_output={triton_output}")
+# print(f"torch_output={torch_output}")
+# if torch.allclose(triton_output, torch_output, atol=1e-2, rtol=0):
+#     print("✅ Triton and Torch match")
+# else:
+#     print("❌ Triton and Torch differ")
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=['M', 'N', 'K'],  # Argument names to use as an x-axis for the plot
+        x_vals=[128 * i for i in range(8, 9)],  # Different possible values for `x_name`
+        line_arg='provider',  # Argument name whose value corresponds to a different line in the plot
+        # Possible values for `line_arg`
+        line_vals=['ixblas', 'triton'],
+        # Label name for the lines
+        line_names=["ixBLAS", "Triton"],
+        # Line styles
+        styles=[('green', '-'), ('blue', '-')],
+        ylabel="TFLOPS",  # Label name for the y-axis
+        plot_name="matmul-performance",  # Name for the plot, used also as a file name for saving the plot.
+        args={},
+    ))
+def benchmark(M, N, K, provider):
+    a = torch.randn((M, K), device='cuda', dtype=torch.float16)
+    b = torch.randn((K, N), device='cuda', dtype=torch.float16)
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == 'ixblas':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), quantiles=quantiles)
+    if provider == 'triton':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b), quantiles=quantiles)
+    perf = lambda ms: 2 * M * N * K * 1e-12 / (ms * 1e-3)
+    return perf(ms), perf(max_ms), perf(min_ms)
+
+
+benchmark.run(show_plots=True, print_data=True, save_path='.')

--- a/third_party/iluvatar/python/tutorials/performance_test/transpose.py
+++ b/third_party/iluvatar/python/tutorials/performance_test/transpose.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2025, Shanghai Iluvatar CoreX Semiconductor Co., Ltd.
+# All Rights Reserved.
+# Licensed under the MIT License
+
+import os
+import torch
+
+import triton
+import triton.language as tl
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({'BLOCK_M': 16, 'BLOCK_N': 16}, num_warps=1, num_stages=1),
+        triton.Config({'BLOCK_M': 32, 'BLOCK_N': 32}, num_warps=1, num_stages=1),
+        triton.Config({'BLOCK_M': 64, 'BLOCK_N': 64}, num_warps=4, num_stages=1),
+        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128}, num_warps=16, num_stages=1),
+        triton.Config({'BLOCK_M': 256, 'BLOCK_N': 256}, num_warps=32, num_stages=1),
+    ], key=['M', 'N'])
+@triton.jit
+def transpose_kernel(input_ptr, output_ptr, stride_am, stride_an, stride_bn, stride_bm, M, N, BLOCK_M: tl.constexpr,
+                     BLOCK_N: tl.constexpr):
+    pid = tl.program_id(0)
+
+    # num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    input = input_ptr + (rm[:, None] * stride_am + rn[None, :] * stride_an)
+    mask = (rm < M)[:, None] & (rn < N)[None, :]
+    output = output_ptr + (rm[:, None] * stride_bm + rn[None, :] * stride_bn)
+
+    tl.store(output, tl.load(input, mask=mask), mask=mask)
+
+
+def transpose(input):
+    M, N = input.shape
+    output = torch.empty((N, M), device=input.device, dtype=input.dtype)
+    grid = lambda META: (triton.cdiv(M, META['BLOCK_M']) * triton.cdiv(N, META['BLOCK_N']), )
+    transpose_kernel[grid](input, output, input.stride(0), input.stride(1), output.stride(0), output.stride(1), M, N)
+    return output
+
+
+def check_accuracy(M_list):
+    """
+    Check that triton results are allclose to torch results.
+    """
+    print("Check accuracy: Triton vs Torch")
+    for M in M_list:
+        x = torch.randn(M, M, device='cuda', dtype=torch.float32)
+        y_triton = transpose(x)
+        y_torch = torch.transpose(x, 0, 1).contiguous()
+        if torch.allclose(y_triton, y_torch):
+            print(f"Test shape = ({M}, {M}), test passed.")
+        else:
+            print(f"Test shape = ({M}, {M}), test failed")
+
+
+def run_performance(M_list, save_path):
+
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=['M'],
+            x_vals=[M for M in M_list],
+            line_arg='provider',
+            line_vals=['triton', 'torch'],
+            line_names=["Triton", "Torch"],
+            styles=[('blue', '-'), ('green', '-')],
+            ylabel="GB/s",
+            plot_name="transpose-performance",
+            args={},
+        ))
+    def benchmark(M, provider):
+        x = torch.randn(M, M, device='cuda', dtype=torch.float32)
+        quantiles = [0.5, 0.2, 0.8]
+        if provider == 'torch':
+            ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.transpose(x, 0, 1).contiguous(),
+                                                         quantiles=quantiles)
+        if provider == 'triton':
+            ms, min_ms, max_ms = triton.testing.do_bench(lambda: transpose(x), quantiles=quantiles)
+
+        perf = lambda ms: 8 * M * M / ms * 1e-6
+        return perf(ms), perf(max_ms), perf(min_ms)
+
+    benchmark.run(show_plots=True, print_data=True, save_path='.')
+
+
+if __name__ == "__main__":
+    M_list = [32, 64, 128, 256, 512, 1024]
+    check_accuracy(M_list)
+    run_performance(M_list)

--- a/third_party/iluvatar/python/tutorials/performance_test/utils.py
+++ b/third_party/iluvatar/python/tutorials/performance_test/utils.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2025, Shanghai Iluvatar CoreX Semiconductor Co., Ltd.
+# All Rights Reserved.
+# Licensed under the MIT License
+
+from itertools import product
+
+import torch
+
+
+# Ref: https://github.com/pytorch-labs/tritonbench/blob/main/tritonbench/utils/triton_op.py#L162
+def llama_shapes():
+    # batch sizes * seq lengths
+    BS = [2**i for i in range(0, 17)]
+    # attn: wqkv, wo; ffn: w13, w2
+    KN = [
+        (4096, 12288),
+        (4096, 4096),
+        (4096, 22016),
+        (11008, 4096),
+        (8192, 1280),
+        (1024, 8192),
+        (8192, 7168),
+        (3584, 8192),
+        (16384, 2304),
+        (2048, 16384),
+        (16384, 13312),
+        (6656, 16384),
+    ]
+    return [(bs, n, k) for bs, (k, n) in product(BS, KN)]
+
+
+# FMT: (M, N, K)
+LLAMA_SHAPES = llama_shapes()
+
+
+# Ref: https://github.com/pytorch/pytorch/blob/main/benchmarks/dynamo/microbenchmarks/bench_mm_fusion.py#L96
+def dynamo_shapes_mm():
+    shapes = []
+    # alexnet
+    shapes.append((128, 4096, 9216))
+    shapes.append((128, 4096, 4096))
+    shapes.append((128, 1000, 4096))
+    # BERT
+    shapes.append((2048, 768, 768))
+    shapes.append((2048, 3072, 768))
+    shapes.append((2048, 768, 3072))
+    # hf_GPT2
+    shapes.append((1024, 768, 768))
+    shapes.append((1024, 3072, 768))
+    shapes.append((1024, 768, 3072))
+    shapes.append((1024, 2304, 768))
+    return shapes
+
+
+# FMT: (M, N, K)
+DYNAMO_SHAPES_MM = dynamo_shapes_mm()
+
+
+# Ref: https://github.com/pytorch/pytorch/blob/main/benchmarks/operator_benchmark/pt/matrix_mult_test.py#L10,L23
+#      https://github.com/pytorch/pytorch/blob/main/benchmarks/dynamo/microbenchmarks/inductor_bmm.py#L49
+def dynamo_shapes_bmm():
+    shapes = []
+    shapes.append((4, 5, 3, 2))
+    shapes.append((32, 25, 20, 30))
+    shapes.append((128, 100, 120, 110))
+    shapes.append((128, 256, 128, 256))
+    shapes.append((512, 1024, 1024, 512))
+
+    # BERT (all)
+    shapes.append((192, 128, 128, 64))
+    shapes.append((192, 128, 128, 64))
+    shapes.append((192, 128, 64, 128))
+    # hf_GPT2 (all)
+    shapes.append((12, 1024, 64, 1024))
+    shapes.append((12, 1024, 1024, 64))
+    # hf_Albert (all)
+    shapes.append((12, 512, 512, 64))
+    shapes.append((12, 512, 64, 512))
+    return shapes
+
+
+# FMT: (B, M, N, K)
+DYNAMO_SHAPES_BMM = dynamo_shapes_bmm()
+
+
+# Ref: https://github.com/FlagOpen/FlagGems/blob/master/benchmark/core_shapes.yaml#L56
+def blas_shapes():
+    shapes = []
+    shapes.append((2, 4096, 4096, 4096))
+    shapes.append((16, 384, 384, 384))
+    shapes.append((16, 1024, 1024, 1024))
+    shapes.append((16, 2048, 2048, 2048))
+    shapes.append((16, 4096, 4096, 4096))
+    return shapes
+
+
+# FMT: (B, M, N, K)
+BLAS_SHAPES = blas_shapes()
+
+
+# Ref: {iluvatar_bitbucket}/projects/CSYSLIB/repos/ixblas/browse/bench/gemm_perf.cpp#1057
+def ixblas_shapes_fp32():
+    shapes = []
+    shapes.append((3072, 4096, 30176))
+    return shapes
+
+
+# FMT: (M, N, K)
+IXBLAS_SHAPES_FP32 = ixblas_shapes_fp32()
+
+
+# Ref: {iluvatar_bitbucket}/projects/CSYSLIB/repos/ixblas/browse/bench/gemm_perf.cpp#1094
+def ixblas_shapes_fp16():
+    shapes = []
+    if torch.cuda.get_device_capability()[0] >= 8:
+        shapes.append((3072, 4096, 30176))
+    else:
+        shapes.append((2048, 2048, 8192))
+    return shapes
+
+
+# FMT: (M, N, K)
+IXBLAS_SHAPES_FP16 = ixblas_shapes_fp16()
+
+
+def deal_perf_mm_shapes():
+    PERF_MM_SHAPES = LLAMA_SHAPES + DYNAMO_SHAPES_MM
+    for _, m, n, k in BLAS_SHAPES:
+        PERF_MM_SHAPES.append((m, n, k))
+
+    return list(set(PERF_MM_SHAPES))
+
+
+PERF_MM_SHAPES = deal_perf_mm_shapes()
+
+
+def deal_perf_bmm_shapes():
+    PERF_BMM_SHAPES = DYNAMO_SHAPES_BMM + BLAS_SHAPES
+    return list(set(PERF_BMM_SHAPES))
+
+
+PERF_BMM_SHAPES = deal_perf_bmm_shapes()


### PR DESCRIPTION
* Jul 15
Add iluvatar copyright
* Jul 11
Fix error when test any op
* Jul 10
Ensure warp-uniform base ptr for stp intrinsic [SWFW-2457]
Support maxnreg
UT | Re-enable previously skipped cases now that ixcc supports function calls. [SWCOMP-2141]
UT | add IsVolatileVal for llvm.bi.load.kop intrinsic. [TEST-11414]
UT|Skip sme in8 UT  on QS. [TEST-11492]
Optimize the sme matching logic of nested kernels[SWFW-2196]
Add mm && bmm perf with model shapes. [SWFW-2380]
Add performace test [SWFW-1620]
Add ut for sme
refactor sme v1 && Opt Membar [SWFW-2196]
Enhance Triton build and install scripts: add directory creation, optional header, and upgrade flag [SWFW-2338]
Fix LoadOp's inferSrcEncoding method by replacing with ori encoding. [SWFW-2310]
[Pick from 1108] Fix segfault in Python3.12 without relock before return cubin [TEST-10727]
mark self.module = None if raise OutOfResources. [SWFW-2301]
UT | Skip float64 UT test. [TEST-10934]
async_copy_global_to_local type check support i64. [SWFW-2301]
Fix QS launch failed when autotune. [SWFW-2301]
Fix | get_wpt skip assertions, but not omit blockarg checks. [SWFW-2308]
Fix lowerSliceToSlice [SWFW-2302]
Perf | Disable OuterLoopPipeline [SWFW-2023]
Update get_corex_sme: Only consider innermost 2 non - 1 dims for SME check [SWFW-2262]
Fix | Blocked Layout(use_sme) use start Value [SWFW-2262]
[NFC] Revert to using options to skip BlockArg check as LLVM 18 supports it.
Fix failed to parse ttgir with triton_gpu.async_copy_global_to_local op [SWFW-2299]
Fix test_core::test_dot::chain_dot error
Update nvidia-smi into ixmsi [SWFW-2224]
Modify test_precise_math::test_sqrt assertion standard [SWFW-2268]
Fix fmha MmaToDotShortCut error
Fix AsyncCopyGlobalToLocalOp's operands size. [CSUPPORT-5716]
[QS UT] Skip test_dot_trans; skip test_core mma_layout related ttgir tests; skip fp32 tl.dot
[QS UT] Add mma->dot_operand for QS. [TEST-10211][SWFW-2208]
[QS UT]Fix reduce when input is mma layout. [TEST-10211]
[QS UT] QS do not support fmha now. [TEST-10211]
[QS UT] QS do not support fp32 / int8 / fp16 with out_dtype=fp16 now. [TEST-10211]
[QS UT] golden is incorrect, use torch cpu as reference [TEST-10211]
[QS UT] skip fp16/fp32 test_print, which need vprint3[TEST-10211]
Fix | SliceLayout with parent=mmaLayout elemId idx incorrect [SWFW-2221]
Fix | Disable best confg cache opt by default.
Fix | distributed autotune bug [SWFW-2211]
Fix two uploaded fused_attention versions
Bugfix | ConvertLayout - Revert to original logic for slice source & mma parent to fix vec>1 bug in bank conflict opt [SWFW-2221]
Fix import error
Fix | fmha fwd 0812 version revert compiler bug workaround [SWFW-2215]
Upload fused_attention tutorials of 3 versions
Add MMALoad pass
[Opt] fmha fwd cvt slice(p=mma, dim=1) to blocked to avoid bank conflict [SWFW-1453]
Update float2bfloat && bfloat2float lowering
MMA Layout store call intrinsics [SWFW-2179]
* Jul 9
Support fp32/fp16 atomic_cas [SWFW-2209]
Load and store support cache modifier [SWFW-2235]
Load support volatile [SWFW-2235]
[SWPERF-2588] triton sme support 16x32 block size
Fix multi-buffer shared memory allocation
* Mar 17
Refactor MembarPass for QS&MR [SWFW-1957]Refactor MembarPass for QS&MR [SWFW-1957]
* Mar 7
Opt Mem_Bar [SWFW-1957]

---------

Co-authored-by: liwei.dai <liwei.dai@iluvatar.com>
Co-authored-by: Zhendong Fu <zhendong.fu@iluvatar.com>
Co-authored-by: junjian.zhan <junjian.zhan@iluvatar.com>
Co-authored-by: pengrui.yao <pengrui.yao@iluvatar.com>
Co-authored-by: jinjiang.li <jinjiang.li@iluvatar.com>
Co-authored-by: lei.zhang1 <lei.zhang1@iluvatar.com>