### PR TITLE
[TLE] gate 3.6 diffs and align language import paths

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -1,5 +1,7 @@
 #include "triton/Analysis/AxisInfo.h"
+#ifdef __TLE__
 #include "triton/Dialect/Triton/IR/Types.h"
+#endif
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/MMAv5PipelineUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
@@ -103,6 +105,7 @@ public:
                          tt::ModuleAxisInfoAnalysis &axisInfoAnalysis,
                          bool filterSmall) {
     if (auto loadOp = dyn_cast<tt::LoadOp>(op)) {
+#ifdef __TLE__
       auto ptrTy = loadOp.getPtr().getType();
       if (auto tensorTy = dyn_cast<RankedTensorType>(ptrTy))
         ptrTy = tensorTy.getElementType();
@@ -111,6 +114,7 @@ public:
         // Shared-memory loads should not be pipelined into async global copies.
         return false;
       }
+#endif
       if (filterSmall && !canBeConvertedToAsyncLoad(loadOp, axisInfoAnalysis)) {
         LDBG("Load " << *loadOp << " is too small for pipelining");
         return false;

--- a/lib/Dialect/TritonGPU/Transforms/ProcessSharedMemoryHint.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/ProcessSharedMemoryHint.cpp
@@ -40,8 +40,7 @@ struct ProcessSharedMemoryHintPass
                  allocDescType.getShape().end());
     auto viewDescType = triton::gpu::MemDescType::get(
         shape, allocDescType.getElementType(), allocDescType.getEncoding(),
-        allocDescType.getMemorySpace(), allocDescType.getMutableMemory(),
-        /*allocShape=*/allocDescType.getAllocShape());
+        allocDescType.getMemorySpace(), allocDescType.getMutableMemory());
     return builder.create<triton::gpu::MemDescIndexOp>(
         alloc.getLoc(), viewDescType, alloc, idx);
   }

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1669,16 +1669,17 @@ bool comesFromLoadOrBlockArg(Value v) {
   }
   // We also accept block arguments as they appear in many MLIR tests
   // If this is problematic we can totally drop them
-  return isa<BlockArgument>(v) ||
-         (v.getDefiningOp() &&
-          (isa<LoadOp, DescriptorLoadOp, DescriptorGatherOp>(
-               v.getDefiningOp()) ||
-           // flagtree tle.gpu.memory_space: Also accept values coming from
-           // shared memory
-           (v.getDefiningOp()->hasAttrOfType<StringAttr>("tt.memory_space") &&
-            v.getDefiningOp()
-                    ->getAttrOfType<StringAttr>("tt.memory_space")
-                    .getValue() == "shared_memory")));
+  Operation *def = v.getDefiningOp();
+  bool fromLoad = def && isa<LoadOp, DescriptorLoadOp, DescriptorGatherOp>(def);
+#ifdef __TLE__
+  bool fromSharedMemory =
+      def && def->hasAttrOfType<StringAttr>("tt.memory_space") &&
+      def->getAttrOfType<StringAttr>("tt.memory_space").getValue() ==
+          "shared_memory";
+  return isa<BlockArgument>(v) || fromLoad || fromSharedMemory;
+#else
+  return isa<BlockArgument>(v) || fromLoad;
+#endif
 }
 
 SmallVector<Value> getTiedArgs(Operation *op, int resultIdx) {

--- a/python/test/tle/integration/test_tle_distributed.py
+++ b/python/test/tle/integration/test_tle_distributed.py
@@ -16,13 +16,12 @@ import re
 import torch
 import triton
 import triton.language as tl
-import triton.experimental.tle as tled
-import triton.experimental.tle.language.gpu as tleg
+import triton.experimental.tle.language as tle
 
-BLOCK_CLUSTER_MESH = tled.device_mesh({"block_cluster": [("cluster_x", 2)]})
-BLOCK_CLUSTER_MESH_8 = tled.device_mesh({"block_cluster": [("cluster_x", 8)]})
-BLOCK_CLUSTER_MESH_2X2 = tled.device_mesh({"block_cluster": [("cluster_x", 2), ("cluster_y", 2)]})
-BLOCK_GRID_MESH_8 = tled.device_mesh({"block": [("block_x", 8)]})
+BLOCK_CLUSTER_MESH = tle.device_mesh({"block_cluster": [("cluster_x", 2)]})
+BLOCK_CLUSTER_MESH_8 = tle.device_mesh({"block_cluster": [("cluster_x", 8)]})
+BLOCK_CLUSTER_MESH_2X2 = tle.device_mesh({"block_cluster": [("cluster_x", 2), ("cluster_y", 2)]})
+BLOCK_GRID_MESH_8 = tle.device_mesh({"block": [("block_x", 8)]})
 BLOCK_CLUSTER_SUBMESH_ROW0 = BLOCK_CLUSTER_MESH_2X2[0, :]
 BLOCK_CLUSTER_SUBMESH_ROW1 = BLOCK_CLUSTER_MESH_2X2[1, :]
 BLOCK_CLUSTER_SUBMESH_COL0 = BLOCK_CLUSTER_MESH_2X2[:, 0]
@@ -47,7 +46,7 @@ def _distributed_barrier_copy_kernel(x_ptr, out_ptr, numel, BLOCK: tl.constexpr)
     offs = tl.arange(0, BLOCK)
     mask = offs < numel
     vals = tl.load(x_ptr + offs, mask=mask, other=0.0)
-    tled.distributed_barrier()
+    tle.distributed_barrier()
     tl.store(out_ptr + offs, vals, mask=mask)
 
 
@@ -57,9 +56,9 @@ def _remote_roundtrip_kernel(x_ptr, out_ptr, numel, BLOCK: tl.constexpr):
     mask = offs < numel
     vals = tl.load(x_ptr + offs, mask=mask, other=0.0)
 
-    smem = tleg.alloc([BLOCK], dtype=tl.float32, layout=None, scope=tleg.smem, nv_mma_shared_layout=False)
-    remote_smem = tled.remote(smem, 0)
-    local_ptr = tleg.local_ptr(remote_smem, (tl.arange(0, BLOCK), ))
+    smem = tle.gpu.alloc([BLOCK], dtype=tl.float32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    remote_smem = tle.remote(smem, 0)
+    local_ptr = tle.gpu.local_ptr(remote_smem, (tl.arange(0, BLOCK), ))
     tl.store(local_ptr, vals, mask=mask)
 
     out_vals = tl.load(local_ptr, mask=mask, other=0.0)
@@ -72,14 +71,14 @@ def _remote_peer_smem_kernel(out_ptr, shard_id_ptr, mesh: tl.constexpr, BLOCK: t
     pid = tl.program_id(0)
     vals = tl.cast(offs + pid * BLOCK, tl.float32)
 
-    smem = tleg.alloc([BLOCK], dtype=tl.float32, layout=None, scope=tleg.smem, nv_mma_shared_layout=False)
-    local_ptr = tleg.local_ptr(smem, (offs, ))
+    smem = tle.gpu.alloc([BLOCK], dtype=tl.float32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    local_ptr = tle.gpu.local_ptr(smem, (offs, ))
     tl.store(local_ptr, vals)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     shard_id = tl.load(shard_id_ptr + pid)
-    remote_smem = tled.remote(smem, shard_id, scope=mesh)
-    peer_ptr = tleg.local_ptr(remote_smem, (offs, ))
+    remote_smem = tle.remote(smem, shard_id, scope=mesh)
+    peer_ptr = tle.gpu.local_ptr(remote_smem, (offs, ))
     peer_vals = tl.load(peer_ptr)
     tl.store(out_ptr + pid * BLOCK + offs, peer_vals)
 
@@ -89,20 +88,20 @@ def _remote_mixed_local_remote_same_buffer_kernel(out_ptr, shard_id_ptr, mesh: t
     offs = tl.arange(0, BLOCK)
     pid = tl.program_id(0)
     vals = tl.cast(offs + pid * BLOCK, tl.float32)
-    rank = tled.shard_id(mesh, "cluster_x")
+    rank = tle.shard_id(mesh, "cluster_x")
 
-    smem = tleg.alloc([BLOCK], dtype=tl.float32, layout=None, scope=tleg.smem, nv_mma_shared_layout=False)
+    smem = tle.gpu.alloc([BLOCK], dtype=tl.float32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
     shard_id = tl.load(shard_id_ptr + pid)
-    remote_smem = tled.remote(smem, shard_id, scope=mesh)
+    remote_smem = tle.remote(smem, shard_id, scope=mesh)
 
-    local_ptr = tleg.local_ptr(smem, (offs, ))
+    local_ptr = tle.gpu.local_ptr(smem, (offs, ))
     tl.store(local_ptr, vals)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     if rank == 0:
         mixed = tl.load(local_ptr)
     else:
-        remote_ptr = tleg.local_ptr(remote_smem, (offs, ))
+        remote_ptr = tle.gpu.local_ptr(remote_smem, (offs, ))
         mixed = tl.load(remote_ptr)
     tl.store(out_ptr + pid * BLOCK + offs, mixed)
 
@@ -120,17 +119,17 @@ def _remote_peer_smem_2d_kernel(
     cols = tl.broadcast_to(tl.arange(0, BLOCK_K)[None, :], (BLOCK_M, BLOCK_K))
     vals = tl.cast(rows * BLOCK_K + cols + pid * BLOCK_M * BLOCK_K, tl.float32)
 
-    smem = tleg.alloc([BLOCK_M, BLOCK_K], dtype=tl.float32, layout=None, scope=tleg.smem, nv_mma_shared_layout=False)
-    local_ptr = tleg.local_ptr(smem, (rows, cols))
+    smem = tle.gpu.alloc([BLOCK_M, BLOCK_K], dtype=tl.float32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    local_ptr = tle.gpu.local_ptr(smem, (rows, cols))
     tl.store(local_ptr, vals)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     shard_id = tl.load(shard_id_ptr + pid)
-    remote_buffer = tled.remote(smem, shard_id, scope=mesh)
-    remote_ptr = tleg.local_ptr(remote_buffer, (rows, cols))
+    remote_buffer = tle.remote(smem, shard_id, scope=mesh)
+    remote_ptr = tle.gpu.local_ptr(remote_buffer, (rows, cols))
     peer_vals = tl.load(remote_ptr)
     # Ensure peer CTA finishes remote reads before either side reuses smem.
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     out_ptrs = out_ptr + pid * BLOCK_M * BLOCK_K + rows * BLOCK_K + cols
     tl.store(out_ptrs, peer_vals)
@@ -142,14 +141,14 @@ def _remote_const_shard_load_kernel(out_ptr, mesh: tl.constexpr, BLOCK: tl.const
     pid = tl.program_id(0)
     vals = tl.cast(offs + pid * BLOCK, tl.float16)
 
-    smem = tleg.alloc([BLOCK], dtype=tl.float16, layout=None, scope=tleg.smem, nv_mma_shared_layout=False)
-    local_ptr = tleg.local_ptr(smem, (offs, ))
+    smem = tle.gpu.alloc([BLOCK], dtype=tl.float16, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    local_ptr = tle.gpu.local_ptr(smem, (offs, ))
     tl.store(local_ptr, vals)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     # Compile-time shard id path should lower to remote cluster load.
-    remote_buffer = tled.remote(smem, 0, scope=mesh)
-    remote_ptr = tleg.local_ptr(remote_buffer, (offs, ))
+    remote_buffer = tle.remote(smem, 0, scope=mesh)
+    remote_ptr = tle.gpu.local_ptr(remote_buffer, (offs, ))
     peer_vals = tl.load(remote_ptr)
     tl.store(out_ptr + pid * BLOCK + offs, peer_vals)
 
@@ -166,15 +165,15 @@ def _remote_const_shard_vectorized_load_kernel(
     cols = tl.broadcast_to(tl.arange(0, BLOCK_K)[None, :], (BLOCK_M, BLOCK_K))
     vals = tl.cast(rows * BLOCK_K + cols + pid * BLOCK_M * BLOCK_K, tl.float16)
 
-    smem = tleg.alloc([BLOCK_M, BLOCK_K], dtype=tl.float16, layout=None, scope=tleg.smem, nv_mma_shared_layout=False)
-    local_ptr = tleg.local_ptr(smem, (rows, cols))
+    smem = tle.gpu.alloc([BLOCK_M, BLOCK_K], dtype=tl.float16, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    local_ptr = tle.gpu.local_ptr(smem, (rows, cols))
     tl.store(local_ptr, vals)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
-    remote_buffer = tled.remote(smem, 0, scope=mesh)
-    remote_ptr = tleg.local_ptr(remote_buffer, (rows, cols))
+    remote_buffer = tle.remote(smem, 0, scope=mesh)
+    remote_ptr = tle.gpu.local_ptr(remote_buffer, (rows, cols))
     peer_vals = tl.load(remote_ptr)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     out_ptrs = out_ptr + pid * BLOCK_M * BLOCK_K + rows * BLOCK_K + cols
     tl.store(out_ptrs, peer_vals)
@@ -183,9 +182,9 @@ def _remote_const_shard_vectorized_load_kernel(
 @triton.jit
 def _remote_pointer_input_disallowed_kernel(out_ptr, mesh: tl.constexpr, BLOCK: tl.constexpr):
     offs = tl.arange(0, BLOCK)
-    smem = tleg.alloc([BLOCK], dtype=tl.float16, layout=None, scope=tleg.smem, nv_mma_shared_layout=False)
-    local_ptr = tleg.local_ptr(smem, (offs, ))
-    remote_ptr = tled.remote(local_ptr, 0, scope=mesh)
+    smem = tle.gpu.alloc([BLOCK], dtype=tl.float16, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    local_ptr = tle.gpu.local_ptr(smem, (offs, ))
+    remote_ptr = tle.remote(local_ptr, 0, scope=mesh)
     vals = tl.load(remote_ptr)
     tl.store(out_ptr + offs, vals)
 
@@ -202,15 +201,15 @@ def _remote_buffer_const_shard_vectorized_load_kernel(
     cols = tl.broadcast_to(tl.arange(0, BLOCK_K)[None, :], (BLOCK_M, BLOCK_K))
     vals = tl.cast(rows * BLOCK_K + cols + pid * BLOCK_M * BLOCK_K, tl.float16)
 
-    smem = tleg.alloc([BLOCK_M, BLOCK_K], dtype=tl.float16, layout=None, scope=tleg.smem, nv_mma_shared_layout=False)
-    local_ptr = tleg.local_ptr(smem, (rows, cols))
+    smem = tle.gpu.alloc([BLOCK_M, BLOCK_K], dtype=tl.float16, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    local_ptr = tle.gpu.local_ptr(smem, (rows, cols))
     tl.store(local_ptr, vals)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
-    remote_buffer = tled.remote(smem, 0, scope=mesh)
-    remote_ptr = tleg.local_ptr(remote_buffer, (rows, cols))
+    remote_buffer = tle.remote(smem, 0, scope=mesh)
+    remote_ptr = tle.gpu.local_ptr(remote_buffer, (rows, cols))
     peer_vals = tl.load(remote_ptr)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     out_ptrs = out_ptr + pid * BLOCK_M * BLOCK_K + rows * BLOCK_K + cols
     tl.store(out_ptrs, peer_vals)
@@ -230,15 +229,15 @@ def _remote_buffer_const_shard_vectorized_load_rank3_kernel(
     vals = tl.cast(rows * BLOCK_K + cols + pid * BLOCK_M * BLOCK_K, tl.float16)
     slots = tl.zeros((BLOCK_M, BLOCK_K), dtype=tl.int32) + SLOT
 
-    smem = tleg.alloc([2, BLOCK_M, BLOCK_K], dtype=tl.float16, layout=None, scope=tleg.smem, nv_mma_shared_layout=False)
-    local_ptr = tleg.local_ptr(smem, (slots, rows, cols))
+    smem = tle.gpu.alloc([2, BLOCK_M, BLOCK_K], dtype=tl.float16, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    local_ptr = tle.gpu.local_ptr(smem, (slots, rows, cols))
     tl.store(local_ptr, vals)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
-    remote_buffer = tled.remote(smem, 0, scope=mesh)
-    remote_ptr = tleg.local_ptr(remote_buffer, (slots, rows, cols))
+    remote_buffer = tle.remote(smem, 0, scope=mesh)
+    remote_ptr = tle.gpu.local_ptr(remote_buffer, (slots, rows, cols))
     peer_vals = tl.load(remote_ptr)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     out_ptrs = out_ptr + pid * BLOCK_M * BLOCK_K + rows * BLOCK_K + cols
     tl.store(out_ptrs, peer_vals)
@@ -249,25 +248,25 @@ def _submesh_barrier_lowering_kernel(out_ptr, mesh: tl.constexpr, BLOCK: tl.cons
     offs = tl.arange(0, BLOCK)
     pid = tl.program_id(0)
     vals = tl.full((BLOCK, ), pid, tl.int32)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
     tl.store(out_ptr + pid * BLOCK + offs, vals)
 
 
 @triton.jit
 def _remote_rank0_dsmem_atomic_add_kernel(out_ptr, mesh: tl.constexpr):
-    rank = tled.shard_id(mesh, "cluster_x")
+    rank = tle.shard_id(mesh, "cluster_x")
     idx = tl.arange(0, 1)
-    smem = tleg.alloc([1], dtype=tl.int32, layout=None, scope=tleg.smem, nv_mma_shared_layout=False)
-    counter_ptr = tleg.local_ptr(smem, (idx, ))
+    smem = tle.gpu.alloc([1], dtype=tl.int32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    counter_ptr = tle.gpu.local_ptr(smem, (idx, ))
 
     if rank == 0:
         tl.store(counter_ptr, 0)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
-    remote_rank0 = tled.remote(smem, 0, scope=mesh)
-    remote_ptr = tleg.local_ptr(remote_rank0, (idx, ))
+    remote_rank0 = tle.remote(smem, 0, scope=mesh)
+    remote_ptr = tle.gpu.local_ptr(remote_rank0, (idx, ))
     tl.atomic_add(remote_ptr, 1, sem="relaxed", scope="cta")
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     if rank == 0:
         counter = tl.load(counter_ptr)
@@ -276,23 +275,23 @@ def _remote_rank0_dsmem_atomic_add_kernel(out_ptr, mesh: tl.constexpr):
 
 @triton.jit
 def _remote_scan_shared_scratch_kernel(out_ptr, mesh: tl.constexpr, BLOCK: tl.constexpr):
-    rank = tled.shard_id(mesh, "cluster_x")
+    rank = tle.shard_id(mesh, "cluster_x")
     offs = tl.arange(0, BLOCK)
 
-    smem = tleg.alloc([BLOCK], dtype=tl.int32, layout=None, scope=tleg.smem, nv_mma_shared_layout=False)
-    local_ptr = tleg.local_ptr(smem, (offs, ))
+    smem = tle.gpu.alloc([BLOCK], dtype=tl.int32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    local_ptr = tle.gpu.local_ptr(smem, (offs, ))
     if rank == 0:
         tl.store(local_ptr, offs)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     if rank == 0:
         vals = tl.load(local_ptr)
         prefix = tl.cumsum(vals, axis=0)
         tl.store(local_ptr, prefix)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
-    remote_rank0 = tled.remote(smem, 0, scope=mesh)
-    remote_ptr = tleg.local_ptr(remote_rank0, (offs, ))
+    remote_rank0 = tle.remote(smem, 0, scope=mesh)
+    remote_ptr = tle.gpu.local_ptr(remote_rank0, (offs, ))
     remote_vals = tl.load(remote_ptr)
     tl.store(out_ptr + rank * BLOCK + offs, remote_vals)
 
@@ -304,7 +303,7 @@ def _distributed_barrier_multiblock_counter_kernel(counter_ptr, out_ptr, mesh: t
     counter_lane_ptr = counter_ptr + cluster_id
 
     tl.atomic_add(counter_lane_ptr, 1)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     seen = tl.load(counter_lane_ptr)
     tl.store(out_ptr + pid, seen)
@@ -314,7 +313,7 @@ def _distributed_barrier_multiblock_counter_kernel(counter_ptr, out_ptr, mesh: t
 def _distributed_barrier_grid_counter_kernel(counter_ptr, out_ptr, mesh: tl.constexpr):
     pid = tl.program_id(0)
     tl.atomic_add(counter_ptr, 1)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
     seen = tl.load(counter_ptr)
     tl.store(out_ptr + pid, seen)
 
@@ -332,7 +331,7 @@ def _submesh_row_group_barrier_kernel(
 
     if pid < 2:
         tl.atomic_add(counter_row0_ptr, 1)
-        tled.distributed_barrier(row0_mesh)
+        tle.distributed_barrier(row0_mesh)
         seen_row0 = tl.load(counter_row0_ptr)
         tl.store(out_row0_ptr + pid, seen_row0)
     else:
@@ -340,7 +339,7 @@ def _submesh_row_group_barrier_kernel(
 
     if pid >= 2:
         tl.atomic_add(counter_row1_ptr, 3)
-        tled.distributed_barrier(row1_mesh)
+        tle.distributed_barrier(row1_mesh)
         seen_row1 = tl.load(counter_row1_ptr)
         tl.store(out_row1_ptr + pid, seen_row1)
     else:
@@ -361,7 +360,7 @@ def _submesh_col_group_barrier_kernel(
 
     if is_col0:
         tl.atomic_add(counter_col0_ptr, 1)
-        tled.distributed_barrier(col0_mesh)
+        tle.distributed_barrier(col0_mesh)
         seen_col0 = tl.load(counter_col0_ptr)
         tl.store(out_col0_ptr + pid, seen_col0)
     else:
@@ -369,7 +368,7 @@ def _submesh_col_group_barrier_kernel(
 
     if not is_col0:
         tl.atomic_add(counter_col1_ptr, 5)
-        tled.distributed_barrier(col1_mesh)
+        tle.distributed_barrier(col1_mesh)
         seen_col1 = tl.load(counter_col1_ptr)
         tl.store(out_col1_ptr + pid, seen_col1)
     else:
@@ -397,7 +396,7 @@ def _remote_cluster_gemm_kernel(
     CLUSTER_SIZE: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    cluster_rank = tled.shard_id(mesh, "cluster_x")
+    cluster_rank = tle.shard_id(mesh, "cluster_x")
     cluster_id = pid // CLUSTER_SIZE
     offs_m = tl.arange(0, BM)
     offs_n = tl.arange(0, BN)
@@ -405,12 +404,12 @@ def _remote_cluster_gemm_kernel(
     a_idx_m = tl.broadcast_to(offs_m[:, None], (BM, BK))
     a_idx_k = tl.broadcast_to(offs_k[None, :], (BM, BK))
     a_flat_idx = a_idx_m * BK + a_idx_k
-    a_buf = tleg.alloc([BM * BK], dtype=tl.float16, layout=None, scope=tleg.smem, nv_mma_shared_layout=False)
-    a_local_ptr = tleg.local_ptr(a_buf, (a_flat_idx, ))
+    a_buf = tle.gpu.alloc([BM * BK], dtype=tl.float16, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    a_local_ptr = tle.gpu.local_ptr(a_buf, (a_flat_idx, ))
     acc = tl.zeros((BM, BN), dtype=tl.float32)
     b_col = cluster_rank * BN + offs_n
     remote_shard_id = tl.load(shard_id_ptr + pid)
-    a_buf_remote = tled.remote(a_buf, remote_shard_id, scope=mesh)
+    a_buf_remote = tle.remote(a_buf, remote_shard_id, scope=mesh)
 
     for k0 in range(0, K, BK):
         if cluster_rank == 0:
@@ -418,24 +417,24 @@ def _remote_cluster_gemm_kernel(
             a_tile = tl.load(a_tile_gptr)
             tl.store(a_local_ptr, a_tile)
 
-        tled.distributed_barrier(mesh)
+        tle.distributed_barrier(mesh)
 
         if cluster_rank == 0:
             for kk in range(0, BK):
                 a_col_idx = offs_m * BK + kk
-                a_col_ptr = tleg.local_ptr(a_buf, (a_col_idx, ))
+                a_col_ptr = tle.gpu.local_ptr(a_buf, (a_col_idx, ))
                 a_vals = tl.cast(tl.load(a_col_ptr), tl.float32)
                 b_vals = tl.cast(tl.load(b_ptr + (k0 + kk) * stride_bk + b_col * stride_bn), tl.float32)
                 acc += tl.expand_dims(a_vals, 1) * tl.expand_dims(b_vals, 0)
         else:
             for kk in range(0, BK):
                 a_col_idx = offs_m * BK + kk
-                a_col_ptr = tleg.local_ptr(a_buf_remote, (a_col_idx, ))
+                a_col_ptr = tle.gpu.local_ptr(a_buf_remote, (a_col_idx, ))
                 a_vals = tl.cast(tl.load(a_col_ptr), tl.float32)
                 b_vals = tl.cast(tl.load(b_ptr + (k0 + kk) * stride_bk + b_col * stride_bn), tl.float32)
                 acc += tl.expand_dims(a_vals, 1) * tl.expand_dims(b_vals, 0)
 
-        tled.distributed_barrier(mesh)
+        tle.distributed_barrier(mesh)
 
     c_col = cluster_rank * BN + offs_n
     c_cluster_base = c_ptr + cluster_id * stride_cc
@@ -446,7 +445,7 @@ def _remote_cluster_gemm_kernel(
 @triton.jit
 def _shard_id_axis_kernel(out_ptr, mesh: tl.constexpr):
     pid = tl.program_id(0)
-    sid = tled.shard_id(mesh, "cluster_x")
+    sid = tle.shard_id(mesh, "cluster_x")
     tl.store(out_ptr + pid, sid)
 
 
@@ -474,7 +473,7 @@ def _remote_dot_dotk32_kernel(
     A_SLOTS: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    cluster_rank = tled.shard_id(mesh, "cluster_x")
+    cluster_rank = tle.shard_id(mesh, "cluster_x")
     cluster_id = pid // CLUSTER_SIZE
     num_pid_n = tl.cdiv(N, BN)
     num_pid_n_group = tl.cdiv(num_pid_n, CLUSTER_SIZE)
@@ -488,11 +487,11 @@ def _remote_dot_dotk32_kernel(
     a_rows_full = tl.broadcast_to(tl.arange(0, BM)[:, None], (BM, BK))
     a_cols_full = tl.broadcast_to(tl.arange(0, BK)[None, :], (BM, BK))
     a_rows = tl.broadcast_to(tl.arange(0, BM)[:, None], (BM, DOT_K))
-    a_buf = tleg.alloc([A_SLOTS, BM, BK], dtype=tl.float16, layout=None, scope=tleg.smem, nv_mma_shared_layout=False)
+    a_buf = tle.gpu.alloc([A_SLOTS, BM, BK], dtype=tl.float16, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
 
     acc = tl.zeros((BM, BN), dtype=tl.float32)
     shard_id = tl.load(shard_id_ptr + pid)
-    a_buf_remote = tled.remote(a_buf, shard_id, scope=mesh)
+    a_buf_remote = tle.remote(a_buf, shard_id, scope=mesh)
     for k0 in range(0, K, BK):
         iter_idx = k0 // BK
         slot = iter_idx % A_SLOTS
@@ -500,27 +499,27 @@ def _remote_dot_dotk32_kernel(
         if cluster_rank == 0:
             a_ptrs = a_ptr + offs_m[:, None] * stride_am + (k0 + offs_k)[None, :] * stride_ak
             a_tile = tl.load(a_ptrs)
-            a_local_ptr_tile = tleg.local_ptr(a_buf, (slot_full, a_rows_full, a_cols_full))
+            a_local_ptr_tile = tle.gpu.local_ptr(a_buf, (slot_full, a_rows_full, a_cols_full))
             tl.store(a_local_ptr_tile, a_tile)
 
-        tled.distributed_barrier(mesh)
+        tle.distributed_barrier(mesh)
 
         for ks in range(0, BK, DOT_K):
             k_local = ks + tl.arange(0, DOT_K)
             a_cols = tl.broadcast_to(k_local[None, :], (BM, DOT_K))
             slot_dot = tl.zeros((BM, DOT_K), dtype=tl.int32) + slot
-            a_ptr_local = tleg.local_ptr(a_buf, (slot_dot, a_rows, a_cols))
+            a_ptr_local = tle.gpu.local_ptr(a_buf, (slot_dot, a_rows, a_cols))
             if cluster_rank == 0:
                 a = tl.load(a_ptr_local)
             else:
-                a_ptr_remote = tleg.local_ptr(a_buf_remote, (slot_dot, a_rows, a_cols))
+                a_ptr_remote = tle.gpu.local_ptr(a_buf_remote, (slot_dot, a_rows, a_cols))
                 a = tl.load(a_ptr_remote)
 
             b_ptrs = b_ptr + (k0 + k_local)[:, None] * stride_bk + offs_n[None, :] * stride_bn
             b = tl.load(b_ptrs)
             acc = tl.dot(a, b, acc)
 
-        tled.distributed_barrier(mesh)
+        tle.distributed_barrier(mesh)
 
     c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
     tl.store(c_ptrs, acc.to(c_ptr.dtype.element_ty))
@@ -551,7 +550,7 @@ def _remote_dot_masked_kernel(
     A_SLOTS: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    cluster_rank = tled.shard_id(mesh, "cluster_x")
+    cluster_rank = tle.shard_id(mesh, "cluster_x")
     cluster_id = pid // CLUSTER_SIZE
     num_pid_n = tl.cdiv(N, BN)
     num_pid_n_group = tl.cdiv(num_pid_n, CLUSTER_SIZE)
@@ -565,11 +564,11 @@ def _remote_dot_masked_kernel(
     a_rows_full = tl.broadcast_to(tl.arange(0, BM)[:, None], (BM, BK))
     a_cols_full = tl.broadcast_to(tl.arange(0, BK)[None, :], (BM, BK))
     a_rows = tl.broadcast_to(tl.arange(0, BM)[:, None], (BM, DOT_K))
-    a_buf = tleg.alloc([A_SLOTS, BM, BK], dtype=tl.float16, layout=None, scope=tleg.smem, nv_mma_shared_layout=False)
+    a_buf = tle.gpu.alloc([A_SLOTS, BM, BK], dtype=tl.float16, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
 
     acc = tl.zeros((BM, BN), dtype=tl.float32)
     shard_id = tl.load(shard_id_ptr + pid)
-    a_buf_remote = tled.remote(a_buf, shard_id, scope=mesh)
+    a_buf_remote = tle.remote(a_buf, shard_id, scope=mesh)
     for k0 in range(0, K, BK):
         iter_idx = k0 // BK
         slot = iter_idx % A_SLOTS
@@ -581,25 +580,25 @@ def _remote_dot_masked_kernel(
                 a_tile = tl.load(a_ptrs, mask=a_mask_tile, other=0.0)
             else:
                 a_tile = tl.load(a_ptrs)
-            a_local_ptr_tile = tleg.local_ptr(a_buf, (slot_full, a_rows_full, a_cols_full))
+            a_local_ptr_tile = tle.gpu.local_ptr(a_buf, (slot_full, a_rows_full, a_cols_full))
             if USE_MASK:
                 tl.store(a_local_ptr_tile, a_tile, mask=a_mask_tile)
             else:
                 tl.store(a_local_ptr_tile, a_tile)
 
-        tled.distributed_barrier(mesh)
+        tle.distributed_barrier(mesh)
 
         for ks in range(0, BK, DOT_K):
             k_local = ks + tl.arange(0, DOT_K)
             a_cols = tl.broadcast_to(k_local[None, :], (BM, DOT_K))
             slot_dot = tl.zeros((BM, DOT_K), dtype=tl.int32) + slot
-            a_ptr_local = tleg.local_ptr(a_buf, (slot_dot, a_rows, a_cols))
+            a_ptr_local = tle.gpu.local_ptr(a_buf, (slot_dot, a_rows, a_cols))
             if USE_MASK:
                 a_mask = (offs_m[:, None] < M) & ((k0 + k_local)[None, :] < K)
                 if cluster_rank == 0:
                     a = tl.load(a_ptr_local, mask=a_mask, other=0.0)
                 else:
-                    a_ptr_remote = tleg.local_ptr(a_buf_remote, (slot_dot, a_rows, a_cols))
+                    a_ptr_remote = tle.gpu.local_ptr(a_buf_remote, (slot_dot, a_rows, a_cols))
                     a = tl.load(a_ptr_remote, mask=a_mask, other=0.0)
                 b_ptrs = b_ptr + (k0 + k_local)[:, None] * stride_bk + offs_n[None, :] * stride_bn
                 b_mask = ((k0 + k_local)[:, None] < K) & (offs_n[None, :] < N)
@@ -608,13 +607,13 @@ def _remote_dot_masked_kernel(
                 if cluster_rank == 0:
                     a = tl.load(a_ptr_local)
                 else:
-                    a_ptr_remote = tleg.local_ptr(a_buf_remote, (slot_dot, a_rows, a_cols))
+                    a_ptr_remote = tle.gpu.local_ptr(a_buf_remote, (slot_dot, a_rows, a_cols))
                     a = tl.load(a_ptr_remote)
                 b_ptrs = b_ptr + (k0 + k_local)[:, None] * stride_bk + offs_n[None, :] * stride_bn
                 b = tl.load(b_ptrs)
             acc = tl.dot(a, b, acc)
 
-        tled.distributed_barrier(mesh)
+        tle.distributed_barrier(mesh)
 
     c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
     if USE_MASK:
@@ -648,7 +647,7 @@ def _remote_dot_prefetch_kernel(
     A_SLOTS: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    cluster_rank = tled.shard_id(mesh, "cluster_x")
+    cluster_rank = tle.shard_id(mesh, "cluster_x")
     cluster_id = pid // CLUSTER_SIZE
     num_pid_n = tl.cdiv(N, BN)
     num_pid_n_group = tl.cdiv(num_pid_n, CLUSTER_SIZE)
@@ -662,20 +661,20 @@ def _remote_dot_prefetch_kernel(
     a_rows_full = tl.broadcast_to(tl.arange(0, BM)[:, None], (BM, BK))
     a_cols_full = tl.broadcast_to(tl.arange(0, BK)[None, :], (BM, BK))
     a_rows = tl.broadcast_to(tl.arange(0, BM)[:, None], (BM, DOT_K))
-    a_buf = tleg.alloc([A_SLOTS, BM, BK], dtype=tl.float16, layout=None, scope=tleg.smem, nv_mma_shared_layout=False)
+    a_buf = tle.gpu.alloc([A_SLOTS, BM, BK], dtype=tl.float16, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
 
     acc = tl.zeros((BM, BN), dtype=tl.float32)
     shard_id = tl.load(shard_id_ptr + pid)
-    a_buf_remote = tled.remote(a_buf, shard_id, scope=mesh)
+    a_buf_remote = tle.remote(a_buf, shard_id, scope=mesh)
 
     slot0 = 0
     slot0_full = tl.zeros((BM, BK), dtype=tl.int32) + slot0
     if cluster_rank == 0:
         a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
         a_tile = tl.load(a_ptrs)
-        a_local_ptr_tile = tleg.local_ptr(a_buf, (slot0_full, a_rows_full, a_cols_full))
+        a_local_ptr_tile = tle.gpu.local_ptr(a_buf, (slot0_full, a_rows_full, a_cols_full))
         tl.store(a_local_ptr_tile, a_tile)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     for k0 in range(0, K, BK):
         iter_idx = k0 // BK
@@ -684,7 +683,7 @@ def _remote_dot_prefetch_kernel(
             k_local = ks + tl.arange(0, DOT_K)
             a_cols = tl.broadcast_to(k_local[None, :], (BM, DOT_K))
             slot_dot = tl.zeros((BM, DOT_K), dtype=tl.int32) + slot
-            a_ptr_remote = tleg.local_ptr(a_buf_remote, (slot_dot, a_rows, a_cols))
+            a_ptr_remote = tle.gpu.local_ptr(a_buf_remote, (slot_dot, a_rows, a_cols))
             a = tl.load(a_ptr_remote)
             b_ptrs = b_ptr + (k0 + k_local)[:, None] * stride_bk + offs_n[None, :] * stride_bn
             b = tl.load(b_ptrs)
@@ -692,7 +691,7 @@ def _remote_dot_prefetch_kernel(
 
         # Prevent same-slot overwrite/read race when A_SLOTS == 1.
         if A_SLOTS == 1:
-            tled.distributed_barrier(mesh)
+            tle.distributed_barrier(mesh)
 
         next_k0 = k0 + BK
         has_next = next_k0 < K
@@ -701,10 +700,10 @@ def _remote_dot_prefetch_kernel(
         if has_next and cluster_rank == 0:
             a_ptrs = a_ptr + offs_m[:, None] * stride_am + (next_k0 + offs_k)[None, :] * stride_ak
             a_tile = tl.load(a_ptrs)
-            a_local_ptr_tile = tleg.local_ptr(a_buf, (next_slot_full, a_rows_full, a_cols_full))
+            a_local_ptr_tile = tle.gpu.local_ptr(a_buf, (next_slot_full, a_rows_full, a_cols_full))
             tl.store(a_local_ptr_tile, a_tile)
 
-        tled.distributed_barrier(mesh)
+        tle.distributed_barrier(mesh)
 
     c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
     tl.store(c_ptrs, acc.to(c_ptr.dtype.element_ty))
@@ -1170,7 +1169,7 @@ class TestTLEDistributed:
         # Minimal repro for previous occasional hangs:
         # pure grid barrier kernel, repeated cooperative launches.
         grid = 3
-        mesh = tled.device_mesh({"block": [("block_x", grid)]})
+        mesh = tle.device_mesh({"block": [("block_x", grid)]})
         counter = torch.zeros((1, ), device="cuda", dtype=torch.int32)
         out = torch.empty((grid, ), device="cuda", dtype=torch.int32)
 
@@ -1204,7 +1203,7 @@ class TestTLEDistributed:
 
     def test_distributed_barrier_grid_counter_runtime_zero_init_scratch(self, with_allocator):
         grid = 3
-        mesh = tled.device_mesh({"block": [("block_x", grid)]})
+        mesh = tle.device_mesh({"block": [("block_x", grid)]})
         counter = torch.zeros((1, ), device="cuda", dtype=torch.int32)
         out = torch.empty((grid, ), device="cuda", dtype=torch.int32)
 

--- a/python/test/tle/integration/test_tle_gemm.py
+++ b/python/test/tle/integration/test_tle_gemm.py
@@ -13,7 +13,7 @@ import pytest
 import torch
 import triton
 import triton.language as tl
-import triton.experimental.tle.language.gpu as tle
+import triton.experimental.tle.language as tle
 # Disable TF32, force pure FP32 accumulation
 torch.backends.cuda.matmul.allow_tf32 = False
 torch.backends.cudnn.allow_tf32 = False
@@ -44,14 +44,14 @@ def gemm_kernel(
     offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
 
     accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-    a_smem = tle.alloc([BLOCK_M, BLOCK_N], dtype=tl.float32, layout=None, scope=tle.smem, nv_mma_shared_layout=False)
-    b_smem = tle.alloc([BLOCK_M, BLOCK_N], dtype=tl.float32, layout=None, scope=tle.smem, nv_mma_shared_layout=False)
+    a_smem = tle.gpu.alloc([BLOCK_M, BLOCK_N], dtype=tl.float32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    b_smem = tle.gpu.alloc([BLOCK_M, BLOCK_N], dtype=tl.float32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
     row_ids = tl.arange(0, BLOCK_M)[:, None]
     col_ids = tl.arange(0, BLOCK_N)[None, :]
     row_ids = tl.broadcast_to(row_ids, (BLOCK_M, BLOCK_N))
     col_ids = tl.broadcast_to(col_ids, (BLOCK_M, BLOCK_N))
-    a_smem_ptrs = tle.local_ptr(a_smem, (row_ids, col_ids))
-    b_smem_ptrs = tle.local_ptr(b_smem, (row_ids, col_ids))
+    a_smem_ptrs = tle.gpu.local_ptr(a_smem, (row_ids, col_ids))
+    b_smem_ptrs = tle.gpu.local_ptr(b_smem, (row_ids, col_ids))
 
     for k_start in range(0, K, BLOCK_K):
         k_offs = k_start + tl.arange(0, BLOCK_K)
@@ -59,8 +59,8 @@ def gemm_kernel(
         a_ptrs = a_ptr + offs_m[:, None] * stride_am + k_offs[None, :] * stride_ak
         b_ptrs = b_ptr + k_offs[:, None] * stride_bk + offs_n[None, :] * stride_bn
 
-        tle.copy(a_ptrs, a_smem, [BLOCK_M, BLOCK_N])
-        tle.copy(b_ptrs, b_smem, [BLOCK_M, BLOCK_N])
+        tle.gpu.copy(a_ptrs, a_smem, [BLOCK_M, BLOCK_N])
+        tle.gpu.copy(b_ptrs, b_smem, [BLOCK_M, BLOCK_N])
         a_tile = tl.load(a_smem_ptrs)
         b_tile = tl.load(b_smem_ptrs)
         accumulator += tl.dot(a_tile, b_tile, input_precision="ieee")

--- a/python/test/tle/integration/test_tle_local_store.py
+++ b/python/test/tle/integration/test_tle_local_store.py
@@ -3,8 +3,8 @@
 TLE Local Pointer Integration Tests
 
 Tests TLE local pointer workflow and bidirectional copy operations:
-- Shared-memory pointer materialization (tle.local_ptr + tl.load/store)
-- Copy function bidirectional support (tle.copy)
+- Shared-memory pointer materialization (tle.gpu.local_ptr + tl.load/store)
+- Copy function bidirectional support (tle.gpu.copy)
 - Integration with Triton JIT
 - Memory allocation and data transfer validation
 """
@@ -13,7 +13,7 @@ import pytest
 import torch
 import triton
 import triton.language as tl
-import triton.experimental.tle.language.gpu as tle
+import triton.experimental.tle.language as tle
 
 
 @triton.jit
@@ -53,16 +53,16 @@ def elementwise_add_kernel(
     c_ptrs = c_ptr + xstride_c * xoffs[:, None]
 
     # Allocate shared memory buffers
-    a_smem = tle.alloc([XBLOCK, YBLOCK], dtype=tl.float32, layout=None, scope=tle.smem, nv_mma_shared_layout=False)
-    b_smem = tle.alloc([XBLOCK, YBLOCK], dtype=tl.float32, layout=None, scope=tle.smem, nv_mma_shared_layout=False)
-    c_smem = tle.alloc([XBLOCK, YBLOCK], dtype=tl.float32, layout=None, scope=tle.smem, nv_mma_shared_layout=False)
+    a_smem = tle.gpu.alloc([XBLOCK, YBLOCK], dtype=tl.float32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    b_smem = tle.gpu.alloc([XBLOCK, YBLOCK], dtype=tl.float32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    c_smem = tle.gpu.alloc([XBLOCK, YBLOCK], dtype=tl.float32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
     row_ids = tl.arange(0, XBLOCK)[:, None]
     col_ids = tl.arange(0, YBLOCK)[None, :]
     row_ids = tl.broadcast_to(row_ids, (XBLOCK, YBLOCK))
     col_ids = tl.broadcast_to(col_ids, (XBLOCK, YBLOCK))
-    a_smem_ptrs = tle.local_ptr(a_smem, (row_ids, col_ids))
-    b_smem_ptrs = tle.local_ptr(b_smem, (row_ids, col_ids))
-    c_smem_ptrs = tle.local_ptr(c_smem, (row_ids, col_ids))
+    a_smem_ptrs = tle.gpu.local_ptr(a_smem, (row_ids, col_ids))
+    b_smem_ptrs = tle.gpu.local_ptr(b_smem, (row_ids, col_ids))
+    c_smem_ptrs = tle.gpu.local_ptr(c_smem, (row_ids, col_ids))
 
     # Use standard range for block-wise processing
     for yoff in range(0, ynumel, YBLOCK):
@@ -70,8 +70,8 @@ def elementwise_add_kernel(
         yoffs = tl.arange(0, YBLOCK) + yoff
 
         # copy data to shared memory
-        tle.copy(a_ptrs + ystride_a * yoffs[None, :], a_smem, [XBLOCK, YBLOCK])
-        tle.copy(b_ptrs + ystride_b * yoffs[None, :], b_smem, [XBLOCK, YBLOCK])
+        tle.gpu.copy(a_ptrs + ystride_a * yoffs[None, :], a_smem, [XBLOCK, YBLOCK])
+        tle.gpu.copy(b_ptrs + ystride_b * yoffs[None, :], b_smem, [XBLOCK, YBLOCK])
 
         # Load data from shared memory
         aval = tl.load(a_smem_ptrs)
@@ -79,8 +79,8 @@ def elementwise_add_kernel(
 
         c_val = aval + bval
         tl.store(c_smem_ptrs, c_val)
-        tle.copy(c_smem, c_ptrs + ystride_c * yoffs[None, :], [XBLOCK, YBLOCK])
-        #tle.copy(c_smem, c_ptr, shape, c_stride[x,y], [XBLOCK, YBLOCK])
+        tle.gpu.copy(c_smem, c_ptrs + ystride_c * yoffs[None, :], [XBLOCK, YBLOCK])
+        #tle.gpu.copy(c_smem, c_ptr, shape, c_stride[x,y], [XBLOCK, YBLOCK])
 
 
 def elementwise_add(A, B, C, XBLOCK=32, YBLOCK=64):

--- a/python/test/tle/integration/test_tle_pipeline_e2e.py
+++ b/python/test/tle/integration/test_tle_pipeline_e2e.py
@@ -3,10 +3,10 @@
 TLE End-to-End Integration Tests
 
 Tests complete workflow of TLE pipeline functionality in real GPU environment:
-- Memory allocation (tle.alloc)
-- Copying between GM and shared memory (tle.copy)
-- Shared-memory pointer materialization (tle.local_ptr + tl.load/store)
-- Pipeline iterator (tle.pipeline)
+- Memory allocation (tle.gpu.alloc)
+- Copying between GM and shared memory (tle.gpu.copy)
+- Shared-memory pointer materialization (tle.gpu.local_ptr + tl.load/store)
+- Pipeline iterator (tle.gpu.pipeline)
 - Integration with Triton JIT
 """
 
@@ -14,7 +14,7 @@ import pytest
 import torch
 import triton
 import triton.language as tl
-import triton.experimental.tle.language.gpu as tle
+import triton.experimental.tle.language as tle
 
 
 @triton.jit
@@ -54,25 +54,25 @@ def elementwise_add_kernel(
     c_ptrs = c_ptr + xstride_c * xoffs[:, None]
 
     # Allocate shared memory buffers
-    a_smem = tle.alloc([XBLOCK, YBLOCK], dtype=tl.float32, layout=None, scope=tle.smem)
-    b_smem = tle.alloc([XBLOCK, YBLOCK], dtype=tl.float32, layout=None, scope=tle.smem)
+    a_smem = tle.gpu.alloc([XBLOCK, YBLOCK], dtype=tl.float32, layout=None, scope=tle.gpu.smem)
+    b_smem = tle.gpu.alloc([XBLOCK, YBLOCK], dtype=tl.float32, layout=None, scope=tle.gpu.smem)
     row_ids = tl.arange(0, XBLOCK)[:, None]
     col_ids = tl.arange(0, YBLOCK)[None, :]
     row_ids = tl.broadcast_to(row_ids, (XBLOCK, YBLOCK))
     col_ids = tl.broadcast_to(col_ids, (XBLOCK, YBLOCK))
-    a_smem_ptrs = tle.local_ptr(a_smem, (row_ids, col_ids))
-    b_smem_ptrs = tle.local_ptr(b_smem, (row_ids, col_ids))
+    a_smem_ptrs = tle.gpu.local_ptr(a_smem, (row_ids, col_ids))
+    b_smem_ptrs = tle.gpu.local_ptr(b_smem, (row_ids, col_ids))
 
     # Use TLE pipeline for block-wise processing
     #for yoff in range(0, ynumel, YBLOCK):
-    for yoff in tle.pipeline(0, ynumel, YBLOCK, num_stages=2):
+    for yoff in tle.gpu.pipeline(0, ynumel, YBLOCK, num_stages=2):
         # Calculate column offset for current block
         yoffs = tl.arange(0, YBLOCK) + yoff
         mask = (xoffs < xnumel)[:, None] & (yoffs < ynumel)[None, :]
 
         # copy data to shared memory
-        tle.copy(a_ptrs + ystride_a * yoffs[None, :], a_smem, [XBLOCK, YBLOCK])
-        tle.copy(b_ptrs + ystride_b * yoffs[None, :], b_smem, [XBLOCK, YBLOCK])
+        tle.gpu.copy(a_ptrs + ystride_a * yoffs[None, :], a_smem, [XBLOCK, YBLOCK])
+        tle.gpu.copy(b_ptrs + ystride_b * yoffs[None, :], b_smem, [XBLOCK, YBLOCK])
 
         # Load data from shared memory
         aval = tl.load(a_smem_ptrs)
@@ -199,18 +199,19 @@ class TestTLEPipelineEndToEnd:
     def test_tle_module_import(self):
         """Test TLE module import (no GPU required)"""
         # Verify all necessary functions and types can be imported
-        assert hasattr(tle, 'alloc')
-        assert hasattr(tle, 'copy')
-        assert hasattr(tle, 'local_ptr')
-        assert hasattr(tle, 'pipeline')
-        assert hasattr(tle, 'scope')
-        assert hasattr(tle, 'buffered_tensor')
+        assert hasattr(tle, 'gpu')
+        assert hasattr(tle.gpu, 'alloc')
+        assert hasattr(tle.gpu, 'copy')
+        assert hasattr(tle.gpu, 'local_ptr')
+        assert hasattr(tle.gpu, 'pipeline')
+        assert hasattr(tle.gpu, 'scope')
+        assert hasattr(tle.gpu, 'buffered_tensor')
 
         # Verify functions have docstrings
-        assert tle.alloc.__doc__ is not None
-        assert tle.copy.__doc__ is not None
-        assert tle.local_ptr.__doc__ is not None
-        assert tle.pipeline.__doc__ is not None
+        assert tle.gpu.alloc.__doc__ is not None
+        assert tle.gpu.copy.__doc__ is not None
+        assert tle.gpu.local_ptr.__doc__ is not None
+        assert tle.gpu.pipeline.__doc__ is not None
 
 
 if __name__ == "__main__":

--- a/python/test/tle/integration/test_tle_tma_copy.py
+++ b/python/test/tle/integration/test_tle_tma_copy.py
@@ -3,8 +3,8 @@
 TLE TMA Copy Integration Tests
 
 Tests TLE TMA copy functionality and bidirectional copy operations:
-- TMA copy operations (tle.copy with TMA descriptors)
-- Shared-memory pointers (tle.alloc, tle.local_ptr + tl.load/store)
+- TMA copy operations (tle.gpu.copy with TMA descriptors)
+- Shared-memory pointers (tle.gpu.alloc, tle.gpu.local_ptr + tl.load/store)
 - Integration with Triton JIT and TMA descriptors
 - Memory allocation and data transfer validation
 """
@@ -13,7 +13,7 @@ import pytest
 import torch
 import triton
 import triton.language as tl
-import triton.experimental.tle.language.gpu as tle
+import triton.experimental.tle.language as tle
 
 
 @triton.jit
@@ -31,33 +31,33 @@ def elementwise_tma_add_kernel(
     # Calculate row offset for current program
 
     # Define block shape and NVMMASharedLayout for TMA compatibility
-    #layout = tle.nv_mma_shared_layout.make_default([XBLOCK, YBLOCK], tl.float32)
+    #layout = tle.gpu.nv_mma_shared_layout.make_default([XBLOCK, YBLOCK], tl.float32)
 
     # Allocate shared memory buffers
-    a_smem = tle.alloc([XBLOCK, YBLOCK], dtype=tl.float32, layout=None, scope=tle.smem)
-    b_smem = tle.alloc([XBLOCK, YBLOCK], dtype=tl.float32, layout=None, scope=tle.smem)
-    c_smem = tle.alloc([XBLOCK, YBLOCK], dtype=tl.float32, layout=None, scope=tle.smem)
+    a_smem = tle.gpu.alloc([XBLOCK, YBLOCK], dtype=tl.float32, layout=None, scope=tle.gpu.smem)
+    b_smem = tle.gpu.alloc([XBLOCK, YBLOCK], dtype=tl.float32, layout=None, scope=tle.gpu.smem)
+    c_smem = tle.gpu.alloc([XBLOCK, YBLOCK], dtype=tl.float32, layout=None, scope=tle.gpu.smem)
     row_ids = tl.arange(0, XBLOCK)[:, None]
     col_ids = tl.arange(0, YBLOCK)[None, :]
     row_ids = tl.broadcast_to(row_ids, (XBLOCK, YBLOCK))
     col_ids = tl.broadcast_to(col_ids, (XBLOCK, YBLOCK))
-    a_smem_ptrs = tle.local_ptr(a_smem, (row_ids, col_ids))
-    b_smem_ptrs = tle.local_ptr(b_smem, (row_ids, col_ids))
-    c_smem_ptrs = tle.local_ptr(c_smem, (row_ids, col_ids))
+    a_smem_ptrs = tle.gpu.local_ptr(a_smem, (row_ids, col_ids))
+    b_smem_ptrs = tle.gpu.local_ptr(b_smem, (row_ids, col_ids))
+    c_smem_ptrs = tle.gpu.local_ptr(c_smem, (row_ids, col_ids))
 
     # Use TLE pipeline for block-wise processing
     for yoff in range(0, ynumel, YBLOCK):
         # Calculate column offset for current block
         # copy data to shared memory
-        tle.copy(a_desc, a_smem, [XBLOCK, YBLOCK], [pid * XBLOCK, yoff])
-        tle.copy(b_desc, b_smem, [XBLOCK, YBLOCK], [pid * XBLOCK, yoff])
+        tle.gpu.copy(a_desc, a_smem, [XBLOCK, YBLOCK], [pid * XBLOCK, yoff])
+        tle.gpu.copy(b_desc, b_smem, [XBLOCK, YBLOCK], [pid * XBLOCK, yoff])
         # Load data from shared memory
         aval = tl.load(a_smem_ptrs)
         bval = tl.load(b_smem_ptrs)
 
         c_val = aval + bval
         tl.store(c_smem_ptrs, c_val)
-        tle.copy(c_smem, c_desc, [XBLOCK, YBLOCK], [pid * XBLOCK, yoff])
+        tle.gpu.copy(c_smem, c_desc, [XBLOCK, YBLOCK], [pid * XBLOCK, yoff])
 
 
 def elementwise_add(A, B, C, XBLOCK=32, YBLOCK=64):

--- a/python/test/tle/run_tests.py
+++ b/python/test/tle/run_tests.py
@@ -82,11 +82,11 @@ def main():
     print(f"{'='*60}")
 
     try:
-        import triton.experimental.tle as tle
+        import triton.experimental.tle.language as tle
         print("✅ TLE module import successful")
 
         # Test basic functionality
-        if hasattr(tle, 'scope') and hasattr(tle, 'pipeline'):
+        if hasattr(tle, 'gpu') and hasattr(tle.gpu, 'scope') and hasattr(tle.gpu, 'pipeline'):
             print("✅ Core functionality available")
         else:
             print("❌ Core functionality not available")

--- a/python/test/tle/unit/test_tle.py
+++ b/python/test/tle/unit/test_tle.py
@@ -13,7 +13,7 @@ Tests core functionality of TLE module, including:
 import pytest
 import torch
 import triton.language as tl
-from triton.experimental.tle.language.gpu import (pipeline, buffered_tensor, swizzled_shared_layout)
+import triton.experimental.tle.language as tle
 from triton.experimental.tle.language.gpu.semantic import TLESemanticError, TLESemantic
 
 
@@ -22,7 +22,7 @@ class TestLayoutEncoding:
 
     def test_swizzled_shared_layout_default(self):
         """Test default swizzled shared layout creation"""
-        layout = swizzled_shared_layout.make_default(2)
+        layout = tle.gpu.swizzled_shared_layout.make_default(2)
         assert layout.vectorSize == 1
         assert layout.perPhase == 1
         assert layout.maxPhase == 1
@@ -30,7 +30,7 @@ class TestLayoutEncoding:
 
     def test_swizzled_shared_layout_permute(self):
         """Test layout permutation transformation"""
-        layout = swizzled_shared_layout.make_default(3)
+        layout = tle.gpu.swizzled_shared_layout.make_default(3)
         permuted = layout.make_permute([1, 0, 2])
         # Original order for 3D rank is [2, 1, 0]
         # Permuting with [1, 0, 2] gives: order[1], order[0], order[2] = [1, 2, 0]
@@ -42,28 +42,28 @@ class TestPipeline:
 
     def test_pipeline_single_arg(self):
         """Test single argument pipeline creation"""
-        pipe = pipeline(10)
+        pipe = tle.gpu.pipeline(10)
         assert pipe.start == 0
         assert pipe.end == 10
         assert pipe.step == 1
 
     def test_pipeline_range_args(self):
         """Test range argument pipeline creation"""
-        pipe = pipeline(2, 8)
+        pipe = tle.gpu.pipeline(2, 8)
         assert pipe.start == 2
         assert pipe.end == 8
         assert pipe.step == 1
 
     def test_pipeline_with_step(self):
         """Test pipeline creation with step"""
-        pipe = pipeline(0, 10, 2)
+        pipe = tle.gpu.pipeline(0, 10, 2)
         assert pipe.start == 0
         assert pipe.end == 10
         assert pipe.step == 2
 
     def test_pipeline_with_options(self):
         """Test pipeline creation with options"""
-        pipe = pipeline(0, 10, 1, num_stages=2, loop_unroll_factor=4)
+        pipe = tle.gpu.pipeline(0, 10, 1, num_stages=2, loop_unroll_factor=4)
         assert pipe.num_stages == 2
         assert pipe.loop_unroll_factor == 4
 
@@ -136,14 +136,14 @@ class TestBufferedTensor:
         """Test buffered tensor creation"""
         # This is a basic type checking test
         # Actual buffered_tensor creation needs IR builder, difficult to mock in unit tests
-        assert hasattr(buffered_tensor, '__annotations__')
+        assert hasattr(tle.gpu.buffered_tensor, '__annotations__')
 
     def test_buffered_tensor_type_attributes(self):
         """Test buffered tensor type attributes"""
         # Check if type has necessary attributes
-        assert hasattr(buffered_tensor, '__init__')
-        assert hasattr(buffered_tensor, '_flatten_ir')
-        assert hasattr(buffered_tensor, 'make_permute')
+        assert hasattr(tle.gpu.buffered_tensor, '__init__')
+        assert hasattr(tle.gpu.buffered_tensor, '_flatten_ir')
+        assert hasattr(tle.gpu.buffered_tensor, 'make_permute')
 
 
 class TestIntegration:
@@ -151,35 +151,30 @@ class TestIntegration:
 
     def test_tle_module_import(self):
         """Test TLE module import"""
-        import triton.experimental.tle.language.gpu as tle
-
         # Check if main functions are importable
-        assert hasattr(tle, 'alloc')
-        assert hasattr(tle, 'copy')
-        assert hasattr(tle, 'local_ptr')
-        assert hasattr(tle, 'pipeline')
-        assert hasattr(tle, 'scope')
-        assert hasattr(tle, 'buffered_tensor')
+        assert hasattr(tle, 'gpu')
+        assert hasattr(tle.gpu, 'alloc')
+        assert hasattr(tle.gpu, 'copy')
+        assert hasattr(tle.gpu, 'local_ptr')
+        assert hasattr(tle.gpu, 'pipeline')
+        assert hasattr(tle.gpu, 'storage_kind')
+        assert hasattr(tle.gpu, 'buffered_tensor')
 
     def test_tle_functions_have_docstrings(self):
         """Test TLE functions have docstrings"""
-        import triton.experimental.tle.language.gpu as tle
-
         # Check if main functions have documentation
-        assert tle.alloc.__doc__ is not None
-        assert tle.copy.__doc__ is not None
-        assert tle.local_ptr.__doc__ is not None
-        assert tle.pipeline.__doc__ is not None
+        assert tle.gpu.alloc.__doc__ is not None
+        assert tle.gpu.copy.__doc__ is not None
+        assert tle.gpu.local_ptr.__doc__ is not None
+        assert tle.gpu.pipeline.__doc__ is not None
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA GPU")
     def test_tle_with_cuda(self):
         """Test TLE compatibility with CUDA (if GPU available)"""
         # This test should run in environments with GPU
         # Since TLE operations need specific hardware support, only basic import testing here
-        import triton.experimental.tle.language as tle
-
         # Ensure TLE module can be imported normally in GPU environment
-        assert tle is not None
+        assert tle.gpu is not None
 
 
 class TestErrorHandling:
@@ -208,7 +203,7 @@ class TestErrorHandling:
         with pytest.raises(ValueError):
             # Simulate type checking
             if not isinstance("invalid", str):  # This will be False, so the ValueError won't be raised
-                raise ValueError("Buffer parameter must be tle.buffered_tensor")
+                raise ValueError("Buffer parameter must be tle.gpu.buffered_tensor")
             # Since the condition is False, we need to actually raise the error for the test
             raise ValueError("Simulated validation error")
 

--- a/python/test/tle/unit/test_tle_distributed.py
+++ b/python/test/tle/unit/test_tle_distributed.py
@@ -1,8 +1,8 @@
 # flagtree tle
 import pytest
 
-import triton.experimental.tle as tle
-from triton.experimental.tle.distributed import (
+import triton.experimental.tle.language as tle
+from triton.experimental.tle.language import (
     _infer_submesh_barrier_group,
     _mesh_to_cluster_dims,
     _normalize_remote_shard_id,

--- a/python/test/tle/unit/test_tle_gpu_local_ptr.py
+++ b/python/test/tle/unit/test_tle_gpu_local_ptr.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 import triton
 import triton.language as tl
-import triton.experimental.tle.language.gpu as tle
+import triton.experimental.tle.language as tle
 
 BLOCK_SIZE = 64
 
@@ -31,8 +31,8 @@ def _local_pointer_axpy_kernel(x_ptr, y_ptr, out_ptr, numel, alpha, BLOCK: tl.co
     offsets = pid * BLOCK + tl.arange(0, BLOCK)
     mask = offsets < numel
 
-    smem_tile = tle.alloc([BLOCK], dtype=tl.float32, layout=None, scope=tle.smem, nv_mma_shared_layout=False)
-    smem_ptrs = tle.local_ptr(smem_tile, (tl.arange(0, BLOCK), ))
+    smem_tile = tle.gpu.alloc([BLOCK], dtype=tl.float32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    smem_ptrs = tle.gpu.local_ptr(smem_tile, (tl.arange(0, BLOCK), ))
 
     x_tile = x_ptr + offsets
     y_tile = y_ptr + offsets
@@ -56,8 +56,8 @@ def _local_pointer_store_kernel(out_ptr, numel, value, BLOCK: tl.constexpr):
     offsets = pid * BLOCK + tl.arange(0, BLOCK)
     mask = offsets < numel
 
-    smem_tile = tle.alloc([BLOCK], dtype=tl.float32, layout=None, scope=tle.smem, nv_mma_shared_layout=False)
-    smem_ptrs = tle.local_ptr(smem_tile, (tl.arange(0, BLOCK), ))
+    smem_tile = tle.gpu.alloc([BLOCK], dtype=tl.float32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    smem_ptrs = tle.gpu.local_ptr(smem_tile, (tl.arange(0, BLOCK), ))
 
     init = tl.full((BLOCK, ), value, tl.float32)
     tl.store(smem_ptrs, init, mask=mask)
@@ -72,8 +72,8 @@ def _local_pointer_conditional_mask_store_kernel(out_ptr, numel, BLOCK: tl.const
     idx = tl.arange(0, BLOCK)
     mask = idx < numel
 
-    smem = tle.alloc([BLOCK], dtype=tl.int32, layout=None, scope=tle.smem, nv_mma_shared_layout=False)
-    ptrs = tle.local_ptr(smem, (idx, ))
+    smem = tle.gpu.alloc([BLOCK], dtype=tl.int32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    ptrs = tle.gpu.local_ptr(smem, (idx, ))
 
     # Keep the masked store inside an scf.if region. This used to trigger a
     # verifier failure in `triton-tle-assign-local-pointers-encoding` because the
@@ -100,8 +100,8 @@ def _local_pointer_looped_elementwise_kernel(
     pid = tl.program_id(0)
     base = pid * BLOCK * CHUNKS
 
-    smem_tile = tle.alloc([BLOCK], dtype=tl.float32, layout=None, scope=tle.smem, nv_mma_shared_layout=False)
-    smem_ptrs = tle.local_ptr(smem_tile, (tl.arange(0, BLOCK), ))
+    smem_tile = tle.gpu.alloc([BLOCK], dtype=tl.float32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    smem_ptrs = tle.gpu.local_ptr(smem_tile, (tl.arange(0, BLOCK), ))
     assert BLOCK % SLICE_SIZE == 0, "BLOCK must be divisible by SLICE_SIZE"
     slice_indices = tl.arange(0, SLICE_SIZE)
 
@@ -113,7 +113,7 @@ def _local_pointer_looped_elementwise_kernel(
 
         for slice_idx in range(SLICES):
             block_offset = slice_idx * SLICE_SIZE
-            slice_ptr = tle.local_ptr(
+            slice_ptr = tle.gpu.local_ptr(
                 smem_tile,
                 (block_offset + slice_indices, ),
             )
@@ -151,8 +151,8 @@ def _local_pointer_tiled_matmul_kernel(
     offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
 
-    smem_a = tle.alloc([BLOCK_M, BLOCK_K], dtype=tl.float16, layout=None, scope=tle.smem, nv_mma_shared_layout=False)
-    smem_b = tle.alloc([BLOCK_K, BLOCK_N], dtype=tl.float16, layout=None, scope=tle.smem, nv_mma_shared_layout=False)
+    smem_a = tle.gpu.alloc([BLOCK_M, BLOCK_K], dtype=tl.float16, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    smem_b = tle.gpu.alloc([BLOCK_K, BLOCK_N], dtype=tl.float16, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
 
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
 
@@ -164,8 +164,8 @@ def _local_pointer_tiled_matmul_kernel(
         k_offsets = k_tile * BLOCK_K + tl.arange(0, BLOCK_K)
         a_tile = a_ptr + offs_m[:, None] * stride_am + k_offsets[None, :] * stride_ak
         b_tile = b_ptr + k_offsets[:, None] * stride_bk + offs_n[None, :] * stride_bn
-        tle.copy(a_tile, smem_a, [BLOCK_M, BLOCK_K])
-        tle.copy(b_tile, smem_b, [BLOCK_K, BLOCK_N])
+        tle.gpu.copy(a_tile, smem_a, [BLOCK_M, BLOCK_K])
+        tle.gpu.copy(b_tile, smem_b, [BLOCK_K, BLOCK_N])
 
         for slice_idx in range(slice_parts):
             k_start = slice_idx * slice_width
@@ -173,13 +173,13 @@ def _local_pointer_tiled_matmul_kernel(
             a_cols = tl.arange(0, SLICE_WIDTH)[None, :] + k_start
             a_rows = tl.broadcast_to(a_rows, (BLOCK_M, SLICE_WIDTH))
             a_cols = tl.broadcast_to(a_cols, (BLOCK_M, SLICE_WIDTH))
-            a_slice = tle.local_ptr(smem_a, (a_rows, a_cols))
+            a_slice = tle.gpu.local_ptr(smem_a, (a_rows, a_cols))
 
             b_rows = tl.arange(0, SLICE_WIDTH)[:, None] + k_start
             b_cols = tl.arange(0, BLOCK_N)[None, :]
             b_rows = tl.broadcast_to(b_rows, (SLICE_WIDTH, BLOCK_N))
             b_cols = tl.broadcast_to(b_cols, (SLICE_WIDTH, BLOCK_N))
-            b_slice = tle.local_ptr(smem_b, (b_rows, b_cols))
+            b_slice = tle.gpu.local_ptr(smem_b, (b_rows, b_cols))
             a_vals = tl.load(a_slice)
             b_vals = tl.load(b_slice)
             acc += tl.dot(a_vals, b_vals, out_dtype=tl.float32)
@@ -200,15 +200,15 @@ def _local_pointer_axis_gather_kernel(
     COLS: tl.constexpr,
     SLICE: tl.constexpr,
 ):
-    smem = tle.alloc([ROWS, COLS], dtype=tl.float32, layout=None, scope=tle.smem, nv_mma_shared_layout=False)
+    smem = tle.gpu.alloc([ROWS, COLS], dtype=tl.float32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
     offs_m = tl.arange(0, ROWS)[:, None]
     offs_n = tl.arange(0, COLS)[None, :]
     x_tile = x_ptr + offs_m * stride_xm + offs_n * stride_xn
-    tle.copy(x_tile, smem, [ROWS, COLS])
+    tle.gpu.copy(x_tile, smem, [ROWS, COLS])
 
     row_ids = tl.broadcast_to(offs_m, (ROWS, SLICE))
     col_ids = tl.broadcast_to(1 + tl.arange(0, SLICE)[None, :], (ROWS, SLICE))
-    smem_slice = tle.local_ptr(smem, (row_ids, col_ids))
+    smem_slice = tle.gpu.local_ptr(smem, (row_ids, col_ids))
     vals = tl.load(smem_slice)
 
     out_tile = out_ptr + offs_m * stride_om + tl.arange(0, SLICE)[None, :] * stride_on
@@ -220,15 +220,15 @@ def _local_pointer_dynamic_scalar_load_after_vector_store_kernel(
     out_ptr,
     BLOCK: tl.constexpr,
 ):
-    smem = tle.alloc([BLOCK], dtype=tl.int32, layout=None, scope=tle.smem, nv_mma_shared_layout=False)
+    smem = tle.gpu.alloc([BLOCK], dtype=tl.int32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
     vec_idx = tl.arange(0, BLOCK)
-    vec_ptr = tle.local_ptr(smem, (vec_idx, ))
+    vec_ptr = tle.gpu.local_ptr(smem, (vec_idx, ))
     tl.store(vec_ptr, vec_idx + 1)
     zero = tl.program_id(0) * 0
 
     for i in range(BLOCK):
         scalar_idx = zero + i
-        scalar_ptr = tle.local_ptr(smem, (scalar_idx, ))
+        scalar_ptr = tle.gpu.local_ptr(smem, (scalar_idx, ))
         scalar_val = tl.load(scalar_ptr)
         tl.store(out_ptr + i, scalar_val)
 

--- a/python/triton/experimental/tle/__init__.py
+++ b/python/triton/experimental/tle/__init__.py
@@ -1,20 +1,4 @@
 # flagtree tle
-from .distributed import (
-    B,
-    P,
-    S,
-    ShardedTensor,
-    ShardingSpec,
-    device_mesh,
-    distributed_barrier,
-    distributed_dot,
-    make_sharded_tensor,
-    remote,
-    reshard,
-    shard_id,
-    sharding,
-)
-
 from . import language
 
 try:
@@ -23,19 +7,6 @@ except ModuleNotFoundError:
     raw = None
 
 __all__ = [
-    "device_mesh",
-    "S",
-    "P",
-    "B",
-    "sharding",
-    "ShardingSpec",
-    "ShardedTensor",
-    "make_sharded_tensor",
-    "reshard",
-    "remote",
-    "shard_id",
-    "distributed_barrier",
-    "distributed_dot",
     "language",
 ]
 

--- a/python/triton/experimental/tle/language/__init__.py
+++ b/python/triton/experimental/tle/language/__init__.py
@@ -1,9 +1,43 @@
 # flagtree tle
 from .core import (
     load, )
+from .distributed import (
+    B,
+    P,
+    S,
+    ShardedTensor,
+    ShardingSpec,
+    device_mesh,
+    distributed_barrier,
+    distributed_dot,
+    _infer_submesh_barrier_group,
+    _mesh_to_cluster_dims,
+    make_sharded_tensor,
+    _normalize_remote_shard_id,
+    remote,
+    reshard,
+    _resolve_launch_axis,
+    shard_id,
+    sharding,
+)
+from . import distributed, gpu, raw
 
 __all__ = [
     "load",
+    "device_mesh",
+    "S",
+    "P",
+    "B",
+    "sharding",
+    "ShardingSpec",
+    "ShardedTensor",
+    "make_sharded_tensor",
+    "reshard",
+    "remote",
+    "shard_id",
+    "distributed_barrier",
+    "distributed_dot",
+    "distributed",
+    "gpu",
+    "raw",
 ]
-
-from . import gpu, raw

--- a/python/triton/experimental/tle/language/distributed.py
+++ b/python/triton/experimental/tle/language/distributed.py
@@ -754,7 +754,7 @@ def remote(
 
     Supported input:
     - tle buffered_tensor: returns a remote-marked buffered tensor; caller
-      should then use `tleg.local_ptr(...)` to materialize remote pointers.
+      should then use `tle.gpu.local_ptr(...)` to materialize remote pointers.
 
     `shard_id` is the target block id inside the current thread block cluster.
     When `scope` is provided, launch cluster dimensions are inferred from that
@@ -773,7 +773,7 @@ def remote(
         if (hasattr(tensor, "_tle_remote_shard_id") or hasattr(tensor, "_tle_remote_scope")
                 or hasattr(tensor.type, "_tle_remote_shard_id") or hasattr(tensor.type, "_tle_remote_scope")):
             raise ValueError("remote(buffered_tensor, ...) cannot be applied twice; "
-                             "materialize pointer views with tleg.local_ptr(remote_buffer, indices)")
+                             "materialize pointer views with tle.gpu.local_ptr(remote_buffer, indices)")
         if isinstance(shard_id, (int, tuple, list)):
             shard_id = _normalize_compile_time_remote_shard_id(shard_id, scope)
         else:

--- a/python/triton/experimental/tle/language/gpu/__init__.py
+++ b/python/triton/experimental/tle/language/gpu/__init__.py
@@ -9,11 +9,15 @@ from .core import (
 from .types import (layout, shared_layout, swizzled_shared_layout, tensor_memory_layout, nv_mma_shared_layout, scope,
                     buffered_tensor, buffered_tensor_type, smem, tmem)
 
+# Backward-compat alias expected by existing tests/tutorials.
+storage_kind = memory_space
+
 __all__ = [
     "pipeline",
     "alloc",
     "copy",
     "local_ptr",
+    "storage_kind",
     "layout",
     "memory_space",
     "shared_layout",

--- a/python/triton/experimental/tle/language/gpu/core.py
+++ b/python/triton/experimental/tle/language/gpu/core.py
@@ -477,8 +477,8 @@ def local_ptr(
             raise ValueError("local_ptr does not yet support scalar indices on remote buffers")
         # Keep remote semantics attached to the source buffered tensor and
         # materialize them only when pointer view is requested.
-        from triton.experimental.tle import distributed as _tled_distributed
-        result_tensor = _tled_distributed._remote_pointer(
+        from triton.experimental.tle.language import distributed as _tle_distributed
+        result_tensor = _tle_distributed._remote_pointer(
             result_tensor,
             remote_shard_id,
             scope=remote_scope,

--- a/python/tutorials/tle/02-moe_align_block_size.py
+++ b/python/tutorials/tle/02-moe_align_block_size.py
@@ -22,11 +22,10 @@ import urllib.request
 import torch
 import triton
 import triton.language as tl
-import triton.experimental.tle as tled
-import triton.experimental.tle.language.gpu as tle
+import triton.experimental.tle.language as tle
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
-BLOCK_CLUSTER_MESH_8 = tled.device_mesh({"block_cluster": [("cluster_x", 8)]})
+BLOCK_CLUSTER_MESH_8 = tle.device_mesh({"block_cluster": [("cluster_x", 8)]})
 TLE_CLUSTER_SIZE = 8
 SGLANG_MOE_ALIGN_KERNEL_URL = (
     "https://raw.githubusercontent.com/sgl-project/sglang/refs/heads/main/sgl-kernel/csrc/moe/moe_align_kernel.cu")
@@ -37,7 +36,7 @@ YIAKWY_MOE_ALIGN_KERNEL_URL = (
 
 @lru_cache(maxsize=64)
 def _block_mesh(num_blocks: int):
-    return tled.device_mesh({"block": [("block_x", int(num_blocks))]})
+    return tle.device_mesh({"block": [("block_x", int(num_blocks))]})
 
 
 _TRITON_ALLOCATOR_INSTALLED = False
@@ -346,20 +345,20 @@ def moe_align_block_size_stage4_triton_atomic_smem(
     off_t = pid * num_experts
     expert_offsets = tl.arange(0, BLOCK_EXPERT)
 
-    local_counts = tle.alloc(
+    local_counts = tle.gpu.alloc(
         [BLOCK_EXPERT],
         dtype=tl.int32,
         layout=None,
-        scope=tle.smem,
+        scope=tle.gpu.smem,
         nv_mma_shared_layout=False,
     )
     row_ptrs = tokens_cnts_ptr + off_t + expert_offsets
-    tle.copy(row_ptrs, local_counts, [num_experts])
+    tle.gpu.copy(row_ptrs, local_counts, [num_experts])
 
     offset = tl.arange(0, tokens_per_thread) + start_idx
     mask = offset < numel
     expert_id = tl.load(topk_ids_ptr + offset, mask=mask, other=0).to(tl.int32)
-    count_ptrs = tle.local_ptr(local_counts, (expert_id, ))
+    count_ptrs = tle.gpu.local_ptr(local_counts, (expert_id, ))
     token_idx_in_expert = tl.atomic_add(count_ptrs, 1, mask=mask, sem="relaxed", scope="cta")
     rank_post_pad = token_idx_in_expert + tl.load(cumsum_ptr + expert_id, mask=mask, other=0)
     tl.store(sorted_token_ids_ptr + rank_post_pad, offset, mask=mask)
@@ -397,31 +396,31 @@ def moe_align_block_size_triton_atomic_fused_coop(
         tl.store(expert_ids_ptr + offs, 0, mask=offs < numel_expert_ids)
     if pid == 0:
         tl.store(cumsum_ptr + expert_offsets, 0, mask=expert_mask)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     # Stage 1: per-program local histogram + global atomic prefix.
-    local_counts = tle.alloc(
+    local_counts = tle.gpu.alloc(
         [BLOCK_EXPERT],
         dtype=tl.int32,
         layout=None,
-        scope=tle.smem,
+        scope=tle.gpu.smem,
         nv_mma_shared_layout=False,
     )
-    local_counts_ptrs = tle.local_ptr(local_counts, (expert_offsets, ))
+    local_counts_ptrs = tle.gpu.local_ptr(local_counts, (expert_offsets, ))
     tl.store(local_counts_ptrs, 0, mask=expert_mask)
 
     for base in range(pid * BLOCK_TOKENS, numel, NUM_BLOCKS * BLOCK_TOKENS):
         offs = base + token_offsets
         mask = offs < numel
         expert_id = tl.load(topk_ids_ptr + offs, mask=mask, other=0).to(tl.int32)
-        count_ptrs = tle.local_ptr(local_counts, (expert_id, ))
+        count_ptrs = tle.gpu.local_ptr(local_counts, (expert_id, ))
         tl.atomic_add(count_ptrs, 1, mask=mask, sem="relaxed", scope="cta")
 
     local_counts_vals = tl.load(local_counts_ptrs, mask=expert_mask, other=0)
     prefix_before = tl.atomic_add(cumsum_ptr + expert_offsets, local_counts_vals, mask=expert_mask, sem="acq_rel",
                                   scope="gpu")
     tl.store(local_counts_ptrs, prefix_before, mask=expert_mask)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     # Stage 2: rank0 aligns expert totals and builds starts in global cumsum.
     if pid == 0:
@@ -431,17 +430,17 @@ def moe_align_block_size_triton_atomic_fused_coop(
         tl.store(cumsum_ptr + expert_offsets, expert_starts, mask=expert_mask)
         total_tokens = tl.sum(aligned_counts, axis=0)
         tl.store(num_tokens_post_pad_ptr, total_tokens)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     # Cache expert starts in shared once; Stage 4 reuses it for every token.
-    expert_starts_local = tle.alloc(
+    expert_starts_local = tle.gpu.alloc(
         [BLOCK_EXPERT],
         dtype=tl.int32,
         layout=None,
-        scope=tle.smem,
+        scope=tle.gpu.smem,
         nv_mma_shared_layout=False,
     )
-    expert_starts_ptrs = tle.local_ptr(expert_starts_local, (expert_offsets, ))
+    expert_starts_ptrs = tle.gpu.local_ptr(expert_starts_local, (expert_offsets, ))
     expert_starts_vals = tl.load(cumsum_ptr + expert_offsets, mask=expert_mask, other=0)
     tl.store(expert_starts_ptrs, expert_starts_vals, mask=expert_mask)
 
@@ -450,10 +449,10 @@ def moe_align_block_size_triton_atomic_fused_coop(
     for local_expert_idx in range(EXPERTS_PER_PROG):
         expert_id = pid + local_expert_idx * NUM_BLOCKS
         valid_expert = expert_id < num_experts
-        start_idx = tl.load(tle.local_ptr(expert_starts_local, (expert_id, )), mask=valid_expert, other=0)
+        start_idx = tl.load(tle.gpu.local_ptr(expert_starts_local, (expert_id, )), mask=valid_expert, other=0)
         next_expert = expert_id + 1
         has_next = valid_expert & (next_expert < num_experts)
-        end_idx = tl.load(tle.local_ptr(expert_starts_local, (next_expert, )), mask=has_next, other=total_tokens)
+        end_idx = tl.load(tle.gpu.local_ptr(expert_starts_local, (next_expert, )), mask=has_next, other=total_tokens)
         end_idx = tl.where(has_next, end_idx, total_tokens)
         start_idx = tl.where(valid_expert, start_idx, 0)
         end_idx = tl.where(valid_expert, end_idx, 0)
@@ -465,9 +464,9 @@ def moe_align_block_size_triton_atomic_fused_coop(
         offs = base + token_offsets
         mask = offs < numel
         expert_id = tl.load(topk_ids_ptr + offs, mask=mask, other=0).to(tl.int32)
-        count_ptrs = tle.local_ptr(local_counts, (expert_id, ))
+        count_ptrs = tle.gpu.local_ptr(local_counts, (expert_id, ))
         rank_with_prefix = tl.atomic_add(count_ptrs, 1, mask=mask, sem="relaxed", scope="cta")
-        rank_base = tl.load(tle.local_ptr(expert_starts_local, (expert_id, )), mask=mask, other=0)
+        rank_base = tl.load(tle.gpu.local_ptr(expert_starts_local, (expert_id, )), mask=mask, other=0)
         rank_post_pad = rank_with_prefix + rank_base
         tl.store(sorted_token_ids_ptr + rank_post_pad, offs, mask=mask)
 
@@ -551,7 +550,7 @@ def moe_align_block_size_tle_cluster_fused(
     BLOCK_EXPERT: tl.constexpr,
     EXPERTS_PER_SHARD: tl.constexpr,
 ):
-    cluster_rank = tled.shard_id(mesh, "cluster_x")
+    cluster_rank = tle.shard_id(mesh, "cluster_x")
     is_rank0 = cluster_rank == 0
     expert_offsets = tl.arange(0, BLOCK_EXPERT)
     expert_mask = expert_offsets < num_experts
@@ -567,49 +566,49 @@ def moe_align_block_size_tle_cluster_fused(
         mask = offs < numel_expert_ids
         tl.store(expert_ids_ptr + offs, 0, mask=mask)
 
-    local_counts = tle.alloc(
+    local_counts = tle.gpu.alloc(
         [BLOCK_EXPERT],
         dtype=tl.int32,
         layout=None,
-        scope=tle.smem,
+        scope=tle.gpu.smem,
         nv_mma_shared_layout=False,
     )
-    cumsum_local = tle.alloc(
+    cumsum_local = tle.gpu.alloc(
         [BLOCK_EXPERT],
         dtype=tl.int32,
         layout=None,
-        scope=tle.smem,
+        scope=tle.gpu.smem,
         nv_mma_shared_layout=False,
     )
 
     # Stage 1a: initialize rank0 DSMEM cumsum before counting.
-    rank0_cumsum_ptrs = tle.local_ptr(cumsum_local, (expert_offsets, ))
+    rank0_cumsum_ptrs = tle.gpu.local_ptr(cumsum_local, (expert_offsets, ))
     if is_rank0:
         tl.store(rank0_cumsum_ptrs, 0, mask=expert_mask)
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     # Stage 1b: per-shard local histogram in shared memory.
-    local_counts_ptrs = tle.local_ptr(local_counts, (expert_offsets, ))
+    local_counts_ptrs = tle.gpu.local_ptr(local_counts, (expert_offsets, ))
     tl.store(local_counts_ptrs, 0, mask=expert_mask)
 
     for base in range(cluster_rank * BLOCK_TOKENS, numel, CLUSTER_SIZE * BLOCK_TOKENS):
         offs = base + init_offsets
         mask = offs < numel
         expert_id = tl.load(topk_ids_ptr + offs, mask=mask, other=0).to(tl.int32)
-        count_ptrs = tle.local_ptr(local_counts, (expert_id, ))
+        count_ptrs = tle.gpu.local_ptr(local_counts, (expert_id, ))
         tl.atomic_add(count_ptrs, 1, mask=mask, sem="relaxed", scope="cta")
 
     # Stage 1c: directly atomic-add shard histogram into rank0 cumsum DSMEM.
     # The atomic return value is this shard's prefix_before for scatter.
     local_counts_vals = tl.load(local_counts_ptrs, mask=expert_mask, other=0)
-    rank0_cumsum_remote = tled.remote(cumsum_local, 0, scope=mesh)
-    rank0_cumsum_remote_ptrs = tle.local_ptr(rank0_cumsum_remote, (expert_offsets, ))
+    rank0_cumsum_remote = tle.remote(cumsum_local, 0, scope=mesh)
+    rank0_cumsum_remote_ptrs = tle.gpu.local_ptr(rank0_cumsum_remote, (expert_offsets, ))
     prefix_before = tl.atomic_add(rank0_cumsum_remote_ptrs, local_counts_vals, mask=expert_mask, sem="relaxed",
                                   scope="cta")
     # Reuse local_counts to hold per-shard prefix_before for Stage 4 scatter.
     tl.store(local_counts_ptrs, prefix_before, mask=expert_mask)
 
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     # Stage 2: rank0 aligns expert totals and materializes start offsets
     # (leading-zero semantics) in rank0 DSMEM.
@@ -625,25 +624,25 @@ def moe_align_block_size_tle_cluster_fused(
         total_tokens = tl.sum(aligned_counts, axis=0)
         tl.store(num_tokens_post_pad_ptr, total_tokens)
 
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     # Stage 4a: fill expert_ids (moved from Stage 3).
     # Each shard handles one contiguous expert segment.
-    rank0_cumsum_remote = tled.remote(cumsum_local, 0, scope=mesh)
-    rank0_cumsum_remote_ptrs = tle.local_ptr(rank0_cumsum_remote, (expert_offsets, ))
+    rank0_cumsum_remote = tle.remote(cumsum_local, 0, scope=mesh)
+    rank0_cumsum_remote_ptrs = tle.gpu.local_ptr(rank0_cumsum_remote, (expert_offsets, ))
     cumsum_vals = tl.load(rank0_cumsum_remote_ptrs, mask=expert_mask, other=0)
-    tl.store(tle.local_ptr(cumsum_local, (expert_offsets, )), cumsum_vals, mask=expert_mask)
+    tl.store(tle.gpu.local_ptr(cumsum_local, (expert_offsets, )), cumsum_vals, mask=expert_mask)
     total_tokens = tl.load(num_tokens_post_pad_ptr)
 
     for local_expert_idx in range(EXPERTS_PER_SHARD):
         expert_idx = cluster_rank * EXPERTS_PER_SHARD + local_expert_idx
         expert_id = expert_idx
         valid_expert = expert_id < num_experts
-        start_ptr = tle.local_ptr(cumsum_local, (expert_id, ))
+        start_ptr = tle.gpu.local_ptr(cumsum_local, (expert_id, ))
         start_idx = tl.load(start_ptr, mask=valid_expert, other=0)
         next_expert_id = expert_id + 1
         has_next = valid_expert & (next_expert_id < num_experts)
-        next_ptr = tle.local_ptr(cumsum_local, (next_expert_id, ))
+        next_ptr = tle.gpu.local_ptr(cumsum_local, (next_expert_id, ))
         end_from_next = tl.load(next_ptr, mask=has_next, other=0)
         end_idx = tl.where(has_next, end_from_next, total_tokens)
         start_idx = tl.where(valid_expert, start_idx, 0)
@@ -651,7 +650,7 @@ def moe_align_block_size_tle_cluster_fused(
         for i in range(start_idx, end_idx, block_size):
             tl.store(expert_ids_ptr + i // block_size, expert_idx)
 
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     # Stage 4b: second token pass, scatter with (prefix_before + rank_in_shard) + expert_base.
     # local_counts currently holds prefix_before from Stage 1c.
@@ -660,9 +659,9 @@ def moe_align_block_size_tle_cluster_fused(
         mask = offs < numel
         expert_id = tl.load(topk_ids_ptr + offs, mask=mask, other=0).to(tl.int32)
 
-        count_ptrs = tle.local_ptr(local_counts, (expert_id, ))
+        count_ptrs = tle.gpu.local_ptr(local_counts, (expert_id, ))
         rank_with_prefix = tl.atomic_add(count_ptrs, 1, mask=mask, sem="relaxed", scope="cta")
-        base_ptrs = tle.local_ptr(cumsum_local, (expert_id, ))
+        base_ptrs = tle.gpu.local_ptr(cumsum_local, (expert_id, ))
         rank_base = tl.load(base_ptrs, mask=mask, other=0)
         rank_post_pad = rank_with_prefix + rank_base
         tl.store(sorted_token_ids_ptr + rank_post_pad, offs, mask=mask)

--- a/python/tutorials/tle/03-topk.py
+++ b/python/tutorials/tle/03-topk.py
@@ -14,7 +14,7 @@ import sys
 import torch
 import triton
 import triton.language as tl
-import triton.experimental.tle.language.gpu as tle
+import triton.experimental.tle.language as tle
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
@@ -79,14 +79,14 @@ def topk_kernel_radix_triton(
     n_tiles = tl.cdiv(n_cols, BLOCK_N)
 
     # Stage 1: shared-memory histogram storage for each radix digit.
-    smem_counts = tle.alloc(
+    smem_counts = tle.gpu.alloc(
         [RADIX_SIZE],
         dtype=tl.int32,
         layout=None,
-        scope=tle.smem,
+        scope=tle.gpu.smem,
         nv_mma_shared_layout=False,
     )
-    smem_count_ptrs = tle.local_ptr(smem_counts, (bins, ))
+    smem_count_ptrs = tle.gpu.local_ptr(smem_counts, (bins, ))
 
     # Stage 2: MSD radix-select; pick one digit bucket per pass.
     for digit_pos in tl.static_range(x_nbits - RADIX_BITS, -1, -RADIX_BITS):
@@ -101,7 +101,7 @@ def topk_kernel_radix_triton(
             matches = (x_key & desired_mask) == desired
             digit = ((x_key >> digit_pos) & RADIX_MASK).to(tl.int32)
             valid = mask_n & matches
-            count_addrs = tle.local_ptr(smem_counts, (digit, ))
+            count_addrs = tle.gpu.local_ptr(smem_counts, (digit, ))
             tl.atomic_add(count_addrs, one, mask=valid, sem="relaxed", scope="cta")
 
         counts = tl.load(smem_count_ptrs)
@@ -115,9 +115,9 @@ def topk_kernel_radix_triton(
         found = 0
         for rev in tl.static_range(RADIX_SIZE):
             d = RADIX_SIZE - 1 - rev
-            cum_d = tl.load(tle.local_ptr(smem_counts, (d, )))
+            cum_d = tl.load(tle.gpu.local_ptr(smem_counts, (d, )))
             if d + 1 < RADIX_SIZE:
-                cum_next = tl.load(tle.local_ptr(smem_counts, (d + 1, )))
+                cum_next = tl.load(tle.gpu.local_ptr(smem_counts, (d + 1, )))
             else:
                 cum_next = 0
             take = (found == 0) & (cum_d >= k_to_find) & (cum_next < k_to_find)
@@ -139,25 +139,25 @@ def topk_kernel_radix_triton(
     min_packed = min_key.to(x_ultype) << 16
     offs_k = tl.arange(0, K_PAD)
 
-    smem_selected = tle.alloc(
+    smem_selected = tle.gpu.alloc(
         [K_PAD],
         dtype=x_ultype,
         layout=None,
-        scope=tle.smem,
+        scope=tle.gpu.smem,
         nv_mma_shared_layout=False,
     )
-    smem_selected_ptrs = tle.local_ptr(smem_selected, (offs_k, ))
+    smem_selected_ptrs = tle.gpu.local_ptr(smem_selected, (offs_k, ))
     tl.store(smem_selected_ptrs, tl.full([K_PAD], min_packed, dtype=x_ultype))
 
-    smem_write_count = tle.alloc(
+    smem_write_count = tle.gpu.alloc(
         [1],
         dtype=tl.int32,
         layout=None,
-        scope=tle.smem,
+        scope=tle.gpu.smem,
         nv_mma_shared_layout=False,
     )
-    tl.store(tle.local_ptr(smem_write_count, (0, )), 0)
-    write_count_ptrs = tle.local_ptr(smem_write_count, (tl.zeros([BLOCK_N], dtype=tl.int32), ))
+    tl.store(tle.gpu.local_ptr(smem_write_count, (0, )), 0)
+    write_count_ptrs = tle.gpu.local_ptr(smem_write_count, (tl.zeros([BLOCK_N], dtype=tl.int32), ))
 
     # Pass 1: write all values strictly greater than threshold.
     for t in tl.range(0, n_tiles):
@@ -172,7 +172,7 @@ def topk_kernel_radix_triton(
         take_gt = mask_n & (x_key > thr_key)
         pos = tl.atomic_add(write_count_ptrs, one, mask=take_gt, sem="relaxed", scope="cta")
         write_mask = take_gt & (pos < K_PAD)
-        dst_ptrs = tle.local_ptr(smem_selected, (pos.to(tl.int32), ))
+        dst_ptrs = tle.gpu.local_ptr(smem_selected, (pos.to(tl.int32), ))
         tl.store(dst_ptrs, packed, mask=write_mask)
 
     # Pass 2: fill remaining slots with values equal to threshold (first-come-first-serve).
@@ -188,7 +188,7 @@ def topk_kernel_radix_triton(
         take_eq = mask_n & (x_key == thr_key)
         pos = tl.atomic_add(write_count_ptrs, one, mask=take_eq, sem="relaxed", scope="cta")
         write_mask = take_eq & (pos < K_PAD)
-        dst_ptrs = tle.local_ptr(smem_selected, (pos.to(tl.int32), ))
+        dst_ptrs = tle.gpu.local_ptr(smem_selected, (pos.to(tl.int32), ))
         tl.store(dst_ptrs, packed, mask=write_mask)
 
     selected_packed = tl.load(smem_selected_ptrs)

--- a/python/tutorials/tle/04-fft.py
+++ b/python/tutorials/tle/04-fft.py
@@ -30,7 +30,7 @@ from typing import Tuple
 import torch
 import triton
 import triton.language as tl
-import triton.experimental.tle.language.gpu as tle
+import triton.experimental.tle.language as tle
 
 try:
     import cuda.tile as ct  # type: ignore
@@ -599,32 +599,32 @@ def fft_kernel_tle(
     row_valid = row < n_rows
     mask = row_valid & (offs < N)
 
-    smem_a_real = tle.alloc(
+    smem_a_real = tle.gpu.alloc(
         [N],
         dtype=tl.float32,
         layout=None,
-        scope=tle.smem,
+        scope=tle.gpu.smem,
         nv_mma_shared_layout=False,
     )
-    smem_a_imag = tle.alloc(
+    smem_a_imag = tle.gpu.alloc(
         [N],
         dtype=tl.float32,
         layout=None,
-        scope=tle.smem,
+        scope=tle.gpu.smem,
         nv_mma_shared_layout=False,
     )
-    smem_b_real = tle.alloc(
+    smem_b_real = tle.gpu.alloc(
         [N],
         dtype=tl.float32,
         layout=None,
-        scope=tle.smem,
+        scope=tle.gpu.smem,
         nv_mma_shared_layout=False,
     )
-    smem_b_imag = tle.alloc(
+    smem_b_imag = tle.gpu.alloc(
         [N],
         dtype=tl.float32,
         layout=None,
-        scope=tle.smem,
+        scope=tle.gpu.smem,
         nv_mma_shared_layout=False,
     )
 
@@ -634,8 +634,8 @@ def fft_kernel_tle(
     vals_real = tl.load(in_real_ptrs, mask=mask, other=0.0)
     vals_imag = tl.load(in_imag_ptrs, mask=mask, other=0.0)
 
-    smem_a_real_ptrs = tle.local_ptr(smem_a_real, (offs, ))
-    smem_a_imag_ptrs = tle.local_ptr(smem_a_imag, (offs, ))
+    smem_a_real_ptrs = tle.gpu.local_ptr(smem_a_real, (offs, ))
+    smem_a_imag_ptrs = tle.gpu.local_ptr(smem_a_imag, (offs, ))
     tl.store(smem_a_real_ptrs, vals_real, mask=mask)
     tl.store(smem_a_imag_ptrs, vals_imag, mask=mask)
     tl.debug_barrier()
@@ -655,10 +655,10 @@ def fft_kernel_tle(
         even_idx = base + j
         odd_idx = even_idx + half
 
-        even_ptrs_real = tle.local_ptr(smem_in_real, (even_idx, ))
-        even_ptrs_imag = tle.local_ptr(smem_in_imag, (even_idx, ))
-        odd_ptrs_real = tle.local_ptr(smem_in_real, (odd_idx, ))
-        odd_ptrs_imag = tle.local_ptr(smem_in_imag, (odd_idx, ))
+        even_ptrs_real = tle.gpu.local_ptr(smem_in_real, (even_idx, ))
+        even_ptrs_imag = tle.gpu.local_ptr(smem_in_imag, (even_idx, ))
+        odd_ptrs_real = tle.gpu.local_ptr(smem_in_real, (odd_idx, ))
+        odd_ptrs_imag = tle.gpu.local_ptr(smem_in_imag, (odd_idx, ))
 
         u_real = tl.load(even_ptrs_real, mask=mask, other=0.0)
         u_imag = tl.load(even_ptrs_imag, mask=mask, other=0.0)
@@ -677,8 +677,8 @@ def fft_kernel_tle(
         out_real_val = tl.where(add_mask, u_real + v_tw_real, u_real - v_tw_real)
         out_imag_val = tl.where(add_mask, u_imag + v_tw_imag, u_imag - v_tw_imag)
 
-        out_ptrs_real = tle.local_ptr(smem_out_real, (idx, ))
-        out_ptrs_imag = tle.local_ptr(smem_out_imag, (idx, ))
+        out_ptrs_real = tle.gpu.local_ptr(smem_out_real, (idx, ))
+        out_ptrs_imag = tle.gpu.local_ptr(smem_out_imag, (idx, ))
         tl.store(out_ptrs_real, out_real_val, mask=mask)
         tl.store(out_ptrs_imag, out_imag_val, mask=mask)
         tl.debug_barrier()
@@ -703,14 +703,14 @@ def fft_kernel_tle(
             i2 = i1 + quarter
             i3 = i2 + quarter
 
-            ptr0_real = tle.local_ptr(smem_in_real, (i0, ))
-            ptr0_imag = tle.local_ptr(smem_in_imag, (i0, ))
-            ptr1_real = tle.local_ptr(smem_in_real, (i1, ))
-            ptr1_imag = tle.local_ptr(smem_in_imag, (i1, ))
-            ptr2_real = tle.local_ptr(smem_in_real, (i2, ))
-            ptr2_imag = tle.local_ptr(smem_in_imag, (i2, ))
-            ptr3_real = tle.local_ptr(smem_in_real, (i3, ))
-            ptr3_imag = tle.local_ptr(smem_in_imag, (i3, ))
+            ptr0_real = tle.gpu.local_ptr(smem_in_real, (i0, ))
+            ptr0_imag = tle.gpu.local_ptr(smem_in_imag, (i0, ))
+            ptr1_real = tle.gpu.local_ptr(smem_in_real, (i1, ))
+            ptr1_imag = tle.gpu.local_ptr(smem_in_imag, (i1, ))
+            ptr2_real = tle.gpu.local_ptr(smem_in_real, (i2, ))
+            ptr2_imag = tle.gpu.local_ptr(smem_in_imag, (i2, ))
+            ptr3_real = tle.gpu.local_ptr(smem_in_real, (i3, ))
+            ptr3_imag = tle.gpu.local_ptr(smem_in_imag, (i3, ))
 
             x0_real = tl.load(ptr0_real, mask=mask, other=0.0)
             x0_imag = tl.load(ptr0_imag, mask=mask, other=0.0)
@@ -766,8 +766,8 @@ def fft_kernel_tle(
             out_real_val = tl.where(m0, o0_real, tl.where(m1, o1_real, tl.where(m2, o2_real, o3_real)))
             out_imag_val = tl.where(m0, o0_imag, tl.where(m1, o1_imag, tl.where(m2, o2_imag, o3_imag)))
 
-            out_ptrs_real = tle.local_ptr(smem_out_real, (idx, ))
-            out_ptrs_imag = tle.local_ptr(smem_out_imag, (idx, ))
+            out_ptrs_real = tle.gpu.local_ptr(smem_out_real, (idx, ))
+            out_ptrs_imag = tle.gpu.local_ptr(smem_out_imag, (idx, ))
             tl.store(out_ptrs_real, out_real_val, mask=mask)
             tl.store(out_ptrs_imag, out_imag_val, mask=mask)
             tl.debug_barrier()
@@ -791,14 +791,14 @@ def fft_kernel_tle(
             i2 = i1 + quarter
             i3 = i2 + quarter
 
-            ptr0_real = tle.local_ptr(smem_in_real, (i0, ))
-            ptr0_imag = tle.local_ptr(smem_in_imag, (i0, ))
-            ptr1_real = tle.local_ptr(smem_in_real, (i1, ))
-            ptr1_imag = tle.local_ptr(smem_in_imag, (i1, ))
-            ptr2_real = tle.local_ptr(smem_in_real, (i2, ))
-            ptr2_imag = tle.local_ptr(smem_in_imag, (i2, ))
-            ptr3_real = tle.local_ptr(smem_in_real, (i3, ))
-            ptr3_imag = tle.local_ptr(smem_in_imag, (i3, ))
+            ptr0_real = tle.gpu.local_ptr(smem_in_real, (i0, ))
+            ptr0_imag = tle.gpu.local_ptr(smem_in_imag, (i0, ))
+            ptr1_real = tle.gpu.local_ptr(smem_in_real, (i1, ))
+            ptr1_imag = tle.gpu.local_ptr(smem_in_imag, (i1, ))
+            ptr2_real = tle.gpu.local_ptr(smem_in_real, (i2, ))
+            ptr2_imag = tle.gpu.local_ptr(smem_in_imag, (i2, ))
+            ptr3_real = tle.gpu.local_ptr(smem_in_real, (i3, ))
+            ptr3_imag = tle.gpu.local_ptr(smem_in_imag, (i3, ))
 
             x0_real = tl.load(ptr0_real, mask=mask, other=0.0)
             x0_imag = tl.load(ptr0_imag, mask=mask, other=0.0)
@@ -854,8 +854,8 @@ def fft_kernel_tle(
             out_real_val = tl.where(m0, o0_real, tl.where(m1, o1_real, tl.where(m2, o2_real, o3_real)))
             out_imag_val = tl.where(m0, o0_imag, tl.where(m1, o1_imag, tl.where(m2, o2_imag, o3_imag)))
 
-            out_ptrs_real = tle.local_ptr(smem_out_real, (idx, ))
-            out_ptrs_imag = tle.local_ptr(smem_out_imag, (idx, ))
+            out_ptrs_real = tle.gpu.local_ptr(smem_out_real, (idx, ))
+            out_ptrs_imag = tle.gpu.local_ptr(smem_out_imag, (idx, ))
             tl.store(out_ptrs_real, out_real_val, mask=mask)
             tl.store(out_ptrs_imag, out_imag_val, mask=mask)
             tl.debug_barrier()
@@ -865,8 +865,8 @@ def fft_kernel_tle(
 
     out_real_ptrs = out_real + row * stride_out + offs
     out_imag_ptrs = out_imag + row * stride_out + offs
-    smem_final_real_ptrs = tle.local_ptr(smem_in_real, (offs, ))
-    smem_final_imag_ptrs = tle.local_ptr(smem_in_imag, (offs, ))
+    smem_final_real_ptrs = tle.gpu.local_ptr(smem_in_real, (offs, ))
+    smem_final_imag_ptrs = tle.gpu.local_ptr(smem_in_imag, (offs, ))
     out_vals_real = tl.load(smem_final_real_ptrs, mask=mask, other=0.0)
     out_vals_imag = tl.load(smem_final_imag_ptrs, mask=mask, other=0.0)
     tl.store(out_real_ptrs, out_vals_real, mask=mask)

--- a/python/tutorials/tle/05-deepseek_v32_topk_selector.py
+++ b/python/tutorials/tle/05-deepseek_v32_topk_selector.py
@@ -6,7 +6,7 @@ This tutorial adapts the TileLang DeepSeek V3-2 top-k selector example and
 implements two kernels:
 - A Triton version rewritten with the radix-select flow used in `03-topk.py`.
 - A TLE version that keeps the shared-memory DeepSeek-style selector
-  (`tle.alloc` + `tle.local_ptr`).
+  (`tle.gpu.alloc` + `tle.gpu.local_ptr`).
 
 If TileLang is installed, the script will also run the original TileLang kernel
 and compare correctness and performance.
@@ -28,7 +28,7 @@ from typing import Optional
 import torch
 import triton
 import triton.language as tl
-import triton.experimental.tle.language.gpu as tle
+import triton.experimental.tle.language as tle
 
 try:
     import tilelang
@@ -210,36 +210,36 @@ def tle_topk_selector_kernel(
     lane = tl.arange(0, BLOCK_SIZE)
     ones = tl.full([BLOCK_SIZE], 1, tl.int32)
 
-    s_histogram = tle.alloc(
+    s_histogram = tle.gpu.alloc(
         [HIST_SIZE],
         dtype=tl.int32,
         layout=None,
-        scope=tle.smem,
+        scope=tle.gpu.smem,
         nv_mma_shared_layout=False,
     )
-    s_num_input = tle.alloc(
+    s_num_input = tle.gpu.alloc(
         [2],
         dtype=tl.int32,
         layout=None,
-        scope=tle.smem,
+        scope=tle.gpu.smem,
         nv_mma_shared_layout=False,
     )
-    s_input_idx = tle.alloc(
+    s_input_idx = tle.gpu.alloc(
         [2, SMEM_INPUT],
         dtype=tl.int32,
         layout=None,
-        scope=tle.smem,
+        scope=tle.gpu.smem,
         nv_mma_shared_layout=False,
     )
 
     hist_idx = tl.arange(0, RADIX)
     hist_last = tl.full([1], RADIX, tl.int32)
 
-    hist_ptrs = tle.local_ptr(s_histogram, (hist_idx, ))
-    hist_last_ptrs = tle.local_ptr(s_histogram, (hist_last, ))
+    hist_ptrs = tle.gpu.local_ptr(s_histogram, (hist_idx, ))
+    hist_last_ptrs = tle.gpu.local_ptr(s_histogram, (hist_last, ))
     tl.store(hist_ptrs, 0)
     tl.store(hist_last_ptrs, 0)
-    tl.store(tle.local_ptr(s_num_input, (tl.arange(0, 2), )), 0)
+    tl.store(tle.gpu.local_ptr(s_num_input, (tl.arange(0, 2), )), 0)
     tl.debug_barrier()
 
     l_new_topk = tl.full((), TOPK, tl.int32)
@@ -251,24 +251,24 @@ def tle_topk_selector_kernel(
         x = tl.load(row_ptr + offs * stride_xn, mask=in_range, other=0.0)
         bin_u16 = _convert_to_uint16(x)
         bin_i32 = bin_u16.to(tl.int32)
-        hist_bin_ptrs = tle.local_ptr(s_histogram, (bin_i32, ))
+        hist_bin_ptrs = tle.gpu.local_ptr(s_histogram, (bin_i32, ))
         tl.atomic_add(hist_bin_ptrs, ones, mask=in_range)
 
     rev_idx = (RADIX - 1) - hist_idx
-    hist_rev = tl.load(tle.local_ptr(s_histogram, (rev_idx, )))
+    hist_rev = tl.load(tle.gpu.local_ptr(s_histogram, (rev_idx, )))
     hist_cum_rev = tl.cumsum(hist_rev, axis=0)
-    tl.store(tle.local_ptr(s_histogram, (rev_idx, )), hist_cum_rev)
+    tl.store(tle.gpu.local_ptr(s_histogram, (rev_idx, )), hist_cum_rev)
     tl.debug_barrier()
 
     hist_cum = tl.load(hist_ptrs)
-    hist_cum_next = tl.load(tle.local_ptr(s_histogram, (hist_idx + 1, )), mask=hist_idx + 1 < RADIX, other=0)
+    hist_cum_next = tl.load(tle.gpu.local_ptr(s_histogram, (hist_idx + 1, )), mask=hist_idx + 1 < RADIX, other=0)
     cond = (hist_cum > l_new_topk) & (hist_cum_next <= l_new_topk)
     cand = tl.where(cond, hist_idx.to(tl.int32), -1)
     threshold = tl.max(cand, axis=0)
     hist_next = tl.max(tl.where(hist_idx == threshold + 1, hist_cum, 0), axis=0)
     l_new_topk = tl.maximum(l_new_topk - hist_next, 0)
 
-    num_ptrs = tle.local_ptr(s_num_input, (tl.zeros([BLOCK_SIZE], tl.int32), ))
+    num_ptrs = tle.gpu.local_ptr(s_num_input, (tl.zeros([BLOCK_SIZE], tl.int32), ))
     for t in tl.static_range(N_TILES):
         offs = t * BLOCK_SIZE + lane
         in_range = (offs < seq_len) & (offs >= row_start) & (offs < row_end)
@@ -278,14 +278,14 @@ def tle_topk_selector_kernel(
         gt_thr = bin_i32 > threshold
         eq_thr = bin_i32 == threshold
 
-        pos = tl.atomic_add(tle.local_ptr(s_histogram, (bin_i32 + 1, )), ones, mask=in_range & gt_thr)
+        pos = tl.atomic_add(tle.gpu.local_ptr(s_histogram, (bin_i32 + 1, )), ones, mask=in_range & gt_thr)
         pos = tl.where(in_range & gt_thr, pos, 0)
         tl.store(out_row + pos * stride_outn, offs.to(tl.int32), mask=in_range & gt_thr & (pos < TOPK))
 
         pos_eq = tl.atomic_add(num_ptrs, ones, mask=in_range & eq_thr & (l_new_topk > 0))
         pos_eq = tl.where(in_range & eq_thr, pos_eq, 0)
         tl.store(
-            tle.local_ptr(s_input_idx, (tl.zeros([BLOCK_SIZE], tl.int32), pos_eq)),
+            tle.gpu.local_ptr(s_input_idx, (tl.zeros([BLOCK_SIZE], tl.int32), pos_eq)),
             offs.to(tl.int32),
             mask=in_range & eq_thr & (pos_eq < SMEM_INPUT) & (l_new_topk > 0),
         )
@@ -298,11 +298,11 @@ def tle_topk_selector_kernel(
 
         tl.store(hist_ptrs, 0)
         tl.store(hist_last_ptrs, 0)
-        num_ptrs_next = tle.local_ptr(s_num_input, (tl.full([BLOCK_SIZE], next_idx, tl.int32), ))
+        num_ptrs_next = tle.gpu.local_ptr(s_num_input, (tl.full([BLOCK_SIZE], next_idx, tl.int32), ))
         tl.store(num_ptrs_next, 0, mask=lane == 0)
         tl.debug_barrier()
 
-        num_ptrs_r = tle.local_ptr(s_num_input, (tl.full([BLOCK_SIZE], r_idx, tl.int32), ))
+        num_ptrs_r = tle.gpu.local_ptr(s_num_input, (tl.full([BLOCK_SIZE], r_idx, tl.int32), ))
         l_num_input = tl.max(tl.load(num_ptrs_r), axis=0).to(tl.int32)
         max_input = tl.full((), SMEM_INPUT, tl.int32)
         l_num_input = tl.minimum(l_num_input, max_input)
@@ -313,23 +313,23 @@ def tle_topk_selector_kernel(
             offs = t * BLOCK_SIZE + lane
             valid = offs < l_num_input
             cand_idx = tl.load(
-                tle.local_ptr(s_input_idx, (tl.full([BLOCK_SIZE], r_idx, tl.int32), offs)),
+                tle.gpu.local_ptr(s_input_idx, (tl.full([BLOCK_SIZE], r_idx, tl.int32), offs)),
                 mask=valid,
                 other=0,
             )
             x = tl.load(row_ptr + cand_idx * stride_xn, mask=valid, other=0.0)
             bin_u32 = _convert_to_uint32(x)
             bin_i32 = ((bin_u32 >> shift) & 0xFF).to(tl.int32)
-            tl.atomic_add(tle.local_ptr(s_histogram, (bin_i32, )), ones, mask=valid & active)
+            tl.atomic_add(tle.gpu.local_ptr(s_histogram, (bin_i32, )), ones, mask=valid & active)
 
         rev_idx = (RADIX - 1) - hist_idx
-        hist_rev = tl.load(tle.local_ptr(s_histogram, (rev_idx, )))
+        hist_rev = tl.load(tle.gpu.local_ptr(s_histogram, (rev_idx, )))
         hist_cum_rev = tl.cumsum(hist_rev, axis=0)
-        tl.store(tle.local_ptr(s_histogram, (rev_idx, )), hist_cum_rev)
+        tl.store(tle.gpu.local_ptr(s_histogram, (rev_idx, )), hist_cum_rev)
         tl.debug_barrier()
 
         hist_cum = tl.load(hist_ptrs)
-        hist_cum_next = tl.load(tle.local_ptr(s_histogram, (hist_idx + 1, )), mask=hist_idx + 1 < RADIX, other=0)
+        hist_cum_next = tl.load(tle.gpu.local_ptr(s_histogram, (hist_idx + 1, )), mask=hist_idx + 1 < RADIX, other=0)
         cond = (hist_cum > l_new_topk) & (hist_cum_next <= l_new_topk)
         cand = tl.where(cond, hist_idx.to(tl.int32), -1)
         threshold = tl.max(cand, axis=0)
@@ -340,7 +340,7 @@ def tle_topk_selector_kernel(
             offs = t * BLOCK_SIZE + lane
             valid = offs < l_num_input
             cand_idx = tl.load(
-                tle.local_ptr(s_input_idx, (tl.full([BLOCK_SIZE], r_idx, tl.int32), offs)),
+                tle.gpu.local_ptr(s_input_idx, (tl.full([BLOCK_SIZE], r_idx, tl.int32), offs)),
                 mask=valid,
                 other=0,
             )
@@ -350,7 +350,7 @@ def tle_topk_selector_kernel(
 
             gt_thr = bin_i32 > threshold
             eq_thr = bin_i32 == threshold
-            pos = tl.atomic_add(tle.local_ptr(s_histogram, (bin_i32 + 1, )), ones, mask=valid & gt_thr & active)
+            pos = tl.atomic_add(tle.gpu.local_ptr(s_histogram, (bin_i32 + 1, )), ones, mask=valid & gt_thr & active)
             pos = tl.where(valid & gt_thr & active, pos, 0)
             out_pos = pos + start_pos
             tl.store(
@@ -361,7 +361,7 @@ def tle_topk_selector_kernel(
 
             if round_id == 3:
                 pos_eq = tl.atomic_add(
-                    tle.local_ptr(s_histogram, (bin_i32 + 1, )),
+                    tle.gpu.local_ptr(s_histogram, (bin_i32 + 1, )),
                     ones,
                     mask=valid & eq_thr & active & (l_new_topk > 0),
                 )
@@ -373,11 +373,11 @@ def tle_topk_selector_kernel(
                     mask=valid & eq_thr & active & (out_pos < TOPK) & (l_new_topk > 0),
                 )
             else:
-                num_ptrs = tle.local_ptr(s_num_input, (tl.full([BLOCK_SIZE], next_idx, tl.int32), ))
+                num_ptrs = tle.gpu.local_ptr(s_num_input, (tl.full([BLOCK_SIZE], next_idx, tl.int32), ))
                 pos_eq = tl.atomic_add(num_ptrs, ones, mask=valid & eq_thr & active & (l_new_topk > 0))
                 pos_eq = tl.where(valid & eq_thr & active, pos_eq, 0)
                 tl.store(
-                    tle.local_ptr(s_input_idx, (tl.full([BLOCK_SIZE], next_idx, tl.int32), pos_eq)),
+                    tle.gpu.local_ptr(s_input_idx, (tl.full([BLOCK_SIZE], next_idx, tl.int32), pos_eq)),
                     cand_idx,
                     mask=valid & eq_thr & active & (pos_eq < SMEM_INPUT) & (l_new_topk > 0),
                 )

--- a/python/tutorials/tle/06-cluster-gemm.py
+++ b/python/tutorials/tle/06-cluster-gemm.py
@@ -5,7 +5,7 @@ Cluster GEMM with TLE Remote
 
 Compare two GEMM implementations:
 - baseline Triton GEMM
-- cluster GEMM that reuses A tile via `tled.remote` inside a 2-block cluster
+- cluster GEMM that reuses A tile via `tle.remote` inside a 2-block cluster
 
 Run example:
   python python/tutorials/tle/04-cluster-gemm.py --m 4096 --n 4096 --k 4096
@@ -20,10 +20,9 @@ from typing import Callable
 import torch
 import triton
 import triton.language as tl
-import triton.experimental.tle as tled
-import triton.experimental.tle.language.gpu as tleg
+import triton.experimental.tle.language as tle
 
-BLOCK_CLUSTER_MESH = tled.device_mesh({"block_cluster": [("cluster_x", 2)]})
+BLOCK_CLUSTER_MESH = tle.device_mesh({"block_cluster": [("cluster_x", 2)]})
 
 
 def _select_dot_k(bk: int) -> int:
@@ -120,7 +119,7 @@ def _cluster_remote_gemm_kernel(
     USE_NV_MMA_SMEM_LAYOUT: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    cluster_rank = tled.shard_id(mesh, "cluster_x")
+    cluster_rank = tle.shard_id(mesh, "cluster_x")
     cluster_id = pid // CLUSTER_SIZE
 
     num_pid_n = tl.cdiv(N, BN)
@@ -136,14 +135,14 @@ def _cluster_remote_gemm_kernel(
     a_rows_full = tl.broadcast_to(a_row_base[:, None], (BM, BK))
     a_cols_full = tl.broadcast_to(tl.arange(0, BK)[None, :], (BM, BK))
     a_rows_t = tl.broadcast_to(a_row_base[None, :], (DOT_K, BM))
-    a_buf = tleg.alloc(
+    a_buf = tle.gpu.alloc(
         [A_SLOTS, BM, BK],
         dtype=tl.float16,
         layout=None,
-        scope=tleg.smem,
+        scope=tle.gpu.smem,
         nv_mma_shared_layout=USE_NV_MMA_SMEM_LAYOUT,
     )
-    a_buf_remote = tled.remote(a_buf, 0, scope=mesh)
+    a_buf_remote = tle.remote(a_buf, 0, scope=mesh)
 
     acc = tl.zeros((BM, BN), dtype=tl.float32)
     # Prefetch the first K-tile before entering the main loop, then keep
@@ -157,13 +156,13 @@ def _cluster_remote_gemm_kernel(
             a_tile = tl.load(a_ptrs, mask=a_mask_tile, other=0.0)
         else:
             a_tile = tl.load(a_ptrs)
-        a_local_ptr_tile = tleg.local_ptr(a_buf, (slot0_full, a_rows_full, a_cols_full))
+        a_local_ptr_tile = tle.gpu.local_ptr(a_buf, (slot0_full, a_rows_full, a_cols_full))
         if USE_MASK:
             tl.store(a_local_ptr_tile, a_tile, mask=a_mask_tile)
         else:
             tl.store(a_local_ptr_tile, a_tile)
 
-    tled.distributed_barrier(mesh)
+    tle.distributed_barrier(mesh)
 
     for k0 in range(0, K, BK):
         iter_idx = k0 // BK
@@ -173,7 +172,7 @@ def _cluster_remote_gemm_kernel(
             k_local = ks + tl.arange(0, DOT_K)
             a_cols_t = tl.broadcast_to(k_local[:, None], (DOT_K, BM))
             slot_dot_t = tl.zeros((DOT_K, BM), dtype=tl.int32) + slot
-            a_ptr_remote = tleg.local_ptr(a_buf_remote, (slot_dot_t, a_rows_t, a_cols_t))
+            a_ptr_remote = tle.gpu.local_ptr(a_buf_remote, (slot_dot_t, a_rows_t, a_cols_t))
             if USE_MASK:
                 a_mask_t = ((k0 + k_local)[:, None] < K) & (offs_m[None, :] < M)
                 a = tl.trans(tl.load(a_ptr_remote, mask=a_mask_t, other=0.0))
@@ -191,7 +190,7 @@ def _cluster_remote_gemm_kernel(
         # With a single slot, producer and consumer share the same DSMEM tile.
         # Ensure all CTAs finish reading current tile before rank0 overwrites it.
         if A_SLOTS == 1:
-            tled.distributed_barrier(mesh)
+            tle.distributed_barrier(mesh)
 
         next_k0 = k0 + BK
         has_next = next_k0 < K
@@ -205,13 +204,13 @@ def _cluster_remote_gemm_kernel(
                 a_tile = tl.load(a_ptrs, mask=a_mask_tile, other=0.0)
             else:
                 a_tile = tl.load(a_ptrs)
-            a_local_ptr_tile = tleg.local_ptr(a_buf, (next_slot_full, a_rows_full, a_cols_full))
+            a_local_ptr_tile = tle.gpu.local_ptr(a_buf, (next_slot_full, a_rows_full, a_cols_full))
             if USE_MASK:
                 tl.store(a_local_ptr_tile, a_tile, mask=a_mask_tile)
             else:
                 tl.store(a_local_ptr_tile, a_tile)
 
-        tled.distributed_barrier(mesh)
+        tle.distributed_barrier(mesh)
 
     c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
     if USE_MASK:

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1401,7 +1401,7 @@ public:
       auto &atom = *ptxBuilderAtomicRMW.create("atom");
       // begin flagtree tle
       if (isSharedPtr || isClusterSharedPtr)
-        atom->o("shared::cluster", useClusterSharedAtomic)
+        atom.o("shared::cluster", useClusterSharedAtomic)
             .o("shared", !useClusterSharedAtomic)
             .o(scope);
       else
@@ -1456,7 +1456,7 @@ public:
       os << op.getSem();
       atom->o(semStr).o(rmwOp).v(vec).o(sTy);
       if (tensorTy) {
-        (*atom)(dstOpr, ptrOpr, valOpr).maybePredicate(pred);
+        atom(dstOpr, ptrOpr, valOpr).maybePredicate(pred);
         Type retType;
         if (vec > 1) {
           SmallVector<Type> retTys(vec, valueElemTy);
@@ -1483,7 +1483,7 @@ public:
         }
       } else {
         auto ASMReturnTy = void_ty(ctx);
-        (*atom)(dstOpr, ptrOpr, valOpr).maybePredicate(pred);
+        atom(dstOpr, ptrOpr, valOpr).maybePredicate(pred);
         auto old = ptxBuilderAtomicRMW.launch(rewriter, loc, valueElemTy);
         if (op.getResult().use_empty()) {
           rewriter.eraseOp(op);

--- a/tle.md
+++ b/tle.md
@@ -426,7 +426,22 @@ x = tle.make_sharded_tensor(x_ptr, sharding=x_spec, shape=[M, K])
 x_full = tle.reshard(x, spec=tle.sharding(mesh, split=[], partial=[]))
 ```
 
-##### 3.2.5.5 `tle.remote` + `tle.distributed_barrier`
+##### 3.2.5.5 `tle.shard_id`
+
+- Signature: `tle.shard_id(mesh, axis)`
+- Returns current program's coordinate on a mesh axis.
+- `axis` can be a mesh-axis name (e.g. `"node"`, `"device"`, `"cluster_x"`) or an axis index.
+- Typical use: build peer shard IDs for ring exchange, staged all-reduce, and cluster-cooperative kernels.
+
+Example: query current program coordinates on node/device axes
+
+```python
+mesh = tle.device_mesh({"node": 2, "device": 4})
+node_rank = tle.shard_id(mesh, "node")      # 0..1
+device_rank = tle.shard_id(mesh, "device")  # 0..3
+```
+
+##### 3.2.5.6 `tle.remote` + `tle.distributed_barrier`
 
 - `tle.remote` reads/writes explicit remote shards.
 - `tle.distributed_barrier` synchronizes only the mesh/sub-mesh you pass in.
@@ -434,9 +449,10 @@ x_full = tle.reshard(x, spec=tle.sharding(mesh, split=[], partial=[]))
 Example: remote read from neighbor shard (ring-like exchange)
 
 ```python
-rank = tle.program_rank(mesh)
-next_rank = (rank + 1) % mesh.shape[0]
-remote_x = tle.remote(x, shard_id=(next_rank,), scope="device")
+node_rank = tle.shard_id(mesh, "node")
+device_rank = tle.shard_id(mesh, "device")
+next_device = (device_rank + 1) % mesh.shape[1]
+remote_x = tle.remote(x, shard_id=(node_rank, next_device), scope=mesh)
 tle.distributed_barrier(mesh)
 neighbor_vals = tl.load(remote_x)
 ```
@@ -901,7 +917,7 @@ TopK selector performance is evaluated with `python/tutorials/tle/deepseek_v32/0
 
 - Runtime: local benchmark (GeForce RTX 5060 Ti), `--skip_correctness --warmup 10 --rep 80`.
 
-| batch | seq_len | topk | Torch-TopK | Triton-Radix | TileLang | TLE-Radix | **Speedup (Torch-TopK / min(Triton-Radix, TileLang, TLE-Radix))** |
+| batch | seq_len | topk | Torch-TopK | Triton-Radix | TileLang | TLE-Radix | **Speedup (Torch-TopK / TLE-Radix)** |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | 64 | 4096 | 128 | 0.038912 | 0.039456 | 0.020480 | **0.015808** | 2.46x |
 | 64 | 8192 | 256 | 0.088624 | 0.053248 | 0.028672 | **0.023936** | 3.70x |
@@ -910,9 +926,9 @@ TopK selector performance is evaluated with `python/tutorials/tle/deepseek_v32/0
 
 #### 4.4.2 H800 (`tle-radix-topk-selector`)
 
-| batch | seq_len | topk | Torch-TopK | Triton-Radix | TileLang | TLE-Radix | **Speedup (Torch-TopK / min(Triton-Radix, TileLang, TLE-Radix))** |
+| batch | seq_len | topk | Torch-TopK | Triton-Radix | TileLang | TLE-Radix | **Speedup (Torch-TopK / TLE-Radix)** |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| 64 | 4096 | 128 | 0.045728 | 0.054256 | **0.017200** | 0.017472 | 2.66x |
+| 64 | 4096 | 128 | 0.045728 | 0.054256 | **0.017200** | 0.017472 | 2.62x |
 | 64 | 8192 | 256 | 0.097344 | 0.072512 | 0.020960 | **0.020928** | 4.65x |
 | 64 | 32768 | 1024 | 0.125008 | 0.176768 | 0.043088 | **0.041856** | 2.99x |
 | 64 | 32768 | 2048 | 0.125072 | 0.179264 | 0.044256 | **0.041984** | 2.98x |

--- a/tle_cn.md
+++ b/tle_cn.md
@@ -420,7 +420,22 @@ x = tle.make_sharded_tensor(x_ptr, sharding=x_spec, shape=[M, K])
 x_full = tle.reshard(x, spec=tle.sharding(mesh, split=[], partial=[]))
 ```
 
-##### 3.2.5.5 `tle.remote` + `tle.distributed_barrier`
+##### 3.2.5.5 `tle.shard_id`
+
+- Signature: `tle.shard_id(mesh, axis)`
+- 含义：返回当前 program 在指定 mesh 轴上的坐标。
+- `axis` 可以是轴名称（如 `"node"`、`"device"`、`"cluster_x"`）或轴序号。
+- 典型用途：构造 ring 交换、分阶段 all-reduce、cluster 协同计算中的对端 shard ID。
+
+示例：查询当前 program 在 node/device 轴上的坐标
+
+```python
+mesh = tle.device_mesh({"node": 2, "device": 4})
+node_rank = tle.shard_id(mesh, "node")      # 0..1
+device_rank = tle.shard_id(mesh, "device")  # 0..3
+```
+
+##### 3.2.5.6 `tle.remote` + `tle.distributed_barrier`
 
 - `tle.remote`：显式读取/写入远端分片。
 - `tle.distributed_barrier`：仅同步传入 mesh/sub-mesh 对应的设备集合。
@@ -428,9 +443,10 @@ x_full = tle.reshard(x, spec=tle.sharding(mesh, split=[], partial=[]))
 示例：读取相邻 shard（ring 风格交换）
 
 ```python
-rank = tle.program_rank(mesh)
-next_rank = (rank + 1) % mesh.shape[0]
-remote_x = tle.remote(x, shard_id=(next_rank,), scope="device")
+node_rank = tle.shard_id(mesh, "node")
+device_rank = tle.shard_id(mesh, "device")
+next_device = (device_rank + 1) % mesh.shape[1]
+remote_x = tle.remote(x, shard_id=(node_rank, next_device), scope=mesh)
 tle.distributed_barrier(mesh)
 neighbor_vals = tl.load(remote_x)
 ```
@@ -895,7 +911,7 @@ TopK Selector 性能使用 `python/tutorials/tle/deepseek_v32/01-topk_selector.p
 
 - 运行参数：本机（GeForce RTX 5060 Ti）执行 `--skip_correctness --warmup 10 --rep 80`。
 
-| batch | seq_len | topk | Torch-TopK | Triton-Radix | TileLang | TLE-Radix | **加速比（Torch-TopK / min(Triton-Radix, TileLang, TLE-Radix)）** |
+| batch | seq_len | topk | Torch-TopK | Triton-Radix | TileLang | TLE-Radix | **加速比（Torch-TopK / TLE-Radix）** |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | 64 | 4096 | 128 | 0.038912 | 0.039456 | 0.020480 | **0.015808** | 2.46x |
 | 64 | 8192 | 256 | 0.088624 | 0.053248 | 0.028672 | **0.023936** | 3.70x |
@@ -904,9 +920,9 @@ TopK Selector 性能使用 `python/tutorials/tle/deepseek_v32/01-topk_selector.p
 
 #### 4.4.2 H800（`tle-radix-topk-selector`）
 
-| batch | seq_len | topk | Torch-TopK | Triton-Radix | TileLang | TLE-Radix | **加速比（Torch-TopK / min(Triton-Radix, TileLang, TLE-Radix)）** |
+| batch | seq_len | topk | Torch-TopK | Triton-Radix | TileLang | TLE-Radix | **加速比（Torch-TopK / TLE-Radix）** |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| 64 | 4096 | 128 | 0.045728 | 0.054256 | **0.017200** | 0.017472 | 2.66x |
+| 64 | 4096 | 128 | 0.045728 | 0.054256 | **0.017200** | 0.017472 | 2.62x |
 | 64 | 8192 | 256 | 0.097344 | 0.072512 | 0.020960 | **0.020928** | 4.65x |
 | 64 | 32768 | 1024 | 0.125008 | 0.176768 | 0.043088 | **0.041856** | 2.99x |
 | 64 | 32768 | 2048 | 0.125072 | 0.179264 | 0.044256 | **0.041984** | 2.98x |


### PR DESCRIPTION
## PR Summary

This PR stabilizes the TLE migration on Triton 3.6 by enforcing strict TLE/non-TLE separation and aligning native paths with upstream 3.6 behavior.

### Key Changes

1. **Restored native Triton 3.6 behavior on non-TLE paths**
- Added `#ifdef __TLE__` guards for TLE-specific logic in native Triton files.
- Ensured non-TLE code paths remain consistent with Triton 3.6 defaults.

2. **Fixed TLE-related compile breakages**
- Updated atomic lowering in `LoadStoreOpToLLVM.cpp` to keep 3.6-style construction and usage patterns while preserving TLE functionality.
- Removed temporary divergence patterns and simplified shared code where possible.

3. **Guarded TLE-only pipeliner/utility behavior**
- `AssignLatencies.cpp`: TLE-only pointer/address-space checks are now gated under `__TLE__`.
- `Utility.cpp`: TLE-specific shared-memory source acceptance (`tt.memory_space == "shared_memory"`) is now gated under `__TLE__`.

4. **Fixed shared-memory hint lowering regressions**
- `ProcessSharedMemoryHint.cpp`: fixed memdesc view construction so it does not violate updated memdesc verification constraints in 3.6.

5. **Cleaned up TLE Python module structure and imports**
- Removed broad top-level aliasing in `triton.experimental.tle.language` (e.g., `alloc = gpu.alloc` style exports).
- Removed distributed API import coupling from `triton.experimental.tle.language.gpu`.
- Updated tests to use explicit import paths/APIs (`tle.gpu.*` where appropriate).

6. **Test and tutorial validation updates**
- Revalidated TLE test suite and adjusted test import expectations to match the cleaned module API surface.
- Kept tutorial-related behavior aligned with the new import boundaries.

### Validation

- `build-nvidia.sh` passes after these changes.
- `pytest python/test/tle -q -s` passes (`102 passed`).

### Compatibility Intent

- **Non-TLE builds**: preserve native Triton 3.6 behavior.
- **TLE builds**: keep TLE functionality/perf-oriented behavior without leaking into non-TLE paths.