### PR TITLE
[Ascend] Align Ascend do_bench_npu with CUDA's do_bench

### DIFF
--- a/third_party/ascend/CMakeLists.txt
+++ b/third_party/ascend/CMakeLists.txt
@@ -49,3 +49,4 @@ add_triton_plugin(TritonAscend
 if(TRITON_BUILD_UT)
   add_subdirectory(unittest)
 endif()
+add_subdirectory(ClearL2Cache)

--- a/third_party/ascend/ClearL2Cache/CMakeLists.txt
+++ b/third_party/ascend/ClearL2Cache/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Copyright 2026- Xcoresigma Technology Co., Ltd
+cmake_minimum_required(VERSION 3.16)
+find_package(ASC REQUIRED)
+project(ClearL2Cache LANGUAGES CXX ASC)
+find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+
+# pybind11
+execute_process(
+    COMMAND ${Python3_EXECUTABLE} -c "import pybind11; print(pybind11.get_cmake_dir())"
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE PYBIND11_CMAKE_PREFIX_PATH
+    ERROR_QUIET
+)
+find_package(pybind11 REQUIRED HINTS ${PYBIND11_CMAKE_PREFIX_PATH})
+
+pybind11_add_module(clear_l2 SHARED clear_l2.asc)
+
+get_directory_property(my_defs COMPILE_DEFINITIONS)
+remove_definitions(-DFLAGTREE_BACKEND="ascend")
+add_definitions(-DFLAGTREE_BACKEND=ascend)
+
+set(ASCEND_HOME_PATH $ENV{ASCEND_HOME_PATH})
+message("ASCEND_HOME_PATH=${ASCEND_HOME_PATH}")
+
+target_include_directories(clear_l2 PRIVATE
+  ${ASCEND_HOME_PATH}/include
+  ${ASCEND_HOME_PATH}/include/experiment/msprof
+  ${ASCEND_HOME_PATH}/aarch64-linux/pkg_inc
+)
+
+target_link_directories(clear_l2 PUBLIC
+  ${ASCEND_HOME_PATH}/lib64
+)
+
+target_link_libraries(clear_l2 PUBLIC
+  runtime
+  ascendcl
+)
+
+set(CMAKE_ASC_ARCHITECTURES "dav-2201" CACHE STRING "NPU architecture: dav-2201, dav-3510")
+target_compile_options(clear_l2 PRIVATE
+    ${TORCH_CXX_FLAGS}
+    $<$<COMPILE_LANGUAGE:ASC>:--npu-arch=${CMAKE_ASC_ARCHITECTURES}>
+)

--- a/third_party/ascend/ClearL2Cache/clear_l2.asc
+++ b/third_party/ascend/ClearL2Cache/clear_l2.asc
@@ -1,0 +1,94 @@
+// Copyright 2026- Xcoresigma Technology Co., Ltd
+#include <pybind11/pybind11.h>
+#include "runtime/runtime/rt.h"
+#include <acl/acl.h>
+#include "kernel_operator.h"
+
+constexpr int32_t BUFFER_NUM = 1;
+constexpr int32_t TILE_NUM = 256;
+
+// Ascend C Kernel
+class GmToUbCopier {
+public:
+    __aicore__ inline GmToUbCopier() {}
+    
+    __aicore__ inline void Init(GM_ADDR x, GM_ADDR z, uint32_t totalElems) {
+        this->blockIdx = AscendC::GetBlockIdx();
+        this->blockNum = AscendC::GetBlockNum();
+
+        this->blockElems = totalElems / blockNum;
+        this->tileElems = this->blockElems / TILE_NUM / BUFFER_NUM;
+
+        xGm.SetGlobalBuffer((__gm__ half*)x + this->blockIdx * this->blockElems, this->blockElems);
+        pipe.InitBuffer(inQueueX, BUFFER_NUM, this->tileElems * sizeof(half));
+    }
+
+    __aicore__ inline void Process() {
+        int32_t loopCount = TILE_NUM * BUFFER_NUM;
+        for (int32_t i = 0; i < loopCount; i++) {
+            CopyIn(i);
+            //Compute(i); // 经过VEC核进行 XOR 0操作，clearL2cache只需搬运不调用VEC核
+            //CopyOut(i);
+        }          
+    }
+
+private:
+    __aicore__ inline void CopyIn(int32_t progress) {
+        AscendC::LocalTensor<half> xLocal = inQueueX.AllocTensor<half>();
+        uint32_t elemOffset = progress * this->tileElems;
+        if (elemOffset + this->tileElems > this->blockElems) {
+            inQueueX.FreeTensor(xLocal);
+            return;
+        }
+        AscendC::DataCopy(xLocal, xGm[elemOffset], this->tileElems);
+
+        inQueueX.EnQue(xLocal);
+        xLocal = inQueueX.DeQue<half>();
+        inQueueX.FreeTensor(xLocal);
+    }
+
+private:
+    AscendC::TPipe pipe;
+    AscendC::TQue<AscendC::TPosition::VECIN, BUFFER_NUM> inQueueX;
+    AscendC::TQue<AscendC::TPosition::VECOUT, BUFFER_NUM> outQueueZ;
+    AscendC::GlobalTensor<half> xGm;
+    AscendC::GlobalTensor<half> zGm;
+    uint32_t blockIdx, blockNum;
+    uint32_t blockElems, tileElems;
+};
+
+__global__ __vector__ void do_bench_clear_kernel(
+    GM_ADDR srcGm, 
+    uint32_t totalBytes) 
+{
+    GmToUbCopier op;
+    GM_ADDR dstGm;
+    op.Init(srcGm, dstGm, totalBytes);
+    op.Process();
+}
+
+namespace py = pybind11;
+
+namespace clear_l2 {
+void do_bench_clear(void* __restrict__ x, uint32_t size, aclrtStream stream)
+{
+    uint32_t numBlocks = 24;
+    do_bench_clear_kernel<<<numBlocks, nullptr, stream>>>((uint8_t*)x,  size);
+}
+} // namespace clear_l2
+
+PYBIND11_MODULE(clear_l2, m)
+{
+    m.doc() = "do_bench_clear pybind11 interfaces";
+    m.def("do_bench_clear",
+        [](uintptr_t data_ptr, uint32_t size, uintptr_t stream_addr) {
+            auto* data = reinterpret_cast<void*>(data_ptr);
+            auto stream = reinterpret_cast<aclrtStream>(stream_addr);
+            clear_l2::do_bench_clear(data, size, stream);
+        },
+        py::arg("data_ptr"),
+        py::arg("size"),
+        py::arg("stream_addr"),
+        "Clear L2 cache: data_ptr=int, size=int, stream_addr=int"
+    );
+}

--- a/third_party/ascend/ClearL2Cache/test_l2_cache.py
+++ b/third_party/ascend/ClearL2Cache/test_l2_cache.py
@@ -1,0 +1,19 @@
+# Copyright 2026- Xcoresigma Technology Co., Ltd
+import triton
+import triton.runtime as runtime
+from triton._C.clear_l2 import do_bench_clear
+
+def test_gm_to_ub():
+    device = triton.runtime.driver.active.get_current_device()
+    stream = triton.runtime.driver.active.get_current_stream(device)
+    # size_bytes = 192 * 1024 * 1024
+    # src = torch.randint(0, 255, (size_bytes // 2,), dtype=torch.float16, device='cpu')
+    buffer = runtime.driver.active.get_empty_cache_for_benchmark()
+    print(buffer.numel())
+    do_bench_clear(buffer.data_ptr() , buffer.numel(), stream)
+
+    print(f"Test passed: {buffer.numel()*buffer.element_size()/1024/1024:.1f}MB GM→UB executed")
+    print(buffer)
+
+if __name__ == "__main__":
+    test_gm_to_ub()

--- a/third_party/ascend/backend/testing.py
+++ b/third_party/ascend/backend/testing.py
@@ -21,22 +21,20 @@
 import builtins
 import multiprocessing
 import os
+import triton
 from datetime import datetime, timezone
 
 import triton.runtime as runtime
+from triton._C.clear_l2 import do_bench_clear
 
-
-def do_bench_npu(funcs, warmup=5, active=30, clear_l2_cache=False, prof_dir=None, keep_res=False, collect_prof=True):
+def do_bench_npu(funcs, warmup=25, active=100, prof_dir=None, clear_l2_cache=False, keep_res=False, collect_prof=True, return_mode="mean", quantiles=None):
     import torch
     import torch_npu
 
+    assert return_mode in ["min", "max", "mean", "median", "all"]
+
     if not isinstance(funcs, list):
         funcs = [funcs]
-
-    # warmup kernel
-    for fn in funcs:
-        fn()
-        torch.npu.synchronize()
 
     experimental_config = torch_npu.profiler._ExperimentalConfig(
         aic_metrics=torch_npu.profiler.AiCMetrics.PipeUtilization,
@@ -56,11 +54,34 @@ def do_bench_npu(funcs, warmup=5, active=30, clear_l2_cache=False, prof_dir=None
         torch_path = os.path.join(base_path, f"prof_{timestamp}_{process_name}-{pid}")
 
     if clear_l2_cache:
+        device = triton.runtime.driver.active.get_current_device()
+        stream = triton.runtime.driver.active.get_current_stream(device)
         buffer = runtime.driver.active.get_empty_cache_for_benchmark()
-        buffer.zero_()
+        do_bench_clear(buffer.data_ptr(), buffer.numel(), stream)
         torch.npu.synchronize()  # shake out of any npu error
 
-    total = warmup + active
+    # cal warmup num
+    di = runtime.driver.active.get_device_interface()
+    for fn in funcs:
+        fn()
+        di.synchronize()
+
+    cache = runtime.driver.active.get_empty_cache_for_benchmark()
+    start_event = di.Event(enable_timing=True)
+    end_event = di.Event(enable_timing=True)
+    start_event.record()
+    for fn in funcs:
+        for _ in range(5):
+            cache.zero_()
+            fn()
+    end_event.record()
+    di.synchronize()
+    estimate_ms = start_event.elapsed_time(end_event) / 5
+
+    n_warmup = min(5, max(1, int(warmup / estimate_ms)))
+    n_repeat = min(30, max(1, int(active / estimate_ms)))
+
+    total =  n_warmup + n_repeat
     with torch_npu.profiler.profile(
             activities=[torch_npu.profiler.ProfilerActivity.NPU],
             on_trace_ready=torch_npu.profiler.tensorboard_trace_handler(torch_path),
@@ -71,26 +92,32 @@ def do_bench_npu(funcs, warmup=5, active=30, clear_l2_cache=False, prof_dir=None
             with_modules=False,
             experimental_config=experimental_config,
     ) as prof:
+        # Run for 300 μs to raise the frequency to 800.
+        mat_a = torch.randn(4096, 4096).to(dtype=torch.bfloat16)
+        mat_b = torch.randn(4096, 4096).to(dtype=torch.bfloat16)
+        mat_c = torch.matmul(mat_a, mat_b)
+        mat_c.cpu()
+
         for fn in funcs:
+            # execute
             for _ in builtins.range(total):
                 if clear_l2_cache:
-                    buffer.zero_()
+                    do_bench_clear(buffer.data_ptr(), buffer.numel(), stream)
                 fn()
                 torch.npu.synchronize()
-    if clear_l2_cache:
-        del buffer
 
     if collect_prof:
-        time_cost = _collect_prof_result(torch_path, funcs, warmup, active)
+        time_cost = _collect_prof_result(torch_path, funcs, n_warmup, n_repeat, return_mode=return_mode, quantiles=quantiles) # read kernel_details.csv
     else:
-        time_cost = _collect_single(torch_path)
+        time_cost = _collect_single(torch_path, return_mode=return_mode) # read op_static.csv
     _rm_dic(keep_res, torch_path)
     return time_cost
 
 
 # keep the original behavior to get the statistics for the specified kernel func
-def _collect_single(base_dir: str, key: str = None) -> float:
+def _collect_single(base_dir: str, key: str = None, print_flag=True, return_mode="mean") -> float:
     if not os.path.exists(base_dir):
+        print("if not os.path.exits(base_dir)")
         return float("inf")
 
     import pandas as pd
@@ -101,29 +128,51 @@ def _collect_single(base_dir: str, key: str = None) -> float:
                 continue
             target_file = os.path.join(root, file)
             df = pd.read_csv(target_file)
-            print(df)
+            if print_flag:
+                print(df)
             if key is not None:
                 key_rows = df[df["OP Type"].str.startswith(key, na=False)]
                 if not key_rows.empty:
-                    return key_rows["Avg Time(us)"].values[0]
+                    if return_mode == "all":
+                        return key_rows["Total Time(us)"].values[0]
+                    elif return_mode == "min":
+                        return key_rows["Min Time(us)"].values[0]
+                    elif return_mode == "max":
+                        return key_rows["Max Time(us)"].values[0]
+                    elif return_mode == "mean":
+                        return key_rows["Avg Time(us)"].values[0]
+                    else:
+                        assert return_mode in ["min", "max", "mean", "all"], "not support other mode"
                 return float("inf")
             else:
                 # default: read the first row except header
                 # return df.loc[0, "Avg Time(us)"]
-                # default: extract ZerosLike time (L2 cache clear operation)
-                filter_cond = df["OP Type"].str.contains(r"^ZerosLike$", case=False, na=False)
+                # default: extract clear L2 cache time (L2 cache clear operation)
+                filter_cond = df["OP Type"].str.contains(r"do_bench_clear", case=False, na=False)
                 filter_df = df[filter_cond]
                 if not filter_df.empty:
-                    zeroslike_time = filter_df.iloc[0]['Avg Time(us)']
-                    print("Clear L2 cache time:", zeroslike_time)
+                    clear_l2_time = filter_df.iloc[0]['Avg Time(us)']
+                    if print_flag:
+                        print("Clear L2 cache time:", clear_l2_time)
 
-                # Calculate total time of all operators excluding ZerosLike
-                non_zeroslike_df = df[~df["OP Type"].str.contains(r"^ZerosLike$", case=False, na=False)]
-                all_ops_total_time = non_zeroslike_df['Avg Time(us)'].sum()
-                all_ops_total_time = round(all_ops_total_time, 3)
-                print("All ops total time:", all_ops_total_time)
+                # Calculate total time of all operators excluding clear l2 cache
+                non_clearL2_df = df[~df["OP Type"].str.contains(r"do_bench_clear", case=False, na=False)]
+                if return_mode == "all":
+                    ops_time = non_clearL2_df["Total Time(us)"].sum()
+                elif return_mode == "min":
+                    ops_time = non_clearL2_df["Min Time(us)"].sum()
+                elif return_mode == "max":
+                    ops_time = non_clearL2_df["Max Time(us)"].sum()
+                elif return_mode == "mean":
+                    ops_time = non_clearL2_df["Avg Time(us)"].sum()
+                else:
+                    assert return_mode in ["min", "max", "mean", "all"], "not support other mode"
+                # all_ops_total_time = non_clearL2_df['Avg Time(us)'].sum()
+                ops_time = round(ops_time, 3)
+                if print_flag:
+                    print(f"All ops {return_mode} time:", ops_time)
 
-                return all_ops_total_time
+                return ops_time
 
     return float("inf")
 
@@ -137,7 +186,7 @@ def _rm_dic(keep_res, torch_path):
         shutil.rmtree(torch_path)
 
 
-def _collect_prof_result(base_dir: str, funcs, num_warmup: int, num_active: int, key: str = None):
+def _collect_prof_result(base_dir: str, funcs, num_warmup: int, num_active: int, key: str = None, return_mode="mean", quantiles=None):
     """
     Collect kernel performance from kernel_details.csv, returned in millisecond.
     The first `num_warmup` rows of each function are warmup data and will be ignored, the next `num_active` rows will be averaged.
@@ -152,10 +201,15 @@ def _collect_prof_result(base_dir: str, funcs, num_warmup: int, num_active: int,
     :type num_active: int
     :param key: filter key for kernel name
     :type key: str
+    :param return mode
+    :type return_mode: str
+    :param quantiles: Performance percentile to return in addition to the median.
+    :type quantiles: list[float], optional
     """
 
     import numpy as np
     import pandas as pd
+    import torch
 
     kernel_details_file = None
     for root, _, files in os.walk(base_dir):
@@ -172,20 +226,37 @@ def _collect_prof_result(base_dir: str, funcs, num_warmup: int, num_active: int,
 
     df = pd.read_csv(kernel_details_file)
     # filter out l2 cache clearing operation
-    filter_cond = ~df["Type"].str.contains(r"^ZerosLike$", case=False, na=False)
+    filter_cond = ~df["Type"].str.contains(r"do_bench_clear", case=False, na=False)
     filter_df = df[filter_cond]
     if key is not None:
         key_rows = filter_df[filter_df["Name"].str.contains(key, na=False)]
     else:
         key_rows = filter_df
-    time_cost = [0] * num_funcs
+
+    times = []
     for func_idx in np.arange(0, num_funcs):
         for active_index in np.arange(0, num_active):
             row_index = func_idx * (num_warmup + num_active) + num_warmup + active_index
-            time_cost[func_idx] += key_rows.iloc[row_index]["Duration(us)"]
-    time_cost = [x / num_active / 1e3 for x in time_cost]
+            times.append(float(key_rows.iloc[row_index]["Duration(us)"]))
 
-    if num_funcs == 1:
-        return time_cost[0]
+    if quantiles is not None and len(quantiles) > 0:
+        if not all(0.0 <= q <= 1.0 for q in quantiles):
+            raise ValueError("quantiles values must be in range [0.0, 1.0].")
+        # 0.0~1.0 to 10~100
+        q_values = np.percentile(times, [q * 100 for q in quantiles])
+        return torch.tensor(q_values, dtype=torch.float32)
+
+    if return_mode == "all":
+        return sum(times)
+    elif return_mode == "min":
+        return min(times)
+    elif return_mode == "max":
+        return max(times)
+    elif return_mode == "median":
+        import statistics
+        return statistics.median(times)
+    elif return_mode == "mean":
+        import statistics
+        return statistics.mean(times)
     else:
-        return time_cost
+        raise ValueError(f"return_mode '{return_mode}' not supported. Use 'min', 'max', 'mean', 'median', or 'all'.")


### PR DESCRIPTION
[FEAT] Align do_bench_npu with CUDA's do_bench
1. add a new ascendC kernel to clear L2 and avoid time calculation error because of torch API
2. add return mode to get "min/max/median/mean" results
3. add matmul kernel before benchmark to stabilize Ascend NPU frequency
4. change do_bench_npu warmup/active from iteration count to duration (ms)
<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->
