### PR TITLE
[TLE-Raw] implement vassert and add unit test

### DIFF
--- a/.github/workflows/hopper-build-and-test.yml
+++ b/.github/workflows/hopper-build-and-test.yml
@@ -83,6 +83,7 @@ jobs:
           set -x
           pip uninstall -y triton
           source ~/env-3.4.sh
+          env | grep -E '^(LLVM_SYSPATH)=' >> $GITHUB_ENV || true
           MAX_JOBS=32 python3 -m pip install . --no-build-isolation
 
       - name: FlagTree Build on NVidia (triton_v3.5.x branch)
@@ -92,6 +93,7 @@ jobs:
           set -x
           pip uninstall -y triton
           source ~/env-3.5.sh
+          env | grep -E '^(LLVM_SYSPATH)=' >> $GITHUB_ENV || true
           MAX_JOBS=32 python3 -m pip install . --no-build-isolation
 
       - name: FlagTree Test on NVidia (triton_v3.4.x branch)

--- a/.github/workflows/hopper-build-and-test.yml
+++ b/.github/workflows/hopper-build-and-test.yml
@@ -153,6 +153,7 @@ jobs:
           python3 python/tutorials/hints/08/08-grouped-gemm.py --only_unit_test
           python3 python/tutorials/hints/11/11-programmatic-dependent-launch.py --only_unit_test
           # flagtree tle raw
-          # python3 python/tutorials/tle/raw/01-vector-add.py
-          # python3 python/tutorials/tle/raw/02-fused-softmax.py
-          # python3 python/tutorials/tle/raw/03-matrix-multiplication.py
+          python3 python/tutorials/tle/raw/01-vector-add.py
+          python3 python/tutorials/tle/raw/02-fused-softmax.py
+          python3 python/tutorials/tle/raw/03-matrix-multiplication.py
+          python3 python/tutorials/tle/raw/06-test-vassert.py

--- a/.github/workflows/hopper-build-and-test.yml
+++ b/.github/workflows/hopper-build-and-test.yml
@@ -158,4 +158,6 @@ jobs:
           python3 python/tutorials/tle/raw/01-vector-add.py
           python3 python/tutorials/tle/raw/02-fused-softmax.py
           python3 python/tutorials/tle/raw/03-matrix-multiplication.py
+          python3 python/tutorials/tle/raw/04-hello-world.py
+          python3 python/tutorials/tle/raw/05-topk.py
           python3 python/tutorials/tle/raw/06-test-vassert.py

--- a/python/triton/experimental/tle/raw/mlir/__init__.py
+++ b/python/triton/experimental/tle/raw/mlir/__init__.py
@@ -1,4 +1,4 @@
 from .runtime import EdslMLIRJITFunction
-from .utils import vprintf
+from .utils import vprintf, vassert
 
-__all__ = ["EdslMLIRJITFunction", "vprintf"]
+__all__ = ["EdslMLIRJITFunction", "vprintf", "vassert"]

--- a/python/triton/experimental/tle/raw/mlir/codegen.py
+++ b/python/triton/experimental/tle/raw/mlir/codegen.py
@@ -93,7 +93,7 @@ class EdslMLIRCodeGenerator(ast.NodeVisitor):
             for idx, arg in enumerate(node.args.args):
                 # issue#328 [bug]edsl InOut&Input anno F722 error
                 # https://github.com/flagos-ai/FlagTree/issues/328
-                # use while find method to fix the bug, 
+                # use while find method to fix the bug,
                 # remember replace below arg.annotation.slice.value with type_str
                 '''
                 slice_node = arg.annotation.slice

--- a/python/triton/experimental/tle/raw/mlir/codegen.py
+++ b/python/triton/experimental/tle/raw/mlir/codegen.py
@@ -91,6 +91,17 @@ class EdslMLIRCodeGenerator(ast.NodeVisitor):
             output_tys: List[ir.Type] = []
             output_indices: List[int] = []
             for idx, arg in enumerate(node.args.args):
+                # issue#328 [bug]edsl InOut&Input anno F722 error
+                # https://github.com/flagos-ai/FlagTree/issues/328
+                # use while find method to fix the bug, 
+                # remember replace below arg.annotation.slice.value with type_str
+                '''
+                slice_node = arg.annotation.slice
+                if isinstance(slice_node, ast.Subscript):
+                    type_str = slice_node.slice.value
+                else:
+                    type_str = slice_node.value
+                '''
                 if arg.annotation.value.id == "InOut":
                     ty: ir.Type = ir.Type.parse(arg.annotation.slice.value)
                     operand_tys += [ty]

--- a/python/triton/experimental/tle/raw/mlir/utils.py
+++ b/python/triton/experimental/tle/raw/mlir/utils.py
@@ -4,7 +4,9 @@ from typing import TYPE_CHECKING, Any, Final, List
 from typing_extensions import override
 
 from mlir import ir
-from mlir.dialects import arith, func, llvm
+from mlir.dialects import arith, func, llvm, scf
+import inspect
+import os
 
 if TYPE_CHECKING:
     from .codegen import EdslMLIRCodeGenerator
@@ -70,3 +72,108 @@ class VPrintf(ExternalCall):
 
 def vprintf(*args) -> VPrintf:
     return VPrintf(args)
+
+
+
+class Assert(ExternalCall):
+    def __init__(self, cond, msg, file_name, func_name, line_no, *args, **kwargs) -> None:
+        # keyword 对应底层的符号名
+        super().__init__("__assert_fail", *args, **kwargs)
+        self.cond = cond
+        # 保存元数据
+        self.msg = msg
+        self.file_name = file_name
+        self.func_name = func_name
+        self.line_no = line_no
+        # args 依然保留，用于 vprintf 的动态参数打印
+        self.print_args = args
+
+    @override
+    def build(self) -> func.FuncOp:
+        """
+        定义 __assert_fail 的函数签名，严格对齐 CUDA 标准。
+        void __assert_fail(const char *message, const char *file, 
+                           unsigned int line, const char *function, 
+                           size_t charSize);
+        """
+        ptr_type = ir.Type.parse("!llvm.ptr") # i8*
+        i32_type = ir.IntegerType.get_signless(32)
+        i64_type = ir.IntegerType.get_signless(64)
+        
+        return func.FuncOp(
+            self.keyword, 
+            ir.FunctionType.get(
+                [ptr_type, ptr_type, i32_type, ptr_type, i64_type], 
+                []
+            ),
+            visibility="private"
+        )
+
+    @override
+    def call(self, codegen: EdslMLIRCodeGenerator) -> Any:
+        # 1. 获取函数声明
+        func_op = self.decl(codegen)
+
+        # 2. 条件取反 (Assert 是 "真则过"，底层是 "假则挂")
+        true_const = arith.constant(ir.IntegerType.get_signless(1), 1)
+        is_false = arith.xori(self.cond, true_const)
+
+        # 3. 构建 If 结构 (对应 C++ 中的 splitBlock)
+        if_op = scf.IfOp(is_false)
+        with ir.InsertionPoint(if_op.then_block):
+            
+            # --- 步骤 A: 打印用户友好的动态信息 ---
+            # 因为 __assert_fail 只能打印固定字符串，
+            # 所以我们先调 vprintf 把变量值(args)打印出来给用户看
+            if self.print_args:
+                # 构造 vprintf 调用，传入格式化字符串和参数
+                # 注意：这里我们重新把 self.msg 和 self.print_args 组合传给 VPrintf
+                # 假设 VPrintf 接受 ([fmt, args...]) 形式
+                VPrintf([self.msg, *self.print_args]).call(codegen)
+
+            # --- 步骤 B: 准备 __assert_fail 的静态参数 ---
+            
+            # 1. Message String
+            msg_global = self.global_string(self.msg, codegen)
+            msg_ptr = llvm.AddressOfOp(ir.Type.parse("!llvm.ptr"), msg_global.sym_name.value)
+            
+            # 2. File Name String
+            file_global = self.global_string(self.file_name, codegen)
+            file_ptr = llvm.AddressOfOp(ir.Type.parse("!llvm.ptr"), file_global.sym_name.value)
+            
+            # 3. Line Number (Integer)
+            line_val = arith.constant(ir.IntegerType.get_signless(32), self.line_no)
+            
+            # 4. Function Name String
+            func_global = self.global_string(self.func_name, codegen)
+            func_ptr = llvm.AddressOfOp(ir.Type.parse("!llvm.ptr"), func_global.sym_name.value)
+            
+            # 5. Char Size (通常设为 1 或 sizeof(char))
+            char_size_val = arith.constant(ir.IntegerType.get_signless(64), 1)
+
+            # --- 步骤 C: 调用 __assert_fail ---
+            func.call(
+                [], 
+                ir.FlatSymbolRefAttr.get(func_op.name.value), 
+                [msg_ptr, file_ptr, line_val, func_ptr, char_size_val]
+            )
+            
+            # 理论上 __assert_fail 不会返回，但在 MLIR 中加上 trap 更保险
+            llvm.intr.trap()
+            
+            scf.yield_([])
+
+        return if_op
+
+# 对外接口 vassert
+def vassert(cond, fmt, *args):
+    # 自动获取调用者的位置信息
+    frame = inspect.currentframe().f_back
+    try:
+        filename = os.path.basename(frame.f_code.co_filename) # 只取文件名，不要绝对路径
+        funcname = frame.f_code.co_name
+        lineno = frame.f_lineno
+    finally:
+        del frame # 避免循环引用内存泄漏
+
+    return Assert(cond, fmt, filename, funcname, lineno, *args).call(EdslMLIRCodeGenerator.current)

--- a/python/triton/experimental/tle/raw/mlir/utils.py
+++ b/python/triton/experimental/tle/raw/mlir/utils.py
@@ -140,7 +140,7 @@ class Assert(ExternalCall):
 def vassert(cond, fmt, *args):
     frame = inspect.currentframe().f_back
     try:
-        filename = os.path.basename(frame.f_code.co_filename)  # 只取文件名，不要绝对路径
+        filename = os.path.basename(frame.f_code.co_filename)
         funcname = frame.f_code.co_name
         lineno = frame.f_lineno
     finally:

--- a/python/triton/experimental/tle/raw/mlir/utils.py
+++ b/python/triton/experimental/tle/raw/mlir/utils.py
@@ -74,8 +74,8 @@ def vprintf(*args) -> VPrintf:
     return VPrintf(args)
 
 
-
 class Assert(ExternalCall):
+
     def __init__(self, cond, msg, file_name, func_name, line_no, *args, **kwargs) -> None:
         dependencies = [cond] + list(args)
         super().__init__("__assertfail", dependencies, **kwargs)
@@ -92,11 +92,8 @@ class Assert(ExternalCall):
         i32_type = ir.IntegerType.get_signless(32)
         i64_type = ir.IntegerType.get_signless(64)
 
-        return func.FuncOp(
-            self.keyword,
-            ir.FunctionType.get(
-                [ptr_type, ptr_type, i32_type, ptr_type, i64_type],
-                []),visibility="private")
+        return func.FuncOp(self.keyword, ir.FunctionType.get([ptr_type, ptr_type, i32_type, ptr_type, i64_type], []),
+                           visibility="private")
 
     @override
     def call(self, codegen: EdslMLIRCodeGenerator) -> Any:
@@ -108,39 +105,33 @@ class Assert(ExternalCall):
         if_op = scf.IfOp(is_false)
         with ir.InsertionPoint(if_op.then_block):
 
-
             debug_args = [self.msg]
             if self.print_args:
                 debug_args.extend(self.print_args)
             VPrintf(debug_args).call(codegen)
 
-            
             # 1. Message String
             msg_global = self.global_string(self.msg, codegen)
             msg_ptr = llvm.AddressOfOp(ir.Type.parse("!llvm.ptr"), msg_global.sym_name.value)
-            
+
             # 2. File Name String
             file_global = self.global_string(self.file_name, codegen)
             file_ptr = llvm.AddressOfOp(ir.Type.parse("!llvm.ptr"), file_global.sym_name.value)
-            
+
             # 3. Line Number (Integer)
             line_val = arith.constant(ir.IntegerType.get_signless(32), self.line_no)
-            
+
             # 4. Function Name String
             func_global = self.global_string(self.func_name, codegen)
             func_ptr = llvm.AddressOfOp(ir.Type.parse("!llvm.ptr"), func_global.sym_name.value)
-            
+
             # 5. Char Size
             char_size_val = arith.constant(ir.IntegerType.get_signless(64), 1)
 
             #__assertfail
-            func.call(
-                [], 
-                ir.FlatSymbolRefAttr.get(func_op.name.value), 
-                [msg_ptr, file_ptr, line_val, func_ptr, char_size_val]
-            )
+            func.call([], ir.FlatSymbolRefAttr.get(func_op.name.value),
+                      [msg_ptr, file_ptr, line_val, func_ptr, char_size_val])
 
-            
             scf.yield_([])
 
         return if_op
@@ -149,7 +140,7 @@ class Assert(ExternalCall):
 def vassert(cond, fmt, *args):
     frame = inspect.currentframe().f_back
     try:
-        filename = os.path.basename(frame.f_code.co_filename) # 只取文件名，不要绝对路径
+        filename = os.path.basename(frame.f_code.co_filename)  # 只取文件名，不要绝对路径
         funcname = frame.f_code.co_name
         lineno = frame.f_lineno
     finally:

--- a/python/tutorials/tle/raw/04-hello-world.py
+++ b/python/tutorials/tle/raw/04-hello-world.py
@@ -1,10 +1,10 @@
 import triton
 from triton.experimental.tle.raw import dialect
-from triton.experimental.tle.raw.mlir import vprintf, vassert
+from triton.experimental.tle.raw.mlir import vprintf
 import triton.experimental.tle.language.raw as tle_raw
 import torch
 
-from mlir.dialects import nvvm, arith
+from mlir.dialects import nvvm
 from mlir import ir
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()

--- a/python/tutorials/tle/raw/04-hello-world.py
+++ b/python/tutorials/tle/raw/04-hello-world.py
@@ -1,10 +1,10 @@
 import triton
 from triton.experimental.tle.raw import dialect
-from triton.experimental.tle.raw.mlir import vprintf
+from triton.experimental.tle.raw.mlir import vprintf, vassert
 import triton.experimental.tle.language.raw as tle_raw
 import torch
 
-from mlir.dialects import nvvm
+from mlir.dialects import nvvm, arith
 from mlir import ir
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
@@ -14,6 +14,17 @@ DEVICE = triton.runtime.driver.active.get_active_torch_device()
 def edsl():
     tidx = nvvm.read_ptx_sreg_tid_x(ir.IntegerType.get_signless(32))
     bidx = nvvm.read_ptx_sreg_ctaid_x(ir.IntegerType.get_signless(32))
+    # A. 创建比较常数 (32)
+    limit = arith.constant(ir.IntegerType.get_signless(32), 32)
+    # B. 生成布尔条件 (i1 类型)
+    # cmpi 谓词: slt (signed less than), eq (equal), sgt (signed greater than) 等
+    is_valid_tidx = arith.cmpi(arith.CmpIPredicate.slt, tidx, limit)
+    # ---------------------------------------------------------
+    # 3. 调用 Assert
+    # 语义：如果 is_valid_tidx 为 True，程序继续执行；
+    #       如果 is_valid_tidx 为 False，打印信息并终止 Kernel。
+    # ---------------------------------------------------------
+    vassert(is_valid_tidx, "Assertion Failed: tidx %d is too large (bidx=%d)\n", tidx, bidx)
     vprintf("Hello from bidx %d, tidx %d\n", bidx, tidx)
 
 

--- a/python/tutorials/tle/raw/04-hello-world.py
+++ b/python/tutorials/tle/raw/04-hello-world.py
@@ -14,17 +14,6 @@ DEVICE = triton.runtime.driver.active.get_active_torch_device()
 def edsl():
     tidx = nvvm.read_ptx_sreg_tid_x(ir.IntegerType.get_signless(32))
     bidx = nvvm.read_ptx_sreg_ctaid_x(ir.IntegerType.get_signless(32))
-    # A. 创建比较常数 (32)
-    limit = arith.constant(ir.IntegerType.get_signless(32), 32)
-    # B. 生成布尔条件 (i1 类型)
-    # cmpi 谓词: slt (signed less than), eq (equal), sgt (signed greater than) 等
-    is_valid_tidx = arith.cmpi(arith.CmpIPredicate.slt, tidx, limit)
-    # ---------------------------------------------------------
-    # 3. 调用 Assert
-    # 语义：如果 is_valid_tidx 为 True，程序继续执行；
-    #       如果 is_valid_tidx 为 False，打印信息并终止 Kernel。
-    # ---------------------------------------------------------
-    vassert(is_valid_tidx, "Assertion Failed: tidx %d is too large (bidx=%d)\n", tidx, bidx)
     vprintf("Hello from bidx %d, tidx %d\n", bidx, tidx)
 
 

--- a/python/tutorials/tle/raw/05-topk.py
+++ b/python/tutorials/tle/raw/05-topk.py
@@ -7,7 +7,7 @@ from mlir import ir
 import torch
 import triton
 from triton.experimental.tle.raw import dialect, InOut, Input
-from triton.experimental.tle.raw.mlir import vassert, vprintf
+from triton.experimental.tle.raw.mlir import vassert
 import triton.experimental.tle.language.raw as tle_raw
 import triton.language as tl
 

--- a/python/tutorials/tle/raw/05-topk.py
+++ b/python/tutorials/tle/raw/05-topk.py
@@ -7,6 +7,7 @@ from mlir import ir
 import torch
 import triton
 from triton.experimental.tle.raw import dialect, InOut, Input
+from triton.experimental.tle.raw.mlir import vassert, vprintf
 import triton.experimental.tle.language.raw as tle_raw
 import triton.language as tl
 
@@ -40,6 +41,17 @@ def edsl1(thre_bin_sum_buf: InOut["memref<?xi32, 3>"], l_new_topk_buf: InOut["me
     tidx = nvvm.read_ptx_sreg_tid_x(ir.IntegerType.get_signless(32))
     bidx = nvvm.read_ptx_sreg_ctaid_x(ir.IntegerType.get_signless(32))
     bdimx = nvvm.read_ptx_sreg_ntid_x(ir.IntegerType.get_signless(32))  # blockDim.x
+
+    # --- Start: Runtime Assertion for BlockDim.x == 1024 ---
+    i32_ty = ir.IntegerType.get_signless(32)
+    c1024 = arith.constant(i32_ty, 1024)
+    is_valid_dim = arith.cmpi(arith.CmpIPredicate.eq, bdimx, c1024)
+    c0 = arith.constant(i32_ty, 0)
+    is_not_thread_0 = arith.cmpi(arith.CmpIPredicate.ne, tidx, c0)
+    should_pass = arith.ori(is_valid_dim, is_not_thread_0)
+    vassert(should_pass, "Runtime Error: BlockDim.x is incorrect, expected 1024.\n")
+    # --- End: Runtime Assertion ---
+
     i32_ty = ir.IntegerType.get_signless(32)
     i16_ty = ir.IntegerType.get_signless(16)
     index_ty = ir.IndexType.get()

--- a/python/tutorials/tle/raw/06-test-vassert.py
+++ b/python/tutorials/tle/raw/06-test-vassert.py
@@ -10,6 +10,7 @@ from mlir import ir
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
+
 @dialect(name="mlir")
 def edsl_assert_test():
     tidx = nvvm.read_ptx_sreg_tid_x(ir.IntegerType.get_signless(32))
@@ -31,11 +32,11 @@ def assert_kernel():
 
 def run_test():
     print(">>> Starting Assert Test (Expect Crash)...")
-    
+
     try:
         assert_kernel[(1, )]()
         torch.cuda.synchronize()
-        
+
     except RuntimeError as e:
         msg = str(e)
         if "device-side assert triggered" in msg or "unspecified launch failure" in msg:
@@ -45,12 +46,12 @@ def run_test():
         else:
             print(f"\n❌ [FAIL] Caught unexpected RuntimeError: {msg}")
             return False
-            
+
     except Exception as e:
         print(f"\n❌ [FAIL] Caught unexpected exception: {type(e)}")
         print(e)
         return False
-        
+
     else:
         print("\n❌ [FAIL] Kernel finished without error (Assert did NOT trigger)")
         return False

--- a/python/tutorials/tle/raw/06-test-vassert.py
+++ b/python/tutorials/tle/raw/06-test-vassert.py
@@ -1,0 +1,62 @@
+import triton
+from triton.experimental.tle.raw import dialect
+from triton.experimental.tle.raw.mlir import vprintf, vassert
+import triton.experimental.tle.language.raw as tle_raw
+import torch
+import sys
+
+from mlir.dialects import nvvm, arith
+from mlir import ir
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+@dialect(name="mlir")
+def edsl_assert_test():
+    tidx = nvvm.read_ptx_sreg_tid_x(ir.IntegerType.get_signless(32))
+    bidx = nvvm.read_ptx_sreg_ctaid_x(ir.IntegerType.get_signless(32))
+
+    c0 = arith.constant(ir.IntegerType.get_signless(32), 0)
+    c1 = arith.constant(ir.IntegerType.get_signless(32), 1)
+    cond_false = arith.cmpi(arith.CmpIPredicate.eq, c0, c1)
+
+    vassert(cond_false, "TEST ASSERT: Block %d, Thread %d should fail!\n", bidx, tidx)
+
+    vprintf("ERROR: This line should NOT be reached! bidx=%d\n", bidx)
+
+
+@triton.jit
+def assert_kernel():
+    tle_raw.call(edsl_assert_test, [], [])
+
+
+def run_test():
+    print(">>> Starting Assert Test (Expect Crash)...")
+    
+    try:
+        assert_kernel[(1, )]()
+        torch.cuda.synchronize()
+        
+    except RuntimeError as e:
+        msg = str(e)
+        if "device-side assert triggered" in msg or "unspecified launch failure" in msg:
+            print("\n✅ [SUCCESS] Assert triggered successfully!")
+            print(f"   Captured Error: {msg}")
+            return True
+        else:
+            print(f"\n❌ [FAIL] Caught unexpected RuntimeError: {msg}")
+            return False
+            
+    except Exception as e:
+        print(f"\n❌ [FAIL] Caught unexpected exception: {type(e)}")
+        print(e)
+        return False
+        
+    else:
+        print("\n❌ [FAIL] Kernel finished without error (Assert did NOT trigger)")
+        return False
+
+
+if __name__ == "__main__":
+    success = run_test()
+    if not success:
+        sys.exit(1)


### PR DESCRIPTION
This PR implements the vassert function for the TLE Raw DSL.

Changes:

Implemented vassert in utils.py by targeting the correct __assertfail symbol, enabling native CUDA device-side assertions.

Added a new test case python/tutorials/tle/raw/05-test-assert.py to verify that assertions correctly terminate the kernel and report errors.