### PR TITLE
[TLE] Guard shared pointer vectorization by alignment

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -204,6 +204,14 @@ struct LoadStoreConversionBase {
   }
 
 #ifdef __TLE__
+  bool isTleSharedTensorPtr(Value ptr) const {
+    auto ptrTensorTy = dyn_cast<RankedTensorType>(ptr.getType());
+    auto ptrElemTy = ptrTensorTy
+                         ? dyn_cast<PointerType>(ptrTensorTy.getElementType())
+                         : PointerType();
+    return ptrElemTy && isSharedFamilyAddressSpace(ptrElemTy.getAddressSpace());
+  }
+
   unsigned getMaxVectorSizeByAlignment(Value ptr) const {
     auto tensorTy = dyn_cast<RankedTensorType>(ptr.getType());
     if (!tensorTy)
@@ -225,6 +233,18 @@ struct LoadStoreConversionBase {
     unsigned maxMultiple = std::max<unsigned>(maxMultipleBytes / elemBytes, 1);
 
     return std::min<unsigned>(128 / pointeeBitWidth, maxMultiple);
+  }
+
+  unsigned getTleSharedPointerVectorSize(Value ptr, unsigned vec) const {
+    if (!isTleSharedTensorPtr(ptr))
+      return vec;
+
+    // AxisInfo contiguity and TLE layout hints may both propose vectorized
+    // shared-memory accesses. They are legal only up to the width whose first
+    // element alignment is proven by AxisInfo divisibility.
+    unsigned hint = tte::inferTlePointerLayoutVectorHint(ptr);
+    unsigned alignmentBound = getMaxVectorSizeByAlignment(ptr);
+    return std::min(std::max(vec, hint), alignmentBound);
   }
 #endif
 
@@ -274,21 +294,8 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
         typeConverter->convertType(getElementTypeOrSelf(op.getType()));
     unsigned vec = getVectorSize(ptr);
 #ifdef __TLE__
-    auto ptrTensorTy = dyn_cast<RankedTensorType>(ptr.getType());
-    auto ptrElemTy = ptrTensorTy
-                         ? dyn_cast<PointerType>(ptrTensorTy.getElementType())
-                         : PointerType();
-    bool isSharedTensorPtr =
-        ptrElemTy && isSharedFamilyAddressSpace(ptrElemTy.getAddressSpace());
-    if (!llMask && isSharedTensorPtr) {
-      // For TLE local/shared pointer chains, AxisInfo contiguity can be
-      // conservative on packed contiguous lanes. The layout hint may recover
-      // the lane grouping, but it is only legal up to the vector width whose
-      // first element alignment is proven by AxisInfo divisibility.
-      unsigned hint = tte::inferTlePointerLayoutVectorHint(ptr);
-      unsigned alignmentBound = getMaxVectorSizeByAlignment(ptr);
-      vec = std::max(vec, std::min(hint, alignmentBound));
-    }
+    if (!llMask)
+      vec = getTleSharedPointerVectorSize(ptr, vec);
 #endif
     unsigned numElems = getTotalElemsPerThread(ptr.getType());
     unsigned vecOrig = vec;
@@ -579,6 +586,7 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
     const bool isClusterSharedPtr =
         inferPtrAddrSpace(ptrElems).value_or(1) ==
         static_cast<unsigned>(NVVM::NVVMMemorySpace::SharedCluster);
+    vec = getTleSharedPointerVectorSize(ptr, vec);
 #else
     auto ptrElems = unpackLLElements(loc, llPtr, rewriter);
     auto valueElems = unpackLLElements(loc, llValue, rewriter);

--- a/third_party/tle/test/GPU/test_tle_local_ptr_misaligned_store.mlir
+++ b/third_party/tle/test/GPU/test_tle_local_ptr_misaligned_store.mlir
@@ -1,0 +1,26 @@
+// RUN: triton-opt %s -pass-pipeline='builtin.module(allocate-shared-memory-nv{compute-capability=120 ptx-version=88}, tritongpu-global-scratch-memory-allocation, convert-triton-gpu-to-llvm{compute-capability=120 ptx-version=88}, canonicalize, cse, convert-nv-gpu-to-llvm, convert-warp-specialize-to-llvm, canonicalize, cse, symbol-dce, convert-nvvm-to-llvm)' | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [16], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 16 : i32, ttg.target = "cuda:120", "ttg.threads-per-warp" = 32 : i32} {
+  // Layout-derived vector hints are legal only when AxisInfo divisibility proves
+  // that the first element is aligned for the requested vector width. This
+  // tensor-indexed local_ptr starts at offset 1, so it is only 4-byte aligned
+  // and must not lower to st.shared.v4.b32.
+  tt.func public @misaligned_tensor_indexed_local_ptr_store() {
+    %one = arith.constant dense<1> : tensor<128xi32, #blocked>
+    %offs0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked>
+    %offs = arith.addi %offs0, %one : tensor<128xi32, #blocked>
+    %vals = arith.constant dense<0.000000e+00> : tensor<128xf32, #blocked>
+    %smem = ttg.local_alloc {tle.barrier_group = 0 : i64} : () -> !ttg.memdesc<256xf32, #shared, #smem, mutable>
+    %ptrs = "tle.local_pointers"(%smem, %offs) {tle.barrier_group = 0 : i64} : (!ttg.memdesc<256xf32, #shared, #smem, mutable>, tensor<128xi32, #blocked>) -> tensor<128x!tt.ptr<f32, 3>, #blocked>
+    tt.store %ptrs, %vals : tensor<128x!tt.ptr<f32, 3>, #blocked>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: @misaligned_tensor_indexed_local_ptr_store
+// CHECK-NOT: st.shared.v4.b32
+// CHECK: st.shared.b32


### PR DESCRIPTION
## Summary
- Fix a probabilistic TLE Cluster GEMM crash on H100 caused by misaligned vectorized shared-memory stores.
- Clamp TLE shared-family pointer vectorization by the alignment proven through AxisInfo divisibility.
- Apply the alignment-bounded vector width to both TLE shared loads and stores, while preserving layout-based vectorization hints when alignment permits.
- Add an MLIR regression for misaligned tensor-indexed `local_ptr` stores so they lower to scalar shared stores instead of invalid `st.shared.v4.b32`.

## Root Cause
The H100 cluster GEMM failure could lower a TLE `local_ptr` store to `st.shared.v4.b32` even when the first per-lane shared address was not 16-byte aligned. The layout hint recovered a wider lane grouping than AxisInfo alignment could legally prove, so the generated PTX could raise a CUDA misaligned-address error.

## Testing
- `git diff --check origin/triton_v3.6.x...HEAD`
- `triton-opt third_party/tle/test/GPU/test_tle_local_ptr_misaligned_store.mlir ... | FileCheck third_party/tle/test/GPU/test_tle_local_ptr_misaligned_store.mlir`
- `triton-opt third_party/tle/test/GPU/test_tle_local_ptr_misaligned_load.mlir ... | FileCheck third_party/tle/test/GPU/test_tle_local_ptr_misaligned_load.mlir`
- `triton-opt third_party/tle/test/GPU/test_tle_local_ptr_vectorized_load.mlir ... | FileCheck third_party/tle/test/GPU/test_tle_local_ptr_vectorized_load.mlir`
- H100 validation on the same root-cause fix: https://github.com/flagos-ai/FlagTree/actions/runs/27114825582/job/80019647478