### PR TITLE
[TLE] Skip TLE cluster paths on unsupported GPUs

### DIFF
--- a/python/test/tle/integration/test_tle_distributed.py
+++ b/python/test/tle/integration/test_tle_distributed.py
@@ -28,17 +28,14 @@ BLOCK_CLUSTER_SUBMESH_COL0 = BLOCK_CLUSTER_MESH_2X2[:, 0]
 BLOCK_CLUSTER_SUBMESH_COL1 = BLOCK_CLUSTER_MESH_2X2[:, 1]
 
 
-def _require_hopper_cuda():
-    if not torch.cuda.is_available():
-        pytest.skip("Requires CUDA GPU")
-    major, _minor = torch.cuda.get_device_capability()
-    if major < 9:
-        pytest.skip("Requires NVIDIA Hopper (sm90+) for cluster instructions")
+def _has_cluster_cuda() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 9
 
 
-@pytest.fixture(scope="module", autouse=True)
-def _cuda_guard():
-    _require_hopper_cuda()
+pytestmark = pytest.mark.skipif(
+    not _has_cluster_cuda(),
+    reason="Requires NVIDIA Hopper (sm90+) for cluster instructions",
+)
 
 
 @triton.jit

--- a/python/test/tle/unit/test_tle_cluster_tutorial_skip.py
+++ b/python/test/tle/unit/test_tle_cluster_tutorial_skip.py
@@ -1,0 +1,26 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_cluster_gemm_module():
+    repo_root = Path(__file__).resolve().parents[4]
+    mod_path = repo_root / "python" / "tutorials" / "tle" / "04-cluster-gemm.py"
+    spec = importlib.util.spec_from_file_location("tle_cluster_gemm_tutorial", mod_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cluster_gemm_tutorial_skips_on_pre_sm90_cuda(monkeypatch, capsys):
+    mod = _load_cluster_gemm_module()
+    monkeypatch.setattr(mod.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(mod.torch.cuda, "get_device_capability", lambda: (8, 0))
+
+    assert mod._cluster_remote_support_skip_reason() == "cluster+remote path requires sm90+ (Hopper or newer)"
+
+    mod.main(["--m", "16", "--n", "16", "--k", "16", "--no-autotune"])
+
+    captured = capsys.readouterr()
+    assert "SKIP: cluster+remote path requires sm90+ (Hopper or newer)" in captured.out

--- a/python/tutorials/tle/04-cluster-gemm.py
+++ b/python/tutorials/tle/04-cluster-gemm.py
@@ -220,12 +220,13 @@ def _cluster_remote_gemm_kernel(
         tl.store(c_ptrs, acc.to(c_ptr.dtype.element_ty))
 
 
-def _require_cluster_remote_support() -> None:
+def _cluster_remote_support_skip_reason() -> str | None:
     if not torch.cuda.is_available():
-        raise RuntimeError("CUDA device is required")
+        return "CUDA device is required"
     major, _minor = torch.cuda.get_device_capability()
     if major < 9:
-        raise RuntimeError("cluster+remote path requires sm90+ (Hopper or newer)")
+        return "cluster+remote path requires sm90+ (Hopper or newer)"
+    return None
 
 
 def _grid_triton(M: int, N: int, BM: int, BN: int) -> tuple[int]:
@@ -510,7 +511,7 @@ def _print_results(results: list[BenchResult]) -> None:
         print(f"{r.name:<24}{r.ms:>10.3f}{r.tflops:>12.2f}{speedup:>12.2f}x")
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--m", type=int, default=4096)
     parser.add_argument("--n", type=int, default=4096)
@@ -529,9 +530,12 @@ def main() -> None:
     parser.add_argument("--tune-rep", type=int, default=30)
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--analyze-ir", action=argparse.BooleanOptionalAction, default=False)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
-    _require_cluster_remote_support()
+    skip_reason = _cluster_remote_support_skip_reason()
+    if skip_reason is not None:
+        print(f"SKIP: {skip_reason}")
+        return
 
     torch.manual_seed(args.seed)
     dtype = torch.float16


### PR DESCRIPTION
## Summary
- Skip TLE distributed cluster integration tests at module level on non-SM90 CUDA devices.
- Make the TLE cluster GEMM tutorial print a skip message and return instead of raising on unsupported devices.
- Add a regression test that simulates an Ampere CUDA device for the tutorial skip path.

## Tests
- `conda run -n flagtree pytest python/test/tle/unit/test_tle_cluster_tutorial_skip.py -q`
- `conda run -n flagtree pytest python/test/tle/integration/test_tle_distributed.py::TestTLEDistributed::test_distributed_barrier_copy -q`
- `python -m py_compile python/tutorials/tle/04-cluster-gemm.py python/test/tle/integration/test_tle_distributed.py python/test/tle/unit/test_tle_cluster_tutorial_skip.py`