### PR TITLE
[CI] Change runner label from iluvatar to flagtree-iluvatar

### DIFF
--- a/.github/workflows/iluvatar-build-and-test.yml
+++ b/.github/workflows/iluvatar-build-and-test.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   iluvatar-build-and-test:
-    runs-on: iluvatar
+    runs-on: flagtree-iluvatar
     if: ${{ github.repository == 'FlagTree/flagtree' || github.repository == 'flagos-ai/flagtree' }}
     steps:
       - name: Setup environment


### PR DESCRIPTION
Because flagos-ai added some runner on label iluvatar, so FlagTree changes the runner label to flagtree-iluvatar.