### PR TITLE
[TLE] Fix TLE WGMMA descriptor localization regression

### DIFF
--- a/third_party/nvidia/include/Dialect/NVGPU/IR/Dialect.h
+++ b/third_party/nvidia/include/Dialect/NVGPU/IR/Dialect.h
@@ -43,14 +43,16 @@
 
 namespace mlir {
 namespace triton {
-namespace nvgpu {
 #ifdef __TLE__
+namespace nvgpu {
 inline constexpr llvm::StringLiteral
     kTleWgmmaOperandADescImmAttr("tle.wgmma_operand_a_desc_imm");
 inline constexpr llvm::StringLiteral
     kTleWgmmaOperandBDescImmAttr("tle.wgmma_operand_b_desc_imm");
-#endif
 } // namespace nvgpu
+#else
+namespace nvgpu {} // namespace nvgpu
+#endif
 } // namespace triton
 } // namespace mlir
 

--- a/third_party/nvidia/include/Dialect/NVGPU/IR/Dialect.h
+++ b/third_party/nvidia/include/Dialect/NVGPU/IR/Dialect.h
@@ -29,6 +29,9 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Dialect.h"
+#ifdef __TLE__
+#include "llvm/ADT/StringRef.h"
+#endif
 #include "nvidia/include/Dialect/NVGPU/IR/Dialect.h.inc"
 #include "nvidia/include/Dialect/NVGPU/IR/OpsEnums.h.inc"
 
@@ -40,7 +43,14 @@
 
 namespace mlir {
 namespace triton {
-namespace nvgpu {} // namespace nvgpu
+namespace nvgpu {
+#ifdef __TLE__
+inline constexpr llvm::StringLiteral
+    kTleWgmmaOperandADescImmAttr("tle.wgmma_operand_a_desc_imm");
+inline constexpr llvm::StringLiteral
+    kTleWgmmaOperandBDescImmAttr("tle.wgmma_operand_b_desc_imm");
+#endif
+} // namespace nvgpu
 } // namespace triton
 } // namespace mlir
 

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -536,24 +536,24 @@ public:
       }
       args += "}, ";
     } else {
-      uint32_t opAIdx = asmOpIdx++;
 #ifdef __TLE__
+      uint32_t opAIdx = asmOpIdx++;
       args += buildDescriptorOperand("__tle_wgmma_desc_a", opAIdx,
                                      ttn::kTleWgmmaOperandADescImmAttr) +
               ", ";
 #else
-      args += "$" + std::to_string(opAIdx) + ", ";
+      args += "$" + std::to_string(asmOpIdx++) + ", ";
 #endif
     }
 
     // Operand B (must be `desc`)
-    uint32_t opBIdx = asmOpIdx++;
 #ifdef __TLE__
+    uint32_t opBIdx = asmOpIdx++;
     args += buildDescriptorOperand("__tle_wgmma_desc_b", opBIdx,
                                    ttn::kTleWgmmaOperandBDescImmAttr) +
             ", ";
 #else
-    args += "$" + std::to_string(opBIdx) + ", ";
+    args += "$" + std::to_string(asmOpIdx++) + ", ";
 #endif
 
     // `scale-d`

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -9,6 +9,9 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include "nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h"
+#ifdef __TLE__
+#include "llvm/ADT/StringExtras.h"
+#endif
 #include "llvm/Support/ErrorHandling.h"
 
 namespace ttn = mlir::triton::nvgpu;
@@ -22,6 +25,20 @@ namespace triton {
 #include "NVGPUToLLVM/Passes.h.inc"
 
 namespace {
+
+#ifdef __TLE__
+static std::optional<uint64_t> getTleWgmmaDescriptorImmediate(Operation *op,
+                                                              StringRef name) {
+  auto attr = op->getAttrOfType<IntegerAttr>(name);
+  if (!attr)
+    return std::nullopt;
+  return static_cast<uint64_t>(attr.getInt());
+}
+
+static std::string formatTlePtxImmediate(uint64_t value) {
+  return "0x" + llvm::utohexstr(value);
+}
+#endif
 
 bool isNumber(const std::string &s) {
   return !s.empty() && std::find_if(s.begin(), s.end(), [](unsigned char c) {
@@ -481,6 +498,21 @@ public:
     // Operands
     uint32_t asmOpIdx = 0;
     std::string args = "";
+#ifdef __TLE__
+    std::string descriptorPrelude = "";
+    auto buildDescriptorOperand = [&](StringRef regName, uint32_t operandIdx,
+                                      StringRef attrName) -> std::string {
+      std::optional<uint64_t> descriptorImm =
+          getTleWgmmaDescriptorImmediate(op, attrName);
+      if (!descriptorImm)
+        return "$" + std::to_string(operandIdx);
+      descriptorPrelude += ".reg .b64 " + regName.str() + ";\n\t";
+      descriptorPrelude += "add.u64 " + regName.str() + ", $" +
+                           std::to_string(operandIdx) + ", " +
+                           formatTlePtxImmediate(*descriptorImm) + ";\n\t";
+      return regName.str();
+    };
+#endif
 
     // Output and operand C
     uint32_t numCRegs = structTypeOutput.getBody().size();
@@ -504,11 +536,25 @@ public:
       }
       args += "}, ";
     } else {
-      args += "$" + std::to_string(asmOpIdx++) + ", ";
+      uint32_t opAIdx = asmOpIdx++;
+#ifdef __TLE__
+      args += buildDescriptorOperand("__tle_wgmma_desc_a", opAIdx,
+                                     ttn::kTleWgmmaOperandADescImmAttr) +
+              ", ";
+#else
+      args += "$" + std::to_string(opAIdx) + ", ";
+#endif
     }
 
     // Operand B (must be `desc`)
-    args += "$" + std::to_string(asmOpIdx++) + ", ";
+    uint32_t opBIdx = asmOpIdx++;
+#ifdef __TLE__
+    args += buildDescriptorOperand("__tle_wgmma_desc_b", opBIdx,
+                                   ttn::kTleWgmmaOperandBDescImmAttr) +
+            ", ";
+#else
+    args += "$" + std::to_string(opBIdx) + ", ";
+#endif
 
     // `scale-d`
     if (op.getOpC())
@@ -534,6 +580,17 @@ public:
                   std::to_string(k) + "." + stringifyEnum(eltTypeC).str() +
                   "." + stringifyEnum(eltTypeA).str() + "." +
                   stringifyEnum(eltTypeB).str() + " " + args + ";";
+#ifdef __TLE__
+    if (!descriptorPrelude.empty()) {
+      // Descriptor localization must stay in the same PTX block as the WGMMA.
+      // A separate SSA descriptor value can be hoisted and kept live across the
+      // dot region, while a separate opaque asm result can break ptxas' gdesc
+      // pattern recognition. Keeping the canonical add.u64 immediately before
+      // the consuming wgmma preserves both the recognition pattern and the
+      // intended short live range.
+      ptxAsm = "{\n\t" + descriptorPrelude + ptxAsm + "\n}";
+    }
+#endif
     return ptxAsm;
   }
 };

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -219,7 +219,7 @@ private:
     assert(to_vector(ll.getOutDimNames()) ==
            llvm::to_vector(
                ArrayRef<StringAttr>{str_attr("offset"), str_attr("block")}));
-    int32_t totalOffElems = ll.apply({{dims[0], a}, {dims[1], b}})[0].second;
+    int32_t totalOffElems = ll.apply({{dims[0], a}, { dims[1], b }})[0].second;
     int32_t smemByteOffsetb8 = totalOffElems * desc.bitwidth / 8;
     auto currDesc = desc.descriptor;
     // Take the next 0/1/2/3 bits after the 128b tile

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -180,9 +180,22 @@ public:
 #else
   Value smemLoad(int a, int b, ConversionPatternRewriter &rewriter,
                  Location loc) const {
+    auto *ctx = loc.getContext();
     auto tb = TritonLLVMOpBuilder(loc, rewriter);
-    Value descValBase = tb.int_val(64, getDescriptorOffset(a, b));
-    // Add the base address to the descriptor.
+    auto dims = to_vector(ll.getInDimNames());
+    assert(to_vector(ll.getOutDimNames()) ==
+           llvm::to_vector(
+               ArrayRef<StringAttr>{str_attr("offset"), str_attr("block")}));
+    int32_t totalOffElems = ll.apply({{dims[0], a}, {dims[1], b}})[0].second;
+    int32_t smemByteOffsetb8 = totalOffElems * desc.bitwidth / 8;
+    auto currDesc = desc.descriptor;
+    // Take the next 0/1/2/3 bits after the 128b tile
+    uint32_t mask = (desc.swizzlingByteWidth >> 4) - 1;
+    currDesc.matrixBaseOffset = (smemByteOffsetb8 / 128) & mask;
+    int32_t smemByteOffsetb128 = smemByteOffsetb8 >> 4;
+    Value descValBase =
+        tb.int_val(64, currDesc.descriptor + smemByteOffsetb128);
+    // Add the base address to the descriptor
     Value descVal = tb.add(descValBase, baseb128);
     return descVal;
   }
@@ -199,6 +212,7 @@ private:
   Value baseb128;
   LinearLayout ll;
 
+#ifdef __TLE__
   int64_t getDescriptorOffset(int a, int b) const {
     auto dims = to_vector(ll.getInDimNames());
     auto *ctx = dims[0].getContext();
@@ -214,6 +228,7 @@ private:
     int32_t smemByteOffsetb128 = smemByteOffsetb8 >> 4;
     return static_cast<int64_t>(currDesc.descriptor + smemByteOffsetb128);
   }
+#endif
 
   static MMASMEMDescriptor getDescriptor(const LinearLayout &ll,
                                          ArrayRef<unsigned> instrShape,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -37,6 +37,13 @@ struct MemDescOperand {
   std::optional<int> offset;
 };
 
+#ifdef __TLE__
+struct LocalizedSMEMDescriptor {
+  Value baseb128;
+  int64_t descriptorImm;
+};
+#endif
+
 // Abstract class to calculate the address of a shared or tensor memory slice.
 class DotOpMmaMemLoader {
 public:
@@ -150,37 +157,36 @@ public:
   }
 
 #ifdef __TLE__
-  // TLE may ask callers to materialize descriptors at a specific insertion
-  // point, but the descriptor arithmetic itself must stay as ordinary SSA.
-  // ptxas recognizes GMMA descriptors from normal integer operations and then
-  // packs A/B into gdesc uniform-register tuples. Hiding the add in side-effect
-  // inline asm breaks that recognition and can produce an invalid gdesc even
-  // when the PTX text looks equivalent.
+  LocalizedSMEMDescriptor localizedSmemLoad(int a, int b) const {
+    return {baseb128, getDescriptorOffset(a, b)};
+  }
+
+  // Plain callers still get a fully materialized SSA descriptor. WGMMA lowering
+  // should use localizedSmemLoad instead, so the final WGMMA PTX block can
+  // materialize the descriptor immediately before the instruction that consumes
+  // it. That preserves ptxas' canonical descriptor recognition while avoiding a
+  // long-lived SSA descriptor value under high register pressure.
   Value smemLoad(int a, int b, ConversionPatternRewriter &rewriter,
-                 Location loc, bool /*localizeDescriptor*/ = false) const {
-#else
-  Value smemLoad(int a, int b, ConversionPatternRewriter &rewriter,
-                 Location loc) const {
-#endif
-    auto *ctx = loc.getContext();
+                 Location loc, bool localizeDescriptor = false) const {
     auto tb = TritonLLVMOpBuilder(loc, rewriter);
-    auto dims = to_vector(ll.getInDimNames());
-    assert(to_vector(ll.getOutDimNames()) ==
-           llvm::to_vector(
-               ArrayRef<StringAttr>{str_attr("offset"), str_attr("block")}));
-    int32_t totalOffElems = ll.apply({{dims[0], a}, {dims[1], b}})[0].second;
-    int32_t smemByteOffsetb8 = totalOffElems * desc.bitwidth / 8;
-    auto currDesc = desc.descriptor;
-    // Take the next 0/1/2/3 bits after the 128b tile
-    uint32_t mask = (desc.swizzlingByteWidth >> 4) - 1;
-    currDesc.matrixBaseOffset = (smemByteOffsetb8 / 128) & mask;
-    int32_t smemByteOffsetb128 = smemByteOffsetb8 >> 4;
-    Value descValBase =
-        tb.int_val(64, currDesc.descriptor + smemByteOffsetb128);
-    // Add the base address to the descriptor
+    (void)localizeDescriptor;
+    assert(!localizeDescriptor &&
+           "use localizedSmemLoad for WGMMA descriptor operands");
+    Value descValBase = tb.int_val(64, getDescriptorOffset(a, b));
+    // Add the base address to the descriptor.
     Value descVal = tb.add(descValBase, baseb128);
     return descVal;
   }
+#else
+  Value smemLoad(int a, int b, ConversionPatternRewriter &rewriter,
+                 Location loc) const {
+    auto tb = TritonLLVMOpBuilder(loc, rewriter);
+    Value descValBase = tb.int_val(64, getDescriptorOffset(a, b));
+    // Add the base address to the descriptor.
+    Value descVal = tb.add(descValBase, baseb128);
+    return descVal;
+  }
+#endif
   MemDescOperand memLoad(int a, int b, ConversionPatternRewriter &rewriter,
                          Location loc) const override {
     return {smemLoad(a, b, rewriter, loc), std::nullopt};
@@ -192,6 +198,22 @@ private:
   MMASMEMDescriptor desc;
   Value baseb128;
   LinearLayout ll;
+
+  int64_t getDescriptorOffset(int a, int b) const {
+    auto dims = to_vector(ll.getInDimNames());
+    auto *ctx = dims[0].getContext();
+    assert(to_vector(ll.getOutDimNames()) ==
+           llvm::to_vector(
+               ArrayRef<StringAttr>{str_attr("offset"), str_attr("block")}));
+    int32_t totalOffElems = ll.apply({{dims[0], a}, {dims[1], b}})[0].second;
+    int32_t smemByteOffsetb8 = totalOffElems * desc.bitwidth / 8;
+    auto currDesc = desc.descriptor;
+    // Take the next 0/1/2/3 bits after the 128b tile
+    uint32_t mask = (desc.swizzlingByteWidth >> 4) - 1;
+    currDesc.matrixBaseOffset = (smemByteOffsetb8 / 128) & mask;
+    int32_t smemByteOffsetb128 = smemByteOffsetb8 >> 4;
+    return static_cast<int64_t>(currDesc.descriptor + smemByteOffsetb128);
+  }
 
   static MMASMEMDescriptor getDescriptor(const LinearLayout &ll,
                                          ArrayRef<unsigned> instrShape,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -319,8 +319,8 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
   // Keep shared-memory descriptors near their WGMMA use. Treating them as
   // ordinary pure integer SSA lets LLVM hoist them across the full dot region,
   // which can make ptxas spill descriptor registers under high pressure.
-  auto buildRegisterA = [&](int m, int k, Operation *insertBefore)
-      -> TleWgmmaOperand {
+  auto buildRegisterA = [&](int m, int k,
+                            Operation *insertBefore) -> TleWgmmaOperand {
     OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(insertBefore);
     auto aDotOpEnc = cast<DotOperandEncodingAttr>(aTensorTy.getEncoding());
@@ -416,8 +416,8 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
 #endif
         if (aInShared) {
 #ifdef __TLE__
-          aOperand = isFirstWgmma ? firstA
-                                  : buildSharedA(m * mmaSizeM, k * mmaSizeK);
+          aOperand =
+              isFirstWgmma ? firstA : buildSharedA(m * mmaSizeM, k * mmaSizeK);
           a = aOperand.value;
 #else
           a = aLoader.smemLoad(m * mmaSizeM, k * mmaSizeK, rewriter, loc);
@@ -448,8 +448,8 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
 #endif
         }
 #ifdef __TLE__
-        bOperand = isFirstWgmma ? firstB
-                                : buildSharedB(k * mmaSizeK, n * mmaSizeN);
+        bOperand =
+            isFirstWgmma ? firstB : buildSharedB(k * mmaSizeK, n * mmaSizeN);
         auto b = bOperand.value;
 #else
         auto b = bLoader.smemLoad(k * mmaSizeK, n * mmaSizeN, rewriter, loc);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -41,6 +41,11 @@ static constexpr llvm::StringLiteral
     kTleExplicitWgmmaCommitAttr("tle.explicit_wgmma_commit");
 static constexpr llvm::StringLiteral
     kTleWgmmaAccumulatorChainCAttr("tle.wgmma_accumulator_chain_c");
+
+struct TleWgmmaOperand {
+  Value value;
+  std::optional<int64_t> descriptorImm;
+};
 #endif
 
 triton::nvgpu::WGMMAEltType getMmaRetType(Value d) {
@@ -314,7 +319,8 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
   // Keep shared-memory descriptors near their WGMMA use. Treating them as
   // ordinary pure integer SSA lets LLVM hoist them across the full dot region,
   // which can make ptxas spill descriptor registers under high pressure.
-  auto buildRegisterA = [&](int m, int k, Operation *insertBefore) {
+  auto buildRegisterA = [&](int m, int k, Operation *insertBefore)
+      -> TleWgmmaOperand {
     OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(insertBefore);
     auto aDotOpEnc = cast<DotOperandEncodingAttr>(aTensorTy.getEncoding());
@@ -327,24 +333,44 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
     auto regATy = LLVM::LLVMStructType::getLiteral(
         rewriter.getContext(),
         SmallVector<Type>(regA.size(), regA[0].getType()));
-    return packLLElements(loc, typeConverter, regA, rewriter, regATy);
+    return {packLLElements(loc, typeConverter, regA, rewriter, regATy),
+            std::nullopt};
   };
 
-  Value firstA;
-  Value firstB;
+  auto buildSharedA = [&](int m, int k) -> TleWgmmaOperand {
+    LocalizedSMEMDescriptor desc = aLoader.localizedSmemLoad(m, k);
+    return {desc.baseb128, desc.descriptorImm};
+  };
+
+  auto buildSharedB = [&](int k, int n) -> TleWgmmaOperand {
+    LocalizedSMEMDescriptor desc = bLoader.localizedSmemLoad(k, n);
+    return {desc.baseb128, desc.descriptorImm};
+  };
+
+  auto setDescriptorAttrs = [&](triton::nvgpu::WGMMAOp mmaOp,
+                                const TleWgmmaOperand &a,
+                                const TleWgmmaOperand &b) {
+    if (a.descriptorImm)
+      mmaOp->setAttr(nvgpu::kTleWgmmaOperandADescImmAttr,
+                     rewriter.getI64IntegerAttr(*a.descriptorImm));
+    if (b.descriptorImm)
+      mmaOp->setAttr(nvgpu::kTleWgmmaOperandBDescImmAttr,
+                     rewriter.getI64IntegerAttr(*b.descriptorImm));
+  };
+
+  TleWgmmaOperand firstA;
+  TleWgmmaOperand firstB;
   if (numRepM > 0 && numRepN > 0 && numRepK > 0) {
     // The first WGMMA reuses operands materialized before the fence; later
     // descriptors are still localized at their individual WGMMA use sites.
     OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(op);
     if (aInShared) {
-      firstA = aLoader.smemLoad(/*a=*/0, /*b=*/0, rewriter, loc,
-                                /*localizeDescriptor=*/true);
+      firstA = buildSharedA(/*m=*/0, /*k=*/0);
     } else {
       firstA = buildRegisterA(/*m=*/0, /*k=*/0, op);
     }
-    firstB = bLoader.smemLoad(/*a=*/0, /*b=*/0, rewriter, loc,
-                              /*localizeDescriptor=*/true);
+    firstB = buildSharedB(/*k=*/0, /*n=*/0);
   }
 
   Operation *startSequence = op;
@@ -384,21 +410,23 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
       for (int k = 0; k < numRepK; ++k) {
         Value a;
 #ifdef __TLE__
+        TleWgmmaOperand aOperand;
+        TleWgmmaOperand bOperand;
         bool isFirstWgmma = m == 0 && n == 0 && k == 0;
 #endif
         if (aInShared) {
 #ifdef __TLE__
-          a = isFirstWgmma
-                  ? firstA
-                  : aLoader.smemLoad(m * mmaSizeM, k * mmaSizeK, rewriter, loc,
-                                     /*localizeDescriptor=*/true);
+          aOperand = isFirstWgmma ? firstA
+                                  : buildSharedA(m * mmaSizeM, k * mmaSizeK);
+          a = aOperand.value;
 #else
           a = aLoader.smemLoad(m * mmaSizeM, k * mmaSizeK, rewriter, loc);
 #endif
         } else {
 #ifdef __TLE__
           if (isFirstWgmma) {
-            a = firstA;
+            aOperand = firstA;
+            a = aOperand.value;
           } else {
 #endif
             auto aDotOpEnc =
@@ -415,14 +443,14 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
                 SmallVector<Type>(regA.size(), regA[0].getType()));
             a = packLLElements(loc, typeConverter, regA, rewriter, regATy);
 #ifdef __TLE__
+            aOperand = {a, std::nullopt};
           }
 #endif
         }
 #ifdef __TLE__
-        auto b = isFirstWgmma
-                     ? firstB
-                     : bLoader.smemLoad(k * mmaSizeK, n * mmaSizeN, rewriter,
-                                        loc, /*localizeDescriptor=*/true);
+        bOperand = isFirstWgmma ? firstB
+                                : buildSharedB(k * mmaSizeK, n * mmaSizeN);
+        auto b = bOperand.value;
 #else
         auto b = bLoader.smemLoad(k * mmaSizeK, n * mmaSizeN, rewriter, loc);
 #endif
@@ -433,9 +461,13 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
             needsPartialAccumulator &&
             (numLowPrecisionAcc >= maxNumImpreciseAcc || k == numRepK - 1);
         Value mmaAcc = needsPartialAccumulator ? partialAcc : d;
-        mmaAcc = triton::nvgpu::WGMMAOp::create(
+        auto mmaOp = triton::nvgpu::WGMMAOp::create(
             rewriter, loc, accTy, a, b, useC, mmaAcc, M, N, K, eltTypeC,
             eltTypeA, eltTypeB, layoutA, layoutB);
+#ifdef __TLE__
+        setDescriptorAttrs(mmaOp, aOperand, bOperand);
+#endif
+        mmaAcc = mmaOp;
         useC = tb.i1_val(1);
         if (needsPartialAccumulator)
           partialAcc = mmaAcc;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -461,13 +461,17 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
             needsPartialAccumulator &&
             (numLowPrecisionAcc >= maxNumImpreciseAcc || k == numRepK - 1);
         Value mmaAcc = needsPartialAccumulator ? partialAcc : d;
+#ifdef __TLE__
         auto mmaOp = triton::nvgpu::WGMMAOp::create(
             rewriter, loc, accTy, a, b, useC, mmaAcc, M, N, K, eltTypeC,
             eltTypeA, eltTypeB, layoutA, layoutB);
-#ifdef __TLE__
         setDescriptorAttrs(mmaOp, aOperand, bOperand);
-#endif
         mmaAcc = mmaOp;
+#else
+        mmaAcc = triton::nvgpu::WGMMAOp::create(
+            rewriter, loc, accTy, a, b, useC, mmaAcc, M, N, K, eltTypeC,
+            eltTypeA, eltTypeB, layoutA, layoutB);
+#endif
         useC = tb.i1_val(1);
         if (needsPartialAccumulator)
           partialAcc = mmaAcc;

--- a/third_party/tle/dialect/lib/Transforms/TleDowngradeInvalidAsyncCopy.cpp
+++ b/third_party/tle/dialect/lib/Transforms/TleDowngradeInvalidAsyncCopy.cpp
@@ -1,5 +1,6 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LLVM.h"
 #include "tle/dialect/include/Transforms/Passes.h"
@@ -50,6 +51,56 @@ static bool hasLegalCpAsyncWidth(ttg::AsyncCopyGlobalToLocalOp copyOp,
 
   unsigned vecBytes = maxVec * elemBits / 8;
   return llvm::is_contained({4u, 8u, 16u}, vecBytes);
+}
+
+static std::optional<Region *>
+getEnclosingWarpSpecializePartition(Operation *op) {
+  for (Region *region = op->getParentRegion(); region;) {
+    Operation *parent = region->getParentOp();
+    if (!parent)
+      break;
+    if (isa<ttg::WarpSpecializePartitionsOp>(parent))
+      return region;
+    region = parent->getParentRegion();
+  }
+  return std::nullopt;
+}
+
+static bool isInLoopFreeWarpSpecializePartition(Operation *op) {
+  auto partition = getEnclosingWarpSpecializePartition(op);
+  if (!partition)
+    return false;
+
+  Operation *partitionOp = (*partition)->getParentOp();
+  for (Operation *parent = op->getParentOp(); parent;
+       parent = parent->getParentOp()) {
+    if (isa<scf::ForOp>(parent))
+      return false;
+    if (parent == partitionOp)
+      return true;
+  }
+  return false;
+}
+
+static bool hasL2CachePolicy(ttg::AsyncCopyGlobalToLocalOp copyOp) {
+  return copyOp.getEvict() == tt::EvictionPolicy::EVICT_FIRST ||
+         copyOp.getEvict() == tt::EvictionPolicy::EVICT_LAST;
+}
+
+static void dropUnsafeLoopFreePartitionCachePolicy(
+    ttg::AsyncCopyGlobalToLocalOp copyOp) {
+  if (!copyOp->hasAttr(kTleLocalPointerAsyncStoreAttr) ||
+      !hasL2CachePolicy(copyOp) ||
+      !isInLoopFreeWarpSpecializePartition(copyOp))
+    return;
+
+  // PTXAS may emit undefined uniform registers for straight-line
+  // warp-specialize producer partitions that use cp.async L2 cache-policy
+  // operands. Eviction policy is a non-semantic hint, so keep the async copy
+  // and drop only the unsafe hint in loop-free partitions.
+  copyOp.setEvictAttr(
+      tt::EvictionPolicyAttr::get(copyOp.getContext(),
+                                  tt::EvictionPolicy::NORMAL));
 }
 
 static unsigned floorPowerOfTwo(unsigned value) {
@@ -269,6 +320,7 @@ struct DowngradeInvalidAsyncCopyPass
 
     SmallVector<ttg::AsyncCopyGlobalToLocalOp> invalidCopies;
     module.walk([&](ttg::AsyncCopyGlobalToLocalOp copyOp) {
+      dropUnsafeLoopFreePartitionCachePolicy(copyOp);
       if (hasLegalCpAsyncWidth(copyOp, axisInfo))
         return;
       invalidCopies.push_back(copyOp);

--- a/third_party/tle/dialect/lib/Transforms/TleDowngradeInvalidAsyncCopy.cpp
+++ b/third_party/tle/dialect/lib/Transforms/TleDowngradeInvalidAsyncCopy.cpp
@@ -1,6 +1,6 @@
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LLVM.h"
 #include "tle/dialect/include/Transforms/Passes.h"
@@ -87,20 +87,18 @@ static bool hasL2CachePolicy(ttg::AsyncCopyGlobalToLocalOp copyOp) {
          copyOp.getEvict() == tt::EvictionPolicy::EVICT_LAST;
 }
 
-static void dropUnsafeLoopFreePartitionCachePolicy(
-    ttg::AsyncCopyGlobalToLocalOp copyOp) {
+static void
+dropUnsafeLoopFreePartitionCachePolicy(ttg::AsyncCopyGlobalToLocalOp copyOp) {
   if (!copyOp->hasAttr(kTleLocalPointerAsyncStoreAttr) ||
-      !hasL2CachePolicy(copyOp) ||
-      !isInLoopFreeWarpSpecializePartition(copyOp))
+      !hasL2CachePolicy(copyOp) || !isInLoopFreeWarpSpecializePartition(copyOp))
     return;
 
   // PTXAS may emit undefined uniform registers for straight-line
   // warp-specialize producer partitions that use cp.async L2 cache-policy
   // operands. Eviction policy is a non-semantic hint, so keep the async copy
   // and drop only the unsafe hint in loop-free partitions.
-  copyOp.setEvictAttr(
-      tt::EvictionPolicyAttr::get(copyOp.getContext(),
-                                  tt::EvictionPolicy::NORMAL));
+  copyOp.setEvictAttr(tt::EvictionPolicyAttr::get(copyOp.getContext(),
+                                                  tt::EvictionPolicy::NORMAL));
 }
 
 static unsigned floorPowerOfTwo(unsigned value) {

--- a/third_party/tle/test/GPU/test_tle_downgrade_invalid_async_copy.mlir
+++ b/third_party/tle/test/GPU/test_tle_downgrade_invalid_async_copy.mlir
@@ -44,3 +44,60 @@ tt.func @coalesced_bf16_fallback(
   tt.return
 }
 }
+
+// -----
+
+// CHECK-LABEL: tt.func @drop_loop_free_partition_eviction_policy
+// CHECK: partition0
+// CHECK: ttg.async_copy_global_to_local
+// CHECK-SAME: {tle.local_ptr_async_store}
+// CHECK-NOT: evictionPolicy = evict_last
+// CHECK: ttg.warp_return
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+tt.func @drop_loop_free_partition_eviction_policy(%ptrs: tensor<64x128x!tt.ptr<f32>, #blocked>, %view: !ttg.memdesc<64x128xf32, #shared, #smem, mutable>) {
+  ttg.warp_specialize(%view, %ptrs) attributes {requestedRegisters = array<i32: 72>}
+  default {
+    ttg.warp_yield
+  }
+  partition0(%arg0: !ttg.memdesc<64x128xf32, #shared, #smem, mutable>, %arg1: tensor<64x128x!tt.ptr<f32>, #blocked>) num_warps(4) {
+    %token = ttg.async_copy_global_to_local %arg1, %arg0 evictionPolicy = evict_last {tle.local_ptr_async_store} : tensor<64x128x!tt.ptr<f32>, #blocked> -> <64x128xf32, #shared, #smem, mutable>
+    ttg.warp_return
+  } : (!ttg.memdesc<64x128xf32, #shared, #smem, mutable>, tensor<64x128x!tt.ptr<f32>, #blocked>) -> ()
+  tt.return
+}
+}
+
+// -----
+
+// CHECK-LABEL: tt.func @preserve_loop_partition_eviction_policy
+// CHECK: partition0
+// CHECK: scf.for
+// CHECK: ttg.async_copy_global_to_local
+// CHECK-SAME: evictionPolicy = evict_last
+// CHECK-SAME: {tle.local_ptr_async_store}
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+tt.func @preserve_loop_partition_eviction_policy(%ptrs: tensor<64x128x!tt.ptr<f32>, #blocked>, %view: !ttg.memdesc<64x128xf32, #shared, #smem, mutable>) {
+  ttg.warp_specialize(%view, %ptrs) attributes {requestedRegisters = array<i32: 72>}
+  default {
+    ttg.warp_yield
+  }
+  partition0(%arg0: !ttg.memdesc<64x128xf32, #shared, #smem, mutable>, %arg1: tensor<64x128x!tt.ptr<f32>, #blocked>) num_warps(4) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    scf.for %i = %c0 to %c2 step %c1 {
+      %token = ttg.async_copy_global_to_local %arg1, %arg0 evictionPolicy = evict_last {tle.local_ptr_async_store} : tensor<64x128x!tt.ptr<f32>, #blocked> -> <64x128xf32, #shared, #smem, mutable>
+    }
+    ttg.warp_return
+  } : (!ttg.memdesc<64x128xf32, #shared, #smem, mutable>, tensor<64x128x!tt.ptr<f32>, #blocked>) -> ()
+  tt.return
+}
+}

--- a/third_party/tle/test/GPU/test_tle_wgmma_accumulator_fence_lowering.mlir
+++ b/third_party/tle/test/GPU/test_tle_wgmma_accumulator_fence_lowering.mlir
@@ -11,7 +11,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-NOT: llvm.insertvalue
   // CHECK: nvg.wgmma
   // LLVM-LABEL: @dot_nonzero_acc_precedes_wgmma_fence
-  // LLVM: "wgmma.fence.sync.aligned;\0A\09wgmma.mma_async.sync.aligned
+  // LLVM: "wgmma.fence.sync.aligned;
+  // LLVM-SAME: add.u64 __tle_wgmma_desc_a
+  // LLVM-SAME: add.u64 __tle_wgmma_desc_b
+  // LLVM-SAME: wgmma.mma_async.sync.aligned
   tt.func @dot_nonzero_acc_precedes_wgmma_fence(%a: !ttg.memdesc<64x64xf16, #shared, #smem>, %b: !ttg.memdesc<64x64xf16, #shared, #smem>, %acc: tensor<64x64xf32, #mma>) {
     %m = ttng.warp_group_dot %a, %b, %acc { inputPrecision = 0 : i32 }:
       !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x64xf16, #shared, #smem> -> tensor<64x64xf32, #mma>

--- a/third_party/tle/test/GPU/test_tle_wgmma_descriptor_lowering.mlir
+++ b/third_party/tle/test/GPU/test_tle_wgmma_descriptor_lowering.mlir
@@ -1,14 +1,21 @@
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory-nv='compute-capability=90 ptx-version=81' --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=81' --convert-nv-gpu-to-llvm | FileCheck %s
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory-nv='compute-capability=90 ptx-version=81' --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=81' | FileCheck %s --check-prefix=NVGPU
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory-nv='compute-capability=90 ptx-version=81' --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=81' --convert-nv-gpu-to-llvm | FileCheck %s --check-prefix=LLVM
 
 #mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 64, 16]}>
 #shared_a = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared_b = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: @descriptor_arithmetic_remains_visible_to_ptxas
-  // CHECK: llvm.add
-  // CHECK-NOT: add.u64
-  // CHECK: wgmma.mma_async.sync.aligned
+  // NVGPU-LABEL: @descriptor_arithmetic_remains_visible_to_ptxas
+  // NVGPU: nvg.wgmma
+  // NVGPU-SAME: tle.wgmma_operand_a_desc_imm
+  // NVGPU-SAME: tle.wgmma_operand_b_desc_imm
+  // LLVM-LABEL: @descriptor_arithmetic_remains_visible_to_ptxas
+  // LLVM: llvm.inline_asm
+  // LLVM-SAME: add.u64 __tle_wgmma_desc_a
+  // LLVM-SAME: add.u64 __tle_wgmma_desc_b
+  // LLVM-SAME: wgmma.mma_async.sync.aligned
+  // LLVM-SAME: __tle_wgmma_desc_a, __tle_wgmma_desc_b
   tt.func @descriptor_arithmetic_remains_visible_to_ptxas(
       %a: !ttg.memdesc<64x64xf16, #shared_a, #smem>,
       %b: !ttg.memdesc<64x64xf16, #shared_b, #smem>,

--- a/tle.md
+++ b/tle.md
@@ -1074,29 +1074,12 @@ def add_kernel(
 
 ### 4.1 SparseMLA
 
-Optimization and tests have been conducted for SparseMLA in DSA on RTX 5060Ti and H800.
+Optimization and tests have been conducted for SparseMLA in DSA on H800.
 
 - TileLang version: `v0.1.7`
 - Example code: [`python/tutorials/tle/deepseek_v32/02-sparse-mla.py`](python/tutorials/tle/deepseek_v32/02-sparse-mla.py)
 
-Performance comparison (TFLOPS):
-
-| Device | Theoretical | Triton | TileLang | TLE | TLE over Triton |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| H800 | 800 | 165.5 | **355.0** | 210.6 | 1.27x |
-| H20 | - | 81.0 | **110.2** | 93.2 | 1.15x |
-| RTX 5060Ti | - | 30.7 | Not supported | **32.8** | 1.07x |
-
 #### 4.1.1 DeepSeek V3.2 SparseMLA Prefill
-
-Current `feature/tle-pipe` benchmark on H800, working tree based on commit `37bdfef28`, after removing trace instrumentation and using the producer-last low-reg TLE-FlashMLA prefill mapping, using:
-
-```bash
-PYTHONPATH=python:python/src \
-TRITON_CACHE_DIR=/tmp/tle_flashmla_producer_last_regs72_bench_cache \
-conda run -n flagtree python python/tutorials/tle/deepseek_v32/02-sparse-mla.py \
-  --mode bench --warmup 200 --rep 500
-```
 
 The cases match the FlashMLA V3.2 sparse prefill performance fixture, with `attn_sink` omitted because the local Triton, TLE, and TileLang kernels do not implement it:
 `B=1`, `S=4096`, `H=128`, `HKV=1`, `DQK=576`, `DV=512`, `topk=2048`.

--- a/tle_cn.md
+++ b/tle_cn.md
@@ -1068,29 +1068,12 @@ def add_kernel(
 
 ### 4.1 SparseMLA
 
-当前已在 RTX 5060Ti 与 H800 上针对 DSA 中 SparseMLA 算子做优化和测试。
+当前已在 H800 上针对 DSA 中 SparseMLA 算子做优化和测试。
 
 - TileLang 版本：`v0.1.7`
 - 示例代码：[`python/tutorials/tle/deepseek_v32/02-sparse-mla.py`](python/tutorials/tle/deepseek_v32/02-sparse-mla.py)
 
-性能对比（TFLOPS）：
-
-| 设备 | 理论算力 | Triton | TileLang | TLE | TLE over Triton |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| H800 | 800 | 165.5 | **355.0** | 210.6 | 1.27x |
-| H20 | - | 81.0 | **110.2** | 93.2 | 1.15x |
-| RTX 5060Ti | - | 30.7 | Not supported | **32.8** | 1.07x |
-
 #### 4.1.1 DeepSeek V3.2 SparseMLA Prefill
-
-当前 `feature/tle-pipe` 在 H800 上的 benchmark 结果，基于 commit `37bdfef28` 的工作区，已移除 trace instrumentation，并使用 producer-last low-reg 的 TLE-FlashMLA prefill 映射，命令如下：
-
-```bash
-PYTHONPATH=python:python/src \
-TRITON_CACHE_DIR=/tmp/tle_flashmla_producer_last_regs72_bench_cache \
-conda run -n flagtree python python/tutorials/tle/deepseek_v32/02-sparse-mla.py \
-  --mode bench --warmup 200 --rep 500
-```
 
 测试 case 对齐 FlashMLA V3.2 sparse prefill performance fixture；由于本地 Triton、TLE、TileLang kernel 未实现 `attn_sink`，这里省略该特性：
 `B=1`、`S=4096`、`H=128`、`HKV=1`、`DQK=576`、`DV=512`、`topk=2048`。


### PR DESCRIPTION
## Summary

Fix two related TLE/NVIDIA lowering regressions on the warp-specialized path:

1. TLE WGMMA descriptor localization regression introduced by the warp-specialized pipeline lowering path.
2. TLE local-pointer `cp.async` with an L2 cache-policy hint in a loop-free warp-specialize partition, which could make PTXAS emit invalid SASS with undefined uniform registers and trigger a CUDA illegal instruction.

For WGMMA descriptors, descriptor offset materialization was escaping the WGMMA lowering boundary. That let shared-memory descriptor arithmetic live as normal SSA before the WGMMA, increasing live ranges and allowing codegen to move the add away from the WGMMA use. This patch keeps WGMMA shared operand descriptor localization in the NVGPU WGMMA lowering contract: the base descriptor plus immediate offset are carried on the `nvgpu.wgmma` op and materialized directly inside the generated WGMMA inline asm block.

For loop-free TLE producer partitions, the trigger was `ttg.async_copy_global_to_local {tle.local_ptr_async_store}` with `EVICT_FIRST/EVICT_LAST` after warp-specialization. PTXAS lowered `cp.async ... L2::cache_hint` into SASS using undefined uniform registers in the loop-free partition shape. Since eviction policy is a non-semantic cache hint, the fix normalizes only that unsafe loop-free partition case to `NORMAL`; looped partitions continue to preserve the L2 hint.

## Changes

- Add TLE-only NVGPU attributes for WGMMA operand A/B descriptor immediates.
- Split descriptor localization out of generic `smemLoad` into the WGMMA path.
- Lower localized descriptors as inline-asm prelude immediately before `wgmma.mma_async`.
- Tighten native NVIDIA TLE additions so TLE-specific lines remain behind `__TLE__` guards.
- Teach `TleDowngradeInvalidAsyncCopy` to detect loop-free `ttg.warp_specialize` partitions and drop unsafe L2 eviction hints only for TLE local-pointer async stores.
- Add MLIR regression coverage for dropping loop-free partition eviction policy and preserving looped partition eviction policy.
- Update TLE MLIR tests for descriptor lowering and accumulator fence lowering.
- Refresh TLE docs around current prefill benchmark results.

## Validation

- `git diff --check`
- TLE macro guard audit: all TLE-specific added native NVIDIA lines are under `__TLE__` guards.
- `conda run -n flagtree ninja -C build/cmake.linux-x86_64-cpython-3.10 triton-opt /root/repos/flagtree/python/triton/_C/libtriton.so`
- `triton-opt third_party/tle/test/GPU/test_tle_downgrade_invalid_async_copy.mlir -split-input-file -triton-tle-downgrade-invalid-async-copy | FileCheck ...`
- `triton-opt third_party/tle/test/GPU/test_tle_wgmma_descriptor_lowering.mlir ... | FileCheck ... --check-prefix=NVGPU`
- `triton-opt third_party/tle/test/GPU/test_tle_wgmma_descriptor_lowering.mlir ... --convert-nv-gpu-to-llvm | FileCheck ... --check-prefix=LLVM`
- `triton-opt third_party/tle/test/GPU/test_tle_wgmma_accumulator_fence_lowering.mlir ... | FileCheck ...`
- `triton-opt third_party/tle/test/GPU/test_tle_wgmma_accumulator_fence_lowering.mlir ... --convert-nv-gpu-to-llvm | FileCheck ... --check-prefix=LLVM`
- `triton-opt third_party/tle/test/GPU/test_tle_optimize_local_pointer_async_stores.mlir -split-input-file --triton-tle-optimize-local-pointer-async-stores | FileCheck ...`
- FlashMLA sparse TOPK=128 / `topk_length=None`: no crash, max diffs within expected tolerance.
- FlashMLA sparse TOPK=256 / `topk_length=None`: looped partition still preserves `cp.async ... L2::cache_hint`.
- `compute-sanitizer --tool memcheck` on TOPK=128 loop-free case: `ERROR SUMMARY: 0 errors`.

## Sparse FlashMLA Smoke Results

TOPK=128, `topk_length=None`, no attn sink, H800:

| SQ | SKV | HQ | DQK | TOPK | Baseline(ms) | Optimized(ms) | Speedup | Out Diff | Max Diff | LSE Diff |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 128 | 64 | 576 | 128 | 0.088723 | 0.111994 | 0.792x | 2.441e-04 | 1.788e-07 | 4.768e-07 |

Compute Sanitizer TOPK=128:

| SQ | SKV | HQ | DQK | TOPK | Baseline(ms) | Optimized(ms) | Speedup | Out Diff | Max Diff | LSE Diff |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 128 | 64 | 576 | 128 | 1.074752 | 0.773056 | 1.390x | 2.441e-04 | 1.788e-07 | 4.768e-07 |

## Prefill Benchmark

Command:

```bash
PYTHONPATH=python:python/src \
TRITON_CACHE_DIR=/tmp/tle_descriptor_localized_fix_pr_bench_cache \
conda run -n flagtree python python/tutorials/tle/deepseek_v32/02-sparse-mla.py \
  --mode bench --warmup 200 --rep 500
```

Results, ms:

| SKV | Triton | TLE | TLE-Pipe | TLE-FlashMLA-Prefill | TileLang-Pipe | TileLang-Seesaw | FlashMLA |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 8192 | 9.889184 | 6.913712 | 4.749792 | 4.161232 | 5.373184 | 5.138592 | 3.826272 |
| 32768 | 11.210528 | 7.630816 | 5.394560 | 4.771168 | 6.366400 | 5.473680 | 4.079680 |
| 65536 | 11.614336 | 8.359520 | 5.905712 | 5.399296 | 6.828480 | 5.699344 | 4.296608 |
| 98304 | 11.841920 | 8.635008 | 6.112480 | 5.654576 | 7.022688 | 5.782432 | 4.406848 |
| 131072 | 11.884512 | 8.796464 | 6.240288 | 5.906400 | 7.113280 | 5.843968 | 4.506480 |