### PR TITLE
[DOC] Rename TLE to Triton Language Extensions

### DIFF
--- a/third_party/tle/README.md
+++ b/third_party/tle/README.md
@@ -1,4 +1,4 @@
-# TLE (Tensor Language Extension)
+# TLE (Triton Language Extensions)
 
 <!-- flagtree tle -->
 


### PR DESCRIPTION
Updated the title to reflect the correct name of the extension.