### PR TITLE
[Refactor] Refactor FFI

### DIFF
--- a/python/triton/experimental/tle/language/raw/core.py
+++ b/python/triton/experimental/tle/language/raw/core.py
@@ -1,40 +1,12 @@
-import ast
-
 import triton.language as tl
 from triton.language.core import builtin, tensor
 
 
 @builtin
 def call(func, outputs, inputs, _semantic=None):
-    # Extract type hints and argument names from function AST
-    arg_type_hints = []
-    arg_names = []
-    if hasattr(func, 'ast') and func.ast.body:
-        func_def = func.ast.body[0]
-        if isinstance(func_def, ast.FunctionDef):
-            for arg in func_def.args.args:
-                # Extract argument name
-                arg_names.append(arg.arg)
-                # Extract type hint
-                if arg.annotation:
-                    if isinstance(arg.annotation, ast.Subscript):
-                        # Handle type hints like Input["memref<?xi32, 3>"]
-                        if isinstance(arg.annotation.slice, ast.Constant):
-                            type_str = arg.annotation.slice.value
-                        elif isinstance(arg.annotation.slice, ast.Str):  # Python < 3.8
-                            type_str = arg.annotation.slice.s
-                        else:
-                            type_str = ""
-                        arg_type_hints.append(type_str)
-                    else:
-                        arg_type_hints.append("")
-                else:
-                    arg_type_hints.append("")
-
-    dsl_region_op = _semantic.builder.create_edsl_region_by_llvm_func(f"{func.llvm}", func.fnname,
-                                                                      [output.handle for output in outputs],
-                                                                      [input.handle
-                                                                       for input in inputs], arg_type_hints, arg_names)
+    dsl_region_op = _semantic.builder.create_tle_raw_region_by_llvm_func(f"{func.llvm}", func.fnname,
+                                                                         [output.handle for output in outputs],
+                                                                         [input.handle for input in inputs])
     tensors = [tensor(result, output.type) for result, output in zip(dsl_region_op.get_results(), outputs)]
     if len(tensors) == 1:
         return tensors[0]

--- a/python/triton/experimental/tle/raw/mlir/runtime.py
+++ b/python/triton/experimental/tle/raw/mlir/runtime.py
@@ -13,16 +13,12 @@ from .codegen import EdslMLIRCodeGenerator
 
 class EdslMLIRJITFunction(object):
 
-    def __init__(self, fn: Any, pipeline: Optional[List[str]] = None, context: Optional[ir.Context] = None, *args,
-                 **kwargs) -> None:
+    def __init__(self, fn: Any, pipeline: List[str], context: Optional[ir.Context] = None, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.fn: Final[Any] = fn
-        # TODO(EDSL): expose pipeline option for customization in `dialect`
-        self.pipeline: Final[List[str]] = [
-            "convert-scf-to-cf", "finalize-memref-to-llvm", "convert-arith-to-llvm", "convert-cf-to-llvm",
-            "convert-func-to-llvm", "convert-index-to-llvm", "convert-nvvm-to-llvm", "cse"
-        ] if pipeline is None else pipeline
+        self.pipeline: Final[List[str]] = [*pipeline]
         self.context: Final[ir.Context] = ir.Context() if context is None else context
+        self.__triton_builtin__: Final[bool] = True
 
     def __deepcopy__(self, memo: Dict[int, Any]) -> EdslMLIRJITFunction:
         return self.__class__(copy.deepcopy(self.fn, memo), copy.deepcopy(self.pipeline, memo), self.context)

--- a/python/triton/experimental/tle/raw/runtime.py
+++ b/python/triton/experimental/tle/raw/runtime.py
@@ -1,14 +1,16 @@
 from .mlir import EdslMLIRJITFunction
-from typing import List, Optional
+from typing import List
 
 registry = {"mlir": EdslMLIRJITFunction}
 
 
-def dialect(*, name: str, pipeline: Optional[List[str]] | None = None):
+def dialect(*, name: str, pipeline: List[str] = [
+    "convert-scf-to-cf", "finalize-memref-to-llvm", "convert-arith-to-llvm", "convert-cf-to-llvm",
+    "convert-func-to-llvm", "convert-index-to-llvm", "convert-nvvm-to-llvm", "cse"
+]):
 
     def decorator(fn):
         edsl = registry[name](fn, pipeline=pipeline)
-        setattr(edsl, "__triton_builtin__", True)
         return edsl
 
     return decorator

--- a/third_party/tle/CMakeLists.txt
+++ b/third_party/tle/CMakeLists.txt
@@ -1,9 +1,16 @@
 # flagtree tle
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/dialect/include)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/dialect/include)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/utils/include)
 add_subdirectory(dialect)
 if(TRITON_BUILD_PYTHON_MODULE)
-  add_triton_plugin(TritonTLE ${CMAKE_CURRENT_SOURCE_DIR}/triton_tle.cc ${CMAKE_CURRENT_SOURCE_DIR}/triton_tle_raw.cc LINK_LIBS TritonTLETransforms TritonIR)
+  add_triton_plugin(TritonTLE
+    ${CMAKE_CURRENT_SOURCE_DIR}/triton_tle.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/triton_tle_raw.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils/lib/Protocol.cpp
+    LINK_LIBS
+    TritonTLETransforms
+    TritonIR)
   target_link_libraries(TritonTLE PRIVATE Python3::Module pybind11::headers)
 endif()
 

--- a/third_party/tle/dialect/include/IR/TleOps.td
+++ b/third_party/tle/dialect/include/IR/TleOps.td
@@ -21,9 +21,7 @@ def Tle_TensorType : AnyTypeOf<[TT_Type, TTG_MemDescType]>;
 def Tle_ArgType : AnyTypeOf<[Tle_TensorType, LLVMPointerType, LLVMStructType]>;
 
 def Tle_DSLRegionOp : Tle_Op<"dsl_region", [IsolatedFromAbove, MemDescViewTrait, RecursiveMemoryEffects]> {
-  let arguments = (ins Variadic<Tle_ArgType>:$inputs,
-    OptionalAttr<ArrayAttr>:$edsl_param_types,
-    OptionalAttr<ArrayAttr>:$edsl_param_names);
+  let arguments = (ins Variadic<Tle_ArgType>:$inputs);
   let results = (outs Variadic<Tle_ArgType>:$outputs);
   let regions = (region AnyRegion:$body);
   let hasVerifier = 1;

--- a/third_party/tle/triton_tle.cc
+++ b/third_party/tle/triton_tle.cc
@@ -54,11 +54,9 @@ namespace ttg = triton::gpu;
 namespace ttng = triton::nvidia_gpu;
 namespace tle = triton::tle;
 
-extern tle::DSLRegionOp createEdslRegionByLLVMFunc(
+extern tle::DSLRegionOp createTLERawRegionByLLVMFunc(
     TritonOpBuilder &self, std::string_view text, std::string_view fnname,
-    const std::vector<Value> &outputs, const std::vector<Value> &inputs,
-    const std::vector<std::string> &arg_type_hints,
-    const std::vector<std::string> &arg_names);
+    const std::vector<Value> &outputs, const std::vector<Value> &inputs);
 
 void init_triton_tle_ir(py::module &&m) {
   using ret = py::return_value_policy;
@@ -189,8 +187,8 @@ void init_tle_raw_ir(py::module &&m) {
       .def("dump", &tle::YieldOp::dump);
 
   auto *builder_cls = ir::getBuilderClass();
-  builder_cls->def("create_edsl_region_by_llvm_func",
-                   &createEdslRegionByLLVMFunc);
+  builder_cls->def("create_tle_raw_region_by_llvm_func",
+                   &createTLERawRegionByLLVMFunc);
 }
 
 void init_tle_raw_passes(py::module &&m) {

--- a/third_party/tle/triton_tle_raw.cc
+++ b/third_party/tle/triton_tle_raw.cc
@@ -1,61 +1,20 @@
+#include "IR/Dialect.h"
 #include "ir.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Parser/Parser.h"
 #include "tle/dialect/include/IR/Dialect.h"
+#include "tle/utils/include/Protocol.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 #include <optional>
 #include <regex>
 #include <string>
 
 using namespace mlir;
 namespace tle = triton::tle;
-
-// Helper function to parse address space from EDSL parameter type
-// Returns the address space if found, or std::nullopt if not found/parse failed
-static std::optional<uint32_t>
-parseAddressSpaceFromTypeHint(const std::string &typeHint) {
-  if (typeHint.empty()) {
-    return std::nullopt;
-  }
-
-  // Parse memref format: "memref<shape, address_space>" or "!memref<shape,
-  // address_space>" Match: optional !, memref<...anything..., address_space>
-  std::regex memref_regex(R"(!?memref<[^>]*,\s*(\d+)\s*>)");
-  std::smatch memref_match;
-  if (std::regex_match(typeHint, memref_match, memref_regex)) {
-    try {
-      return static_cast<uint32_t>(std::stoul(memref_match[1].str()));
-    } catch (...) {
-      llvm::errs()
-          << "[ERROR] Failed to parse address space from memref param type: "
-          << typeHint << "\n";
-      return std::nullopt;
-    }
-  }
-
-  // Parse llvm.ptr format: "llvm.ptr<address_space>" or
-  // "!llvm.ptr<address_space>" Match: optional !, llvm.ptr<address_space>
-  std::regex ptr_regex(R"(!?llvm\.ptr<(\d+)>)");
-  std::smatch ptr_match;
-  if (std::regex_match(typeHint, ptr_match, ptr_regex)) {
-    try {
-      return static_cast<uint32_t>(std::stoul(ptr_match[1].str()));
-    } catch (...) {
-      llvm::errs()
-          << "[ERROR] Failed to parse address space from llvm.ptr param type: "
-          << typeHint << "\n";
-      return std::nullopt;
-    }
-  }
-
-  // If type hint is not empty but doesn't match expected formats, report error
-  llvm::errs() << "[ERROR] Unsupported EDSL parameter type format: " << typeHint
-               << "\n";
-  llvm::errs() << "[ERROR] Expected format: \"memref<shape, address_space>\" "
-                  "or \"llvm.ptr<address_space>\"\n";
-  return std::nullopt;
-}
 
 // Create a DSLRegionOp that wraps an LLVM function, performing type conversion
 // from Triton IR types to LLVM types based on EDSL function declarations.
@@ -88,12 +47,9 @@ parseAddressSpaceFromTypeHint(const std::string &typeHint) {
 //   - EDSL param type: "i32"
 //   - LLVM func: 1 arg = i32
 //   - Conversion: Use block argument directly
-tle::DSLRegionOp createEdslRegionByLLVMFunc(
+tle::DSLRegionOp createTLERawRegionByLLVMFunc(
     TritonOpBuilder &self, std::string_view text, std::string_view fnname,
-    const std::vector<Value> &outputs, const std::vector<Value> &inputs,
-    const std::vector<std::string> &arg_type_hints,
-    const std::vector<std::string> &arg_names) {
-  // Stage 1: Parse LLVM IR and extract function using Triton's MLIR context
+    const std::vector<Value> &outputs, const std::vector<Value> &inputs) {
   ParserConfig config(self.getContext());
   OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(text, config);
   LLVM::LLVMFuncOp func = module->lookupSymbol<LLVM::LLVMFuncOp>(fnname);
@@ -119,353 +75,39 @@ tle::DSLRegionOp createEdslRegionByLLVMFunc(
       llvm::concat<Value>(SmallVector<Value>(outputs.begin(), outputs.end()),
                           SmallVector<Value>(inputs.begin(), inputs.end())));
 
-  // Stage 2: Create DSLRegionOp, create new body
-  // The edsl_param_types contain the EDSL function parameter type
-  // declarations (e.g., "memref<?xi32, 3>", "i32") These are stored as an
-  // ArrayAttr of StringAttrs in the DSLRegionOp's "edsl_param_types"
-  // attribute The edsl_param_names contain the EDSL function parameter names
-  // (e.g., "sum_buf", "indices") These are stored as an ArrayAttr of
-  // StringAttrs in the DSLRegionOp's "edsl_param_names" attribute
-  ArrayAttr edslParamTypesAttr = nullptr;
-  if (!arg_type_hints.empty()) {
-    SmallVector<Attribute> typeAttrs;
-    for (const auto &typeHint : arg_type_hints) {
-      typeAttrs.push_back(StringAttr::get(self.getContext(), typeHint));
-    }
-    edslParamTypesAttr = ArrayAttr::get(self.getContext(), typeAttrs);
-  }
-
-  ArrayAttr edslParamNamesAttr = nullptr;
-  if (!arg_names.empty()) {
-    SmallVector<Attribute> nameAttrs;
-    for (const auto &name : arg_names) {
-      nameAttrs.push_back(StringAttr::get(self.getContext(), name));
-    }
-    edslParamNamesAttr = ArrayAttr::get(self.getContext(), nameAttrs);
-  }
-
-  SmallVector<NamedAttribute> attrs;
-  if (edslParamTypesAttr) {
-    attrs.push_back(
-        NamedAttribute(StringAttr::get(self.getContext(), "edsl_param_types"),
-                       edslParamTypesAttr));
-  }
-  if (edslParamNamesAttr) {
-    attrs.push_back(
-        NamedAttribute(StringAttr::get(self.getContext(), "edsl_param_names"),
-                       edslParamNamesAttr));
-  }
-
   tle::DSLRegionOp dslRegionOp =
-      self.create<tle::DSLRegionOp>(outputTys, operands, attrs);
+      self.create<tle::DSLRegionOp>(outputTys, operands);
   OpBuilder::InsertionGuard guard(builder);
   Region &body = dslRegionOp.getBody();
   SmallVector<Type> operandTys = llvm::map_to_vector(
       operands, [](Value value) -> Type { return value.getType(); });
   IRMapping mapper;
 
-  // Stage 3: Argument type conversion and and establish mapping relationships
-  // Convert TT IR types (DSLRegionOp operands) to LLVM types (LLVM function
-  // arguments) For each DSLRegionOp operand:
-  //   1. Check its TT IR type (tensor, pointer, scalar)
-  //   2. Check the corresponding EDSL type hint from attribute (e.g.,
-  //   "memref<?xi32, 3>", "i32")
-  //   3. Verify the LLVM function has the expected number and types of
-  //   arguments
-  //   4. Create extract operations to convert TT IR values to LLVM values
-  //   5. Map LLVM function arguments to extract operation results in
-  //   IRMapping
-  //
-  // Type conversion examples:
-  //   - TT tensor<128xi32> + EDSL "memref<?xi32, 3>" -> LLVM 5 args (ptr<3>,
-  //   ptr<3>, offset, size, stride)
-  //   - TT ptr<f32> + EDSL param type "llvm.ptr<1>" -> LLVM 1 arg (ptr<1>)
-  //   - TT i32 + EDSL "i32" -> LLVM 1 arg (i32, passed through directly)
-  uint32_t llvm_arg_idx = 0;     // Track position in LLVM function arguments
-  SmallVector<Value> extractOps; // Collect all extract operations for mapping
+  uint32_t llvm_arg_idx = 0;
+  SmallVector<Value> extractOps;
 
   for (auto [idx, oldBlock] : llvm::enumerate(func.getBlocks())) {
     if (idx == 0) {
-      // Create the first block with operands as block arguments
       Block *newBlock = builder.createBlock(
           &body, {}, operandTys,
           SmallVector<Location>(operandTys.size(), self.getLastLoc()));
-
-      // Set insertion point to start: extract operations will be inserted at
-      // the beginning
       builder.setInsertionPointToStart(newBlock);
 
-      // Iterate through DSLRegionOp operands and create extract operations
-      // Note: operands = [outputs..., inputs...], edsl_param_types
-      // corresponds to all operands Extract edsl_param_names from attribute
-      SmallVector<std::string> edsl_param_names_from_attr;
-      if (auto edslParamNamesAttr =
-              dslRegionOp->getAttrOfType<ArrayAttr>("edsl_param_names")) {
-        for (auto nameAttr : edslParamNamesAttr) {
-          if (auto strAttr = dyn_cast<StringAttr>(nameAttr)) {
-            edsl_param_names_from_attr.push_back(strAttr.str());
-          }
-        }
+      using Pattern =
+          tle::ProtocolPattern<RankedTensorType, triton::PointerType,
+                               IntegerType, FloatType>;
+
+      ValueRange tgts = func.getArguments();
+      SmallVector<Value> ops = {};
+      for (Value src : newBlock->getArguments()) {
+        ops.append(Pattern::consume(self, tgts, src));
+      }
+      for (auto [arg, op] : zip_equal(func.getArguments(), ops)) {
+        mapper.map(arg, op);
       }
 
-      for (size_t operand_idx = 0; operand_idx < operands.size();
-           ++operand_idx) {
-        Value operand = operands[operand_idx];
-        Value blockArg = newBlock->getArgument(operand_idx);
-        std::string arg_type = operand_idx < arg_type_hints.size()
-                                   ? arg_type_hints[operand_idx]
-                                   : "";
-        std::string arg_name = operand_idx < edsl_param_names_from_attr.size()
-                                   ? edsl_param_names_from_attr[operand_idx]
-                                   : "";
-
-        // Case 1: TT Tensor type conversion
-        // TT IR: RankedTensorType (e.g., tensor<128xi32>)
-        // EDSL param type: "memref<?xi32, 3>" (stored in edsl_param_types
-        // attribute) LLVM func: 3 + 2*rank args =
-        // allocated_ptr<address_space>, aligned_ptr<address_space>, offset,
-        // sizes[rank], strides[rank] Conversion: Create
-        // ExtractAllocatedPtrOp, ExtractAlignedPtrOp, ExtractOffsetOp,
-        // ExtractSizesOp, ExtractStridesOp
-        if (RankedTensorType tensorTy =
-                dyn_cast<RankedTensorType>(blockArg.getType())) {
-          // Type consistency check: verify EDSL parameter type matches actual
-          // Triton type If EDSL param type is "llvm.ptr<...>", it requires
-          // triton::PointerType, not RankedTensorType
-          if (!arg_type.empty()) {
-            std::regex ptr_regex(R"(!?llvm\.ptr<\d+>)");
-            if (std::regex_match(arg_type, ptr_regex)) {
-              llvm::errs() << "[ERROR] Type mismatch for operand "
-                           << operand_idx;
-              if (!arg_name.empty()) {
-                llvm::errs() << " (parameter: " << arg_name << ")";
-              }
-              llvm::errs() << "\n";
-              llvm::errs() << "[ERROR] EDSL param type: " << arg_type
-                           << " (expects triton::PointerType)\n";
-              llvm::errs() << "[ERROR] Actual Triton type: "
-                           << blockArg.getType() << " (RankedTensorType)\n";
-              assert(false && "EDSL type hint mismatch: llvm.ptr requires "
-                              "triton::PointerType, but got RankedTensorType");
-            }
-          }
-          const size_t rank = tensorTy.getRank();
-          size_t expected_llvm_args =
-              3 + 2 * rank; // allocated_ptr, aligned_ptr, offset, sizes...,
-                            // strides...
-
-          // Verify we have enough LLVM arguments
-          if (llvm_arg_idx + expected_llvm_args > func.getNumArguments()) {
-            llvm::errs() << "[ERROR] Not enough LLVM arguments for tensor. "
-                         << "Expected " << expected_llvm_args
-                         << " args starting at index " << llvm_arg_idx
-                         << ", but only "
-                         << (func.getNumArguments() - llvm_arg_idx)
-                         << " remaining\n";
-            assert(false && "Not enough LLVM arguments for tensor");
-          }
-
-          // Get address space from the first LLVM argument (allocated_ptr)
-          uint32_t llvm_as = cast<LLVM::LLVMPointerType>(
-                                 func.getArgument(llvm_arg_idx).getType())
-                                 .getAddressSpace();
-
-          // Parse expected address space from EDSL parameter type (e.g.,
-          // "memref<?xi32, 3>" -> 3)
-          uint32_t expected_as = llvm_as; // Default to LLVM's address space
-          if (auto parsed_as = parseAddressSpaceFromTypeHint(arg_type)) {
-            expected_as = *parsed_as;
-
-            // Verify address space consistency
-            if (expected_as != llvm_as) {
-              llvm::errs()
-                  << "[ERROR] Address space mismatch for tensor operand "
-                  << operand_idx << "\n";
-              llvm::errs() << "[ERROR] EDSL hint: " << arg_type
-                           << " (address space: " << expected_as << ")\n";
-              llvm::errs() << "[ERROR] LLVM func arg address space: " << llvm_as
-                           << "\n";
-              assert(false && "Address space mismatch");
-            }
-          }
-
-          Type ptrTy =
-              LLVM::LLVMPointerType::get(self.getContext(), expected_as);
-
-          // Create extract operations for tensor components
-          size_t extract_start_idx = extractOps.size();
-          extractOps.push_back(
-              self.create<tle::ExtractAllocatedPtrOp>(ptrTy, blockArg));
-          extractOps.push_back(
-              self.create<tle::ExtractAlignedPtrOp>(ptrTy, blockArg));
-          extractOps.push_back(self.create<tle::ExtractOffsetOp>(blockArg));
-
-          auto sizesOp = self.create<tle::ExtractSizesOp>(rank, blockArg);
-          auto stridesOp = self.create<tle::ExtractStridesOp>(rank, blockArg);
-          for (const auto &result : sizesOp.getResults()) {
-            extractOps.push_back(result);
-          }
-          for (const auto &result : stridesOp.getResults()) {
-            extractOps.push_back(result);
-          }
-
-          // Map LLVM function arguments to extract operation results
-          for (size_t i = 0; i < expected_llvm_args; ++i) {
-            mapper.map(func.getArgument(llvm_arg_idx + i),
-                       extractOps[extract_start_idx + i]);
-          }
-
-          llvm_arg_idx += expected_llvm_args;
-
-          // Case 2: TT Pointer type conversion
-          // TT IR: triton::PointerType (e.g., ptr<f32>)
-          // EDSL param type: "llvm.ptr<1>" (stored in edsl_param_types
-          // attribute) LLVM func: 1 arg = ptr<address_space> Conversion:
-          // Create ExtractPtrOp to convert TT pointer to LLVM pointer
-        } else if (auto ptrTy =
-                       dyn_cast<triton::PointerType>(blockArg.getType())) {
-          // Type consistency check: verify EDSL parameter type matches actual
-          // Triton type If EDSL param type is "memref<...>", it requires
-          // RankedTensorType, not triton::PointerType
-          if (!arg_type.empty()) {
-            std::regex memref_regex(R"(!?memref<[^>]*,\s*\d+\s*>)");
-            if (std::regex_match(arg_type, memref_regex)) {
-              llvm::errs() << "[ERROR] Type mismatch for operand "
-                           << operand_idx;
-              if (!arg_name.empty()) {
-                llvm::errs() << " (parameter: " << arg_name << ")";
-              }
-              llvm::errs() << "\n";
-              llvm::errs() << "[ERROR] EDSL param type: " << arg_type
-                           << " (expects RankedTensorType)\n";
-              llvm::errs() << "[ERROR] Actual Triton type: "
-                           << blockArg.getType() << " (triton::PointerType)\n";
-              assert(false && "EDSL type hint mismatch: memref requires "
-                              "RankedTensorType, but got triton::PointerType");
-            }
-          }
-          size_t expected_llvm_args = 1;
-
-          // Verify we have enough LLVM arguments
-          if (llvm_arg_idx + expected_llvm_args > func.getNumArguments()) {
-            llvm::errs() << "[ERROR] Not enough LLVM arguments for pointer. "
-                         << "Expected " << expected_llvm_args
-                         << " args starting at index " << llvm_arg_idx
-                         << ", but only "
-                         << (func.getNumArguments() - llvm_arg_idx)
-                         << " remaining\n";
-            assert(false && "Not enough LLVM arguments for pointer");
-          }
-
-          // Get address space from LLVM argument
-          uint32_t llvm_as = cast<LLVM::LLVMPointerType>(
-                                 func.getArgument(llvm_arg_idx).getType())
-                                 .getAddressSpace();
-
-          // Parse expected address space from EDSL parameter type (e.g.,
-          // "llvm.ptr<1>" -> 1)
-          uint32_t expected_as = llvm_as; // Default to LLVM's address space
-          if (auto parsed_as = parseAddressSpaceFromTypeHint(arg_type)) {
-            expected_as = *parsed_as;
-
-            // Verify address space consistency
-            if (expected_as != llvm_as) {
-              llvm::errs()
-                  << "[ERROR] Address space mismatch for pointer operand "
-                  << operand_idx << "\n";
-              llvm::errs() << "[ERROR] EDSL hint: " << arg_type
-                           << " (address space: " << expected_as << ")\n";
-              llvm::errs() << "[ERROR] LLVM func arg address space: " << llvm_as
-                           << "\n";
-              assert(false && "Address space mismatch");
-            }
-          }
-
-          Type llvmPtrTy =
-              LLVM::LLVMPointerType::get(self.getContext(), expected_as);
-
-          // Create extract operation for pointer
-          extractOps.push_back(
-              self.create<tle::ExtractPtrOp>(llvmPtrTy, blockArg));
-
-          // Map LLVM function argument to extract operation result
-          mapper.map(func.getArgument(llvm_arg_idx), extractOps.back());
-
-          llvm_arg_idx += expected_llvm_args;
-
-          // Case 3: Scalar type conversion
-          // TT IR: IntegerType or FloatType (e.g., i32, i64, f32)
-          // EDSL hint: Same type string (e.g., "i32", "i64")
-          // LLVM func: 1 arg = same type (i32, i64, f32, etc.)
-          // Conversion: Use block argument directly (no extract operation
-          // needed)
-        } else if (isa<IntegerType>(blockArg.getType()) ||
-                   isa<FloatType>(blockArg.getType())) {
-          // Type consistency check: verify EDSL parameter type matches actual
-          // Triton type Scalars should not have memref or llvm.ptr param
-          // types
-          if (!arg_type.empty()) {
-            std::regex memref_regex(R"(!?memref<[^>]*,\s*\d+\s*>)");
-            std::regex ptr_regex(R"(!?llvm\.ptr<\d+>)");
-            bool is_memref_hint = std::regex_match(arg_type, memref_regex);
-            bool is_ptr_hint = std::regex_match(arg_type, ptr_regex);
-            if (is_memref_hint || is_ptr_hint) {
-              llvm::errs() << "[ERROR] Type mismatch for operand "
-                           << operand_idx;
-              if (!arg_name.empty()) {
-                llvm::errs() << " (parameter: " << arg_name << ")";
-              }
-              llvm::errs() << "\n";
-              llvm::errs() << "[ERROR] EDSL param type: " << arg_type
-                           << " (expects tensor or pointer type)\n";
-              llvm::errs() << "[ERROR] Actual Triton type: "
-                           << blockArg.getType() << " (scalar type)\n";
-              assert(false && "EDSL type hint mismatch: memref/llvm.ptr "
-                              "requires tensor/pointer type, but got scalar");
-            }
-          }
-          size_t expected_llvm_args = 1;
-
-          // Verify we have enough LLVM arguments
-          if (llvm_arg_idx + expected_llvm_args > func.getNumArguments()) {
-            llvm::errs() << "[ERROR] Not enough LLVM arguments for scalar. "
-                         << "Expected " << expected_llvm_args
-                         << " args starting at index " << llvm_arg_idx
-                         << ", but only "
-                         << (func.getNumArguments() - llvm_arg_idx)
-                         << " remaining\n";
-            assert(false && "Not enough LLVM arguments for scalar");
-          }
-
-          // For scalars, use the block argument directly (no extract needed)
-          extractOps.push_back(blockArg);
-
-          // Map LLVM function argument to block argument
-          mapper.map(func.getArgument(llvm_arg_idx), blockArg);
-
-          llvm_arg_idx += expected_llvm_args;
-        } else {
-          // Unsupported type: report error
-          Type argType = blockArg.getType();
-          llvm::errs() << "[ERROR] Unsupported operand type: " << argType
-                       << " at operand index " << operand_idx << "\n";
-          llvm::errs() << "[ERROR] Expected one of: RankedTensorType, "
-                          "triton::PointerType, IntegerType, FloatType\n";
-          llvm::errs() << "[ERROR] EDSL param type: " << arg_type << "\n";
-          assert(false && "Unsupported operand type");
-        }
-      }
-
-      // Verify we consumed all LLVM function arguments
-      if (llvm_arg_idx != func.getNumArguments()) {
-        llvm::errs() << "[WARNING] Mismatch in LLVM argument count. "
-                     << "Consumed " << llvm_arg_idx
-                     << " args, but function has " << func.getNumArguments()
-                     << " args\n";
-      }
       mapper.map(&oldBlock, newBlock);
     } else {
-      // For other blocks, just map block arguments
       Block *newBlock = builder.createBlock(
           &body, {}, oldBlock.getArgumentTypes(),
           SmallVector<Location>(oldBlock.getNumArguments(), self.getLastLoc()));
@@ -476,14 +118,9 @@ tle::DSLRegionOp createEdslRegionByLLVMFunc(
       mapper.map(&oldBlock, newBlock);
     }
   }
-
-  // Stage 4: Clone the LLVM function body to the DSLRegionOp body
   for (auto [oldBlock, newBlock] :
        llvm::zip(func.getBlocks(), body.getBlocks())) {
     OpBuilder::InsertionGuard guard(builder);
-    // Use setInsertionPointToEnd because extract operations were inserted at
-    // the start in Stage 3 Clone operations will be inserted after extract
-    // operations
     builder.setInsertionPointToEnd(&newBlock);
     for (Operation &operation : oldBlock.getOperations()) {
       if (LLVM::ReturnOp returnOp = dyn_cast<LLVM::ReturnOp>(operation)) {

--- a/third_party/tle/utils/include/Protocol.h
+++ b/third_party/tle/utils/include/Protocol.h
@@ -1,0 +1,79 @@
+#ifndef TLE_UTILS_PROTOCOL_H_
+#define TLE_UTILS_PROTOCOL_H_
+
+#include "IR/Dialect.h"
+#include "ir.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+#include <cstddef>
+#include <stdexcept>
+
+/* --------------- Definitions --------------- */
+
+namespace mlir::triton::tle {
+
+/* --------------- Protocol  --------------- */
+
+template <typename T> struct Protocol {
+  static SmallVector<Value> consume(TritonOpBuilder &builder, ValueRange &tgts,
+                                    TypedValue<T> src);
+};
+
+template <> struct Protocol<RankedTensorType> {
+  static SmallVector<Value> consume(TritonOpBuilder &builder, ValueRange &tgts,
+                                    TypedValue<RankedTensorType> src);
+};
+
+template <> struct Protocol<PointerType> {
+  static SmallVector<Value> consume(TritonOpBuilder &builder, ValueRange &tgts,
+                                    TypedValue<PointerType> src);
+};
+
+template <> struct Protocol<IntegerType> {
+  static SmallVector<Value> consume(TritonOpBuilder &builder, ValueRange &tgts,
+                                    TypedValue<IntegerType> src);
+};
+
+template <> struct Protocol<FloatType> {
+  static SmallVector<Value> consume(TritonOpBuilder &builder, ValueRange &tgts,
+                                    TypedValue<FloatType> src);
+};
+
+/* --------------- ProtocolPattern --------------- */
+
+template <typename... Ts> struct ProtocolPattern {
+  static SmallVector<Value> consume(TritonOpBuilder &builder, ValueRange &tgts,
+                                    Value src);
+};
+
+template <> struct ProtocolPattern<> {
+  static SmallVector<Value> consume(TritonOpBuilder &builder, ValueRange &tgts,
+                                    Value src);
+};
+
+template <typename T, typename... Ts> struct ProtocolPattern<T, Ts...> {
+  static SmallVector<Value> consume(TritonOpBuilder &builder, ValueRange &tgts,
+                                    Value src);
+};
+
+/* --------------- Implementatoins --------------- */
+
+/* --------------- ProtocolPattern --------------- */
+
+template <typename T, typename... Ts>
+SmallVector<Value> ProtocolPattern<T, Ts...>::consume(TritonOpBuilder &builder,
+                                                      ValueRange &tgts,
+                                                      Value src) {
+  if (isa<T>(src.getType())) {
+    return Protocol<T>::consume(builder, tgts, cast<TypedValue<T>>(src));
+  } else {
+    return ProtocolPattern<Ts...>::consume(builder, tgts, src);
+  }
+}
+
+} // namespace mlir::triton::tle
+
+#endif

--- a/third_party/tle/utils/lib/Protocol.cpp
+++ b/third_party/tle/utils/lib/Protocol.cpp
@@ -1,89 +1,126 @@
 #include "tle/utils/include/Protocol.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "tle/dialect/include/IR/Dialect.h"
+#include "llvm/Support/raw_ostream.h"
+#include <exception>
 
-namespace mlir::triton::tle {
+#define COND_CHECK(cond)                                                       \
+  if (!(cond)) {                                                               \
+    return {};                                                                 \
+  }
+
+namespace mlir::triton::tle::protocol {
 
 /* --------------- Definitions --------------- */
 
 /* --------------- ProtocolImpl --------------- */
 
 template <typename T> struct GenericProtocolImpl {
-  static SmallVector<Value> consume(TritonOpBuilder &builder, ValueRange &tgts,
-                                    TypedValue<T> src);
+  static SmallVector<Value> apply(TritonOpBuilder &builder, TypeRange &tgts,
+                                  TypedValue<T> src);
 };
 
 /* --------------- Implementatoins --------------- */
 
 /* --------------- Protocol --------------- */
 
-SmallVector<Value>
-Protocol<RankedTensorType>::consume(TritonOpBuilder &builder, ValueRange &tgts,
-                                    TypedValue<RankedTensorType> src) {
-  size_t counter = 0;
-  SmallVector<Value> rets;
-  Value val = tgts[counter++];
-  LLVM::LLVMPointerType ty = cast<LLVM::LLVMPointerType>(val.getType());
-  rets.push_back(builder.create<ExtractAllocatedPtrOp>(ty, src));
-  val = tgts[counter++];
-  ty = cast<LLVM::LLVMPointerType>(val.getType());
-  rets.push_back(builder.create<ExtractAlignedPtrOp>(ty, src));
-  val = tgts[counter++];
-  assert(val.getType().isInteger(64));
-  rets.push_back(builder.create<ExtractOffsetOp>(src));
+namespace signature {
+
+SmallVector<Value> RankedTensorPattern::apply(TritonOpBuilder &builder,
+                                              TypeRange &tgts,
+                                              TypedValue<E> src) {
   const size_t rank = src.getType().getRank();
-  for (size_t i = counter; i < counter + 2 * rank; ++i) {
-    val = tgts[i];
-    assert(val.getType().isInteger(64));
+  SmallVector<Value> rets;
+  Type tgt = tgts[0];
+  LLVM::LLVMPointerType ty = cast<LLVM::LLVMPointerType>(tgt);
+  rets.push_back(builder.create<ExtractAllocatedPtrOp>(ty, src));
+  tgt = tgts[1];
+  ty = cast<LLVM::LLVMPointerType>(tgt);
+  rets.push_back(builder.create<ExtractAlignedPtrOp>(ty, src));
+  tgt = tgts[2];
+  COND_CHECK(tgt.isInteger(64));
+  rets.push_back(builder.create<ExtractOffsetOp>(src));
+  for (size_t i = 3; i < 3 + 2 * rank; ++i) {
+    tgt = tgts[i];
+    COND_CHECK(tgt.isInteger(64));
   }
-  counter += 2 * rank;
   ExtractSizesOp sizesOp = builder.create<ExtractSizesOp>(rank, src);
   ExtractStridesOp stridesOp = builder.create<ExtractStridesOp>(rank, src);
   for (const auto &result :
        llvm::concat<OpResult>(sizesOp.getResults(), stridesOp.getResults())) {
     rets.push_back(result);
   }
-  tgts = tgts.drop_front(counter);
+  tgts = tgts.drop_front(3 + 2 * rank);
   return rets;
 }
 
-SmallVector<Value> Protocol<PointerType>::consume(TritonOpBuilder &builder,
-                                                  ValueRange &tgts,
-                                                  TypedValue<PointerType> src) {
-  Value tgt = tgts.front();
-  LLVM::LLVMPointerType llvmPtrTy = cast<LLVM::LLVMPointerType>(tgt.getType());
+SmallVector<Value> PointerPattern::apply(TritonOpBuilder &builder,
+                                         TypeRange &tgts, TypedValue<E> src) {
+  Type tgt = tgts.front();
+  LLVM::LLVMPointerType llvmPtrTy = cast<LLVM::LLVMPointerType>(tgt);
   tgts = tgts.drop_front();
   return {builder.create<tle::ExtractPtrOp>(llvmPtrTy, src)};
 }
 
-SmallVector<Value> Protocol<IntegerType>::consume(TritonOpBuilder &builder,
-                                                  ValueRange &tgts,
-                                                  TypedValue<IntegerType> src) {
-  return GenericProtocolImpl<IntegerType>::consume(builder, tgts, src);
+} // namespace signature
+
+namespace ret {
+
+SmallVector<Value> LLVMStructurePattern::apply(TritonOpBuilder &builder,
+                                               TypeRange &tgts,
+                                               TypedValue<E> src) {
+  COND_CHECK(!tgts.empty());
+  RankedTensorType tgt = dyn_cast<RankedTensorType>(tgts.front());
+  COND_CHECK(tgt);
+  const size_t rank = tgt.getRank();
+  LLVM::LLVMStructType structTy = src.getType();
+  ArrayRef<Type> types = structTy.getBody();
+  const size_t size = types.size();
+  COND_CHECK(size == 5 &&
+             llvm::all_of(types.take_front(2),
+                          [](const Type &ty) -> bool {
+                            return isa<LLVM::LLVMPointerType>(ty);
+                          }) &&
+             types[2].isInteger(64) &&
+             llvm::all_of(types.take_back(2), [rank](const Type &ty) -> bool {
+               LLVM::LLVMArrayType arrayTy = dyn_cast<LLVM::LLVMArrayType>(ty);
+               return arrayTy && arrayTy.getElementType().isInteger(64) &&
+                      arrayTy.getNumElements() == rank;
+             }));
+  tgts = tgts.drop_front();
+  return {builder.create<tle::PackOp>(tgt, src)};
 }
 
-SmallVector<Value> Protocol<FloatType>::consume(TritonOpBuilder &builder,
-                                                ValueRange &tgts,
-                                                TypedValue<FloatType> src) {
-  return GenericProtocolImpl<FloatType>::consume(builder, tgts, src);
+} // namespace ret
+
+SmallVector<Value> IntegerPattern::apply(TritonOpBuilder &builder,
+                                         TypeRange &tgts, TypedValue<E> src) {
+  return GenericProtocolImpl<E>::apply(builder, tgts, src);
+}
+
+SmallVector<Value> FloatPattern::apply(TritonOpBuilder &builder,
+                                       TypeRange &tgts, TypedValue<E> src) {
+  return GenericProtocolImpl<E>::apply(builder, tgts, src);
 }
 
 /* --------------- ProtocolPattern --------------- */
 
-SmallVector<Value> ProtocolPattern<>::consume(TritonOpBuilder &builder,
-                                              ValueRange &tgts, Value src) {
+SmallVector<Value> ProtocolPatternT<>::apply(TritonOpBuilder &builder,
+                                             TypeRange &tgts, Value src) {
   return {};
 }
 
 /* --------------- ProtocolImpl --------------- */
 
 template <typename T>
-SmallVector<Value> GenericProtocolImpl<T>::consume(TritonOpBuilder &builder,
-                                                   ValueRange &tgts,
-                                                   TypedValue<T> src) {
-  Value val = tgts.front();
-  assert(val.getType() == src.getType());
+SmallVector<Value> GenericProtocolImpl<T>::apply(TritonOpBuilder &builder,
+                                                 TypeRange &tgts,
+                                                 TypedValue<T> src) {
+  Type tgt = tgts.front();
+  COND_CHECK(tgt == src.getType());
   tgts = tgts.drop_front();
-  return SmallVector<Value>{src};
+  return {src};
 }
 
-} // namespace mlir::triton::tle
+} // namespace mlir::triton::tle::protocol

--- a/third_party/tle/utils/lib/Protocol.cpp
+++ b/third_party/tle/utils/lib/Protocol.cpp
@@ -1,0 +1,89 @@
+#include "tle/utils/include/Protocol.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+namespace mlir::triton::tle {
+
+/* --------------- Definitions --------------- */
+
+/* --------------- ProtocolImpl --------------- */
+
+template <typename T> struct GenericProtocolImpl {
+  static SmallVector<Value> consume(TritonOpBuilder &builder, ValueRange &tgts,
+                                    TypedValue<T> src);
+};
+
+/* --------------- Implementatoins --------------- */
+
+/* --------------- Protocol --------------- */
+
+SmallVector<Value>
+Protocol<RankedTensorType>::consume(TritonOpBuilder &builder, ValueRange &tgts,
+                                    TypedValue<RankedTensorType> src) {
+  size_t counter = 0;
+  SmallVector<Value> rets;
+  Value val = tgts[counter++];
+  LLVM::LLVMPointerType ty = cast<LLVM::LLVMPointerType>(val.getType());
+  rets.push_back(builder.create<ExtractAllocatedPtrOp>(ty, src));
+  val = tgts[counter++];
+  ty = cast<LLVM::LLVMPointerType>(val.getType());
+  rets.push_back(builder.create<ExtractAlignedPtrOp>(ty, src));
+  val = tgts[counter++];
+  assert(val.getType().isInteger(64));
+  rets.push_back(builder.create<ExtractOffsetOp>(src));
+  const size_t rank = src.getType().getRank();
+  for (size_t i = counter; i < counter + 2 * rank; ++i) {
+    val = tgts[i];
+    assert(val.getType().isInteger(64));
+  }
+  counter += 2 * rank;
+  ExtractSizesOp sizesOp = builder.create<ExtractSizesOp>(rank, src);
+  ExtractStridesOp stridesOp = builder.create<ExtractStridesOp>(rank, src);
+  for (const auto &result :
+       llvm::concat<OpResult>(sizesOp.getResults(), stridesOp.getResults())) {
+    rets.push_back(result);
+  }
+  tgts = tgts.drop_front(counter);
+  return rets;
+}
+
+SmallVector<Value> Protocol<PointerType>::consume(TritonOpBuilder &builder,
+                                                  ValueRange &tgts,
+                                                  TypedValue<PointerType> src) {
+  Value tgt = tgts.front();
+  LLVM::LLVMPointerType llvmPtrTy = cast<LLVM::LLVMPointerType>(tgt.getType());
+  tgts = tgts.drop_front();
+  return {builder.create<tle::ExtractPtrOp>(llvmPtrTy, src)};
+}
+
+SmallVector<Value> Protocol<IntegerType>::consume(TritonOpBuilder &builder,
+                                                  ValueRange &tgts,
+                                                  TypedValue<IntegerType> src) {
+  return GenericProtocolImpl<IntegerType>::consume(builder, tgts, src);
+}
+
+SmallVector<Value> Protocol<FloatType>::consume(TritonOpBuilder &builder,
+                                                ValueRange &tgts,
+                                                TypedValue<FloatType> src) {
+  return GenericProtocolImpl<FloatType>::consume(builder, tgts, src);
+}
+
+/* --------------- ProtocolPattern --------------- */
+
+SmallVector<Value> ProtocolPattern<>::consume(TritonOpBuilder &builder,
+                                              ValueRange &tgts, Value src) {
+  return {};
+}
+
+/* --------------- ProtocolImpl --------------- */
+
+template <typename T>
+SmallVector<Value> GenericProtocolImpl<T>::consume(TritonOpBuilder &builder,
+                                                   ValueRange &tgts,
+                                                   TypedValue<T> src) {
+  Value val = tgts.front();
+  assert(val.getType() == src.getType());
+  tgts = tgts.drop_front();
+  return SmallVector<Value>{src};
+}
+
+} // namespace mlir::triton::tle


### PR DESCRIPTION
<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->

This PR is related to #298. It utilizes a new class `Refactor` to register and apply signature conversion when building `DSLRegionOp`.
