### PR TITLE
[BUILD] Update setuptools version and project URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1"]
+requires = ["setuptools>=79.0.1,<82", "wheel", "cmake>=3.18", "ninja>=1.11.1"]
 
 [tool.yapf]
 based_on_style = "pep8"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,5 @@
-
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1"]
+requires = ["setuptools>=79.0.1,<82", "wheel", "cmake>=3.18", "ninja>=1.11.1"]
 
 # We're incrementally switching from autopep8 to ruff.
 [tool.autopep8]

--- a/python/setup.py
+++ b/python/setup.py
@@ -674,7 +674,7 @@ setup(
     zip_safe=False,
     # for PyPI
     keywords=["Compiler", "Deep Learning"],
-    url="https://github.com/triton-lang/triton/",
+    url="https://github.com/flagos-ai/FlagTree/",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
This PR updates the `setuptools` version requirement in `pyproject.toml` because the current version requirement is leading to errors for `pip` on some platforms.
This PR also updates the project URL to avoid confusion.
