### PR TITLE
[build 3.1]Fix path reference in git clone command

### DIFF
--- a/python/setup_tools/utils/tools.py
+++ b/python/setup_tools/utils/tools.py
@@ -160,7 +160,7 @@ class DownloadManager:
             try:
                 os.system(f"git clone {module.url} {module.dst_path}")
                 if has_specialization_commit:
-                    os.system("cd module.dst_path")
+                    os.system(f"cd {module.dst_path}")
                     os.system(f"git checkout {module.commit_id}")
                     os.system("cd -")
                 return True


### PR DESCRIPTION
<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->
