### PR TITLE
[TLE] Fix atomic PTXInstr reference call in LoadStoreOpToLLVM

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1454,7 +1454,7 @@ public:
       std::string semStr;
       llvm::raw_string_ostream os(semStr);
       os << op.getSem();
-      atom->o(semStr).o(rmwOp).v(vec).o(sTy);
+      atom.o(semStr).o(rmwOp).v(vec).o(sTy);
       if (tensorTy) {
         atom(dstOpr, ptrOpr, valOpr).maybePredicate(pred);
         Type retType;


### PR DESCRIPTION
## PR Summary

This PR fixes a Triton 3.6 build regression in NVIDIA load/store lowering by aligning atomic instruction usage with Triton 3.6-style reference semantics.

### What was fixed

- Updated `third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp` in the atomic RMW path:
  - Kept atom construction in 3.6-style reference form.
  - Fixed the instruction builder call from pointer-style member access to reference-style member access.
  - This resolves the compile error caused by treating a `PTXInstr` reference as a pointer.

### Why

After recent refactoring, one call site still used pointer syntax (`->`) while `atom` was a reference, causing a C++ compile failure (`base operand of '->' has non-pointer type 'mlir::triton::PTXInstr'`).

### Validation

- Rebuilt with `build-nvidia.sh` in `conda` env `flagtree`: **pass**.
- Verified TLE test suite still passes (`python/test/tle`): **102 passed**.

### Scope

- Minimal, targeted change: one file, one semantic fix.
- No intended behavior change beyond restoring successful compilation and preserving existing lowering behavior.