### PR TITLE
[DOC] Fix install-from-source instructions for Triton 3.4+ branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,15 @@ General building and installation procedure (Recommended for environments with g
 ```shell
 # Set FLAGTREE_BACKEND using the backend name from the table above
 export FLAGTREE_BACKEND=${backend_name}  # Do not set it on nvidia/amd/triton-shared
-cd python  # Need to enter the python directory for Triton 3.1/3.2/3.3
-python3 -m pip install . --no-build-isolation -v  # Install flagtree and uninstall triton
+
+# For Triton 3.1/3.2/3.3 (main, triton_v3.2.x, triton_v3.3.x):
+cd python
+python3 -m pip install . --no-build-isolation -v
+
+# For Triton 3.4+ (triton_v3.4.x, triton_v3.5.x, triton_v3.6.x):
+# Install from the project root directory directly (setup.py is in the root)
+python3 -m pip install . --no-build-isolation -v
+
 python3 -m pip show flagtree
 cd ${ANY_OTHER_PATH}; python3 -c 'import triton; print(triton.__path__)'
 ```


### PR DESCRIPTION
## Summary

The install-from-source section in README.md only mentions `cd python` before running `pip install`. This works for Triton 3.1/3.2/3.3 branches where `setup.py` is under `python/`, but fails on Triton 3.4+ branches (triton_v3.4.x, triton_v3.5.x, triton_v3.6.x) where `setup.py` has been moved to the project root.

Running `cd python && pip install .` on these branches gives:
```
ERROR: Directory '.' is not installable. Neither 'setup.py' nor 'pyproject.toml' found.
```

## Changes

Clarified the install instructions to distinguish between:
- Triton 3.1/3.2/3.3: install from `python/` directory
- Triton 3.4+: install from project root directory