### PR TITLE
Replace default code owner for the project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,6 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @zhzhcookie
 
 # --------
 # Setup

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,9 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 
+# TODO(Qiming): Replace the individual names with maintainers group
+* @menchunlei @zhzhcookie @sunnycase @hxl0809 @i3wanna2 @Galaxy1458 @sgjzfzzf
+
 # --------
 # Setup
 # --------


### PR DESCRIPTION
Remove @zhzhcookie as a default code owner.
We are not supposed to push all review workloads to a single person. It will lead to biased assessment and create bottleneck for the project. On the contrary, we encourage all maintainers to participate in PR reviews.

