### PR TITLE
[Common] Add 'getReduceStrategy'

### DIFF
--- a/include/flagtree/Common/UnifiedHardware.h
+++ b/include/flagtree/Common/UnifiedHardware.h
@@ -17,10 +17,11 @@ class UnifiedHardware {
 public:
   UnifiedHardware() = default;
   virtual ~UnifiedHardware() = default;
-  virtual bool isRegistered();
-  virtual int getDMATag();
-  virtual int getSharedMemoryTag();
-  virtual std::string getFlagTreeBackend();
+  virtual bool isRegistered() const;
+  virtual int getDMATag() const;
+  virtual int getSharedMemoryTag() const;
+  virtual std::string getReduceStrategy() const;
+  virtual std::string getFlagTreeBackend() const;
 };
 
 std::unique_ptr<UnifiedHardware> createUnifiedHardwareManager();

--- a/lib/flagtree/Common/UnifiedHardware.cc
+++ b/lib/flagtree/Common/UnifiedHardware.cc
@@ -3,7 +3,7 @@
 namespace mlir {
 namespace flagtree {
 
-bool UnifiedHardware::isRegistered() {
+bool UnifiedHardware::isRegistered() const {
 #ifdef FLAGTREE_BACKEND
   return true;
 #else
@@ -11,11 +11,15 @@ bool UnifiedHardware::isRegistered() {
 #endif
 }
 
-int UnifiedHardware::getDMATag() { return 0; }
+int UnifiedHardware::getDMATag() const { return 0; }
 
-int UnifiedHardware::getSharedMemoryTag() { return 0; }
+int UnifiedHardware::getSharedMemoryTag() const { return 0; }
 
-std::string UnifiedHardware::getFlagTreeBackend() { return "default"; }
+std::string UnifiedHardware::getReduceStrategy() const {
+  return "linalg_reduce";
+}
+
+std::string UnifiedHardware::getFlagTreeBackend() const { return "default"; }
 
 __attribute__((weak)) std::unique_ptr<UnifiedHardware>
 createUnifiedHardwareManager() {

--- a/third_party/aipu/lib/Registrar.cc
+++ b/third_party/aipu/lib/Registrar.cc
@@ -2,10 +2,10 @@
 
 class AipuUnifiedHardware : public mlir::flagtree::UnifiedHardware {
 public:
-  int getDMATag() override;
+  int getDMATag() const override;
 };
 
-int AipuUnifiedHardware::getDMATag() { return 11; }
+int AipuUnifiedHardware::getDMATag() const { return 11; }
 
 std::unique_ptr<mlir::flagtree::UnifiedHardware>
 mlir::flagtree::createUnifiedHardwareManager() {


### PR DESCRIPTION
<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->
[BACKEND] provide `getReduceStrategy` to assign reduction lowering strategy. The link of related FLIR PR is [here](https://github.com/FlagTree/flir/pull/25).