### PR TITLE
[BUILD] Modify setuptools version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1"]
+requires = ["setuptools>=79.0.1,<82", "wheel", "cmake>=3.18", "ninja>=1.11.1"]
 
 [tool.yapf]
 based_on_style = "pep8"


### PR DESCRIPTION
Update `setuptools` version constraint in `pyproject.toml`. The `40.x.x` version is too old and it leads to errors when trying to install using `pip` on some platforms.


