### PR TITLE
[Common] refactor UnifiedHardware

### DIFF
--- a/include/flagtree/Common/UnifiedHardware.h
+++ b/include/flagtree/Common/UnifiedHardware.h
@@ -15,36 +15,15 @@ namespace flagtree {
 class UnifiedHardware {
 
 public:
-  ~UnifiedHardware() = default;
   UnifiedHardware() = default;
-#ifdef FLAGTREE_BACKEND
-  static bool registered;
-  int getDMATag();
-  int getSharedMemoryTag();
-  std::string getFlagTreeBackend() { return FLAGTREE_BACKEND; }
-#else
-  static constexpr bool registered = false;
-  void *getDMATag() { return nullptr; }
-  void *getSharedMemoryTag() { return nullptr; }
-  std::string getFlagTreeBackend() { return "default"; }
-#endif
+  virtual ~UnifiedHardware() = default;
+  virtual bool isRegistered();
+  virtual int getDMATag();
+  virtual int getSharedMemoryTag();
+  virtual std::string getFlagTreeBackend();
 };
 
 std::unique_ptr<UnifiedHardware> createUnifiedHardwareManager();
 
 } // namespace flagtree
 } // namespace mlir
-
-#define SET_REGISTER_FLAG(_Ty, FLAG) bool _Ty::registered = FLAG;
-
-#define FLAGTREE_REGISTRAR_GET(_Ty, _Fn, _VAL)                                 \
-  decltype(_VAL) _Ty::get##_Fn() { return static_cast<decltype(_VAL)>(_VAL); }
-
-#ifdef FLAGTREE_BACKEND
-#define FLAGTREE_REGISTRAR(fn_name, _VAL)                                      \
-  using UnifiedHardwareType = mlir::flagtree::UnifiedHardware;                 \
-  FLAGTREE_REGISTRAR_GET(UnifiedHardwareType, fn_name, _VAL)                   \
-  SET_REGISTER_FLAG(UnifiedHardwareType, true)
-#else
-#define FLAGTREE_REGISTRAR(...)
-#endif

--- a/lib/flagtree/Common/UnifiedHardware.cc
+++ b/lib/flagtree/Common/UnifiedHardware.cc
@@ -3,7 +3,22 @@
 namespace mlir {
 namespace flagtree {
 
-std::unique_ptr<UnifiedHardware> createUnifiedHardwareManager() {
+bool UnifiedHardware::isRegistered() {
+#ifdef FLAGTREE_BACKEND
+  return true;
+#else
+  return false;
+#endif
+}
+
+int UnifiedHardware::getDMATag() { return 0; }
+
+int UnifiedHardware::getSharedMemoryTag() { return 0; }
+
+std::string UnifiedHardware::getFlagTreeBackend() { return "default"; }
+
+__attribute__((weak)) std::unique_ptr<UnifiedHardware>
+createUnifiedHardwareManager() {
   return std::make_unique<UnifiedHardware>();
 }
 

--- a/third_party/aipu/lib/Registrar.cc
+++ b/third_party/aipu/lib/Registrar.cc
@@ -1,2 +1,13 @@
 #include "flagtree/Common/UnifiedHardware.h"
-FLAGTREE_REGISTRAR(DMATag, 11)
+
+class AipuUnifiedHardware : public mlir::flagtree::UnifiedHardware {
+public:
+  int getDMATag() override;
+};
+
+int AipuUnifiedHardware::getDMATag() { return 11; }
+
+std::unique_ptr<mlir::flagtree::UnifiedHardware>
+mlir::flagtree::createUnifiedHardwareManager() {
+  return std::make_unique<AipuUnifiedHardware>();
+}


### PR DESCRIPTION
<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->

[BACKEND] This PR refactored `UnifiedHardware`. We define a base class and provides its default method implementations. When a new hardware is included, it needs to inherit the base class and override the methods if needed. Then they need to provide their own `createUnifiedHardwareManager` function to create it. We put a default implementation but mark it as "weak" so it could be overridden.