### PR TITLE
[TLE] Expose Ascend TLE pipeline support 

### DIFF
--- a/python/triton/experimental/tle/language/dsa/ascend/__init__.py
+++ b/python/triton/experimental/tle/language/dsa/ascend/__init__.py
@@ -6,6 +6,12 @@ from .core import (
     L0A,
     L0B,
     L0C,
+    PIPE,
+    sub_vec_id,
+    sub_vec_num,
+    sync_block_set,
+    sync_block_wait,
+    sync_block_all,
 )
 
 __all__ = [
@@ -14,4 +20,10 @@ __all__ = [
     "L0A",
     "L0B",
     "L0C",
+    "PIPE",
+    "sub_vec_id",
+    "sub_vec_num",
+    "sync_block_set",
+    "sync_block_wait",
+    "sync_block_all",
 ]

--- a/python/triton/experimental/tle/language/dsa/ascend/core.py
+++ b/python/triton/experimental/tle/language/dsa/ascend/core.py
@@ -1,7 +1,15 @@
-from triton.language.extra.cann.extension.core import ascend_address_space
+from triton.language.extra.cann.extension.core import ascend_address_space, sub_vec_id, sub_vec_num, sync_block_set, sync_block_wait, sync_block_all
+import triton.language.extra.cann.extension as ascend_langugage_cann_extension
 
 UB = ascend_address_space.UB
 L1 = ascend_address_space.L1
 L0A = ascend_address_space.L0A
 L0B = ascend_address_space.L0B
 L0C = ascend_address_space.L0C
+
+sub_vec_id = sub_vec_id
+sub_vec_num = sub_vec_num
+sync_block_set = sync_block_set
+sync_block_wait = sync_block_wait
+sync_block_all = sync_block_all
+PIPE = ascend_langugage_cann_extension.PIPE


### PR DESCRIPTION
## Summary

- Expose Ascend TLE pipeline support through the TLE language namespace.
- Add PIPE, block synchronization, and sub-vector helper exports.
- Enable pipeline-enabled kernels to access Ascend CANN extension primitives.

## Details

This change exposes the following Ascend TLE interfaces:

- PIPE
- sub_vec_id
- sub_vec_num
- sync_block_set
- sync_block_wait
- sync_block_all
