### PR TITLE
[Build] Fix Triton cmake dependence bug

### DIFF
--- a/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -11,6 +11,8 @@ add_triton_library(TritonTransforms
   DEPENDS
   TritonTransformsIncGen
   TritonCombineIncGen
+  TritonGPUAttrDefsIncGen
+  TritonGPUTypeInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRPass

--- a/lib/Dialect/TritonGPU/IR/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/IR/CMakeLists.txt
@@ -8,6 +8,9 @@ add_triton_library(TritonGPUIR
   TritonGPUTableGen
   TritonGPUAttrDefsIncGen
   TritonGPUTypeInterfacesIncGen
+  TritonNvidiaGPUTableGen
+  TritonNvidiaGPUAttrDefsIncGen
+  TritonNvidiaGPUOpInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRGPUDialect

--- a/third_party/aipu/CMakeLists.txt
+++ b/third_party/aipu/CMakeLists.txt
@@ -2,8 +2,14 @@ add_subdirectory(include)
 add_subdirectory(lib)
 add_subdirectory(tools)
 
-add_triton_plugin(TritonAIPU ${CMAKE_CURRENT_SOURCE_DIR}/triton_aipu.cc)
+add_triton_plugin(TritonAIPU
+    ${CMAKE_CURRENT_SOURCE_DIR}/triton_aipu.cc
+
+    DEPENDS
+    TritonTableGen
+)
 target_include_directories(TritonAIPU PRIVATE ${CMAKE_SOURCE_DIR}/third_party/flir/include)
+
 target_link_libraries(TritonAIPU PRIVATE
     Python3::Module
     pybind11::headers

--- a/third_party/amd/test/lib/Analysis/CMakeLists.txt
+++ b/third_party/amd/test/lib/Analysis/CMakeLists.txt
@@ -1,6 +1,11 @@
 add_mlir_library(TritonAMDGPUTestAnalysis
   TestAMDRangeAnalysis.cpp
 
+  DEPENDS
+  TritonTableGen
+  TritonGPUAttrDefsIncGen
+  TritonGPUTypeInterfacesIncGen
+
   LINK_LIBS PUBLIC
   MLIRPass
   ${triton_libs}


### PR DESCRIPTION
<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->
Fix the missing dependence.