### PR TITLE
[BUILD] fix TLE build issue - tablegen depends

### DIFF
--- a/third_party/tle/CMakeLists.txt
+++ b/third_party/tle/CMakeLists.txt
@@ -16,6 +16,8 @@ if(TRITON_BUILD_PYTHON_MODULE)
     TritonTLETransforms
     TritonIR)
   target_link_libraries(TritonTLE PRIVATE Python3::Module pybind11::headers MLIRTargetLLVMIRImport)
+  # Ensure tablegen-generated headers are available before compiling TritonTLE sources
+  add_dependencies(TritonTLE TleTableGen TritonTLETransformsIncGen)
 endif()
 
 add_subdirectory(test)


### PR DESCRIPTION
并行编译时，需要确保在 TritonTLE 编译任何源文件之前，TableGen 已经生成了所有需要的 .h.inc 文件。

加上 depends 
  add_dependencies(TritonTLE TleTableGen TritonTLETransformsIncGen)

以避免类似下面的 error
  565 2026-05-20 13:08:59 U /builds/workspace/flagtree/third_party/tle/dialect/include/IR/Dialect.h:12:10: fatal error: tle/dialect/include/IR/TleAttrDefs.h.inc: No such file or directory
   566 2026-05-20 13:08:59 U    12 | #include "tle/dialect/include/IR/TleAttrDefs.h.inc"
   567 2026-05-20 13:08:59 U       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~