### PR TITLE
[TLE][MTHREADS] Support TLE Lite primitives 

### DIFF
--- a/.github/workflows/mthreads-build-and-test.yml
+++ b/.github/workflows/mthreads-build-and-test.yml
@@ -46,3 +46,6 @@ jobs:
         run: |
           set -x
           python3 -m pytest -s third_party/mthreads/python/test/unit --device musa
+          # TLE tutorials unit tests
+          python3 python/tutorials/tle/01-fft.py --only_unit_test
+          python3 python/tutorials/tle/03-topk.py --only_unit_test

--- a/python/tutorials/tle/01-fft.py
+++ b/python/tutorials/tle/01-fft.py
@@ -292,7 +292,7 @@ if _HAVE_CUTILE:
 def cutile_fft(x: torch.Tensor) -> torch.Tensor:
     if not _HAVE_CUTILE:
         raise RuntimeError("cuda.tile/cupy not available")
-    assert x.is_cuda, "input must be on CUDA"
+    assert x.device.type == DEVICE.type, "input must be on device"
     assert x.ndim == 2, "input must be 2D (M, N)"
     m, n = x.shape
     if not _is_power_of_two(n):
@@ -1096,7 +1096,7 @@ def fft_kernel_tle_reg(
 
 
 def triton_fft(x: torch.Tensor) -> torch.Tensor:
-    assert x.is_cuda, "input must be on CUDA"
+    assert x.device.type == DEVICE.type, "input must be on device"
     assert x.ndim == 2, "input must be 2D (M, N)"
     m, n = x.shape
     if not _is_power_of_two(n):
@@ -1145,7 +1145,7 @@ def triton_fft(x: torch.Tensor) -> torch.Tensor:
 
 
 def tle_fft(x: torch.Tensor) -> torch.Tensor:
-    assert x.is_cuda, "input must be on CUDA"
+    assert x.device.type == DEVICE.type, "input must be on device"
     assert x.ndim == 2, "input must be 2D (M, N)"
     m, n = x.shape
     if not _is_power_of_two(n):

--- a/python/tutorials/tle/03-topk.py
+++ b/python/tutorials/tle/03-topk.py
@@ -236,7 +236,7 @@ def triton_radix_topk(
     out_vals: torch.Tensor | None = None,
     out_idx: torch.Tensor | None = None,
 ):
-    assert x.is_cuda, "input must be on CUDA"
+    assert x.device.type == DEVICE.type, "input must be on device"
     assert x.ndim == 2, "input must be 2D (M, N)"
     n_rows, n_cols = x.shape
     if k > n_cols:
@@ -292,7 +292,7 @@ def triton_topk(
     out_vals: torch.Tensor | None = None,
     out_idx: torch.Tensor | None = None,
 ):
-    assert x.is_cuda, "input must be on CUDA"
+    assert x.device.type == DEVICE.type, "input must be on device"
     assert x.ndim == 2, "input must be 2D (M, N)"
     n_rows, n_cols = x.shape
     if k > n_cols:

--- a/third_party/mthreads/backend/compiler.py
+++ b/third_party/mthreads/backend/compiler.py
@@ -746,6 +746,8 @@ class MUSABackend(BaseBackend):
             mthreads.passes.ttgpuir.add_tle_early_assign_memory_space(pm)
         if hasattr(mthreads.passes.ttgpuir, "add_tle_select_encodings"):
             mthreads.passes.ttgpuir.add_tle_select_encodings(pm)
+        if hasattr(mthreads.passes.ttgpuir, "add_tle_lower_exclusive_cumsum"):
+            mthreads.passes.ttgpuir.add_tle_lower_exclusive_cumsum(pm)
         if hasattr(mthreads.passes.ttgpuir, "add_tle_insert_local_pointer_barriers"):
             mthreads.passes.ttgpuir.add_tle_insert_local_pointer_barriers(pm)
         if hasattr(mthreads.passes.ttgpuir, "add_tle_optimize_local_pointer_loads"):

--- a/third_party/mthreads/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
+++ b/third_party/mthreads/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
@@ -92,6 +92,9 @@ TritonGPUConversionTarget::TritonGPUConversionTarget(
 #ifdef __TLE__
   addDynamicallyLegalOp<triton::gpu::LocalAllocOp>(
       [&](Operation *op) { return isDynamicallyLegal(op, typeConverter); });
+  addDynamicallyLegalOp<mlir::triton::musa_tle::ExtractTileOp,
+                        mlir::triton::musa_tle::InsertTileOp>(
+      [&](Operation *op) { return isDynamicallyLegal(op, typeConverter); });
   addDynamicallyLegalDialect<mlir::triton::musa_tle::MUSATLEDialect>(
       [&](Operation *op) { return isDynamicallyLegal(op, typeConverter); });
 #endif

--- a/third_party/mthreads/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/third_party/mthreads/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -13,6 +13,7 @@
 #include "triton/Dialect/TritonGPU/Transforms/TritonGPUConversion.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "llvm/ADT/STLExtras.h"
 
 namespace mlir::triton {
 #define GEN_PASS_DEF_CONVERTTRITONTOTRITONGPU
@@ -800,10 +801,60 @@ void populateCFPatterns(TritonGPUTypeConverter &typeConverter,
 }
 
 #ifdef __TLE__
+struct MUSATLEExtractTilePattern
+    : public OpConversionPattern<mlir::triton::musa_tle::ExtractTileOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::triton::musa_tle::ExtractTileOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto srcTy = dyn_cast<RankedTensorType>(adaptor.getSrc().getType());
+    if (!srcTy || !srcTy.getEncoding())
+      return failure();
+
+    SmallVector<int64_t> tileShape;
+    llvm::append_range(tileShape, op.getTileShape());
+    auto resultTy = RankedTensorType::get(tileShape, srcTy.getElementType(),
+                                          srcTy.getEncoding());
+    OperationState state(
+        op.getLoc(), mlir::triton::musa_tle::ExtractTileOp::getOperationName());
+    state.addOperands({adaptor.getSrc(), adaptor.getIndex()});
+    state.addAttributes(op->getAttrs());
+    state.addTypes(resultTy);
+    Operation *newOp = rewriter.create(state);
+    rewriter.replaceOp(op, newOp->getResults());
+    return success();
+  }
+};
+
+struct MUSATLEInsertTilePattern
+    : public OpConversionPattern<mlir::triton::musa_tle::InsertTileOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::triton::musa_tle::InsertTileOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto srcTy = dyn_cast<RankedTensorType>(adaptor.getSrc().getType());
+    if (!srcTy || !srcTy.getEncoding())
+      return failure();
+
+    OperationState state(
+        op.getLoc(), mlir::triton::musa_tle::InsertTileOp::getOperationName());
+    state.addOperands(
+        {adaptor.getSrc(), adaptor.getTile(), adaptor.getIndex()});
+    state.addAttributes(op->getAttrs());
+    state.addTypes(srcTy);
+    Operation *newOp = rewriter.create(state);
+    rewriter.replaceOp(op, newOp->getResults());
+    return success();
+  }
+};
+
 void populateMUSATlePatterns(TritonGPUTypeConverter &typeConverter,
                              RewritePatternSet &patterns) {
   MLIRContext *context = patterns.getContext();
-  patterns.add<GenericOpPattern<mlir::triton::musa_tle::LocalPointersOp>>(
+  patterns.add<GenericOpPattern<mlir::triton::musa_tle::LocalPointersOp>,
+               MUSATLEExtractTilePattern, MUSATLEInsertTilePattern>(
       typeConverter, context);
 }
 #endif

--- a/third_party/mthreads/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/third_party/mthreads/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -854,6 +854,7 @@ void populateMUSATlePatterns(TritonGPUTypeConverter &typeConverter,
                              RewritePatternSet &patterns) {
   MLIRContext *context = patterns.getContext();
   patterns.add<GenericOpPattern<mlir::triton::musa_tle::LocalPointersOp>,
+               GenericOpPattern<mlir::triton::musa_tle::ExclusiveCumsumOp>,
                MUSATLEExtractTilePattern, MUSATLEInsertTilePattern>(
       typeConverter, context);
 }

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUToLLVM/AllocateSharedMemory.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUToLLVM/AllocateSharedMemory.cpp
@@ -1,6 +1,9 @@
 #include "TritonMUSAGPUToLLVM/Allocation.h"
 #include "TritonMUSAGPUToLLVM/Passes.h"
 #include "TritonMUSAGPUToLLVM/TargetInfo.h"
+#ifdef __TLE__
+#include "Dialect/MUSATLE/IR/Dialect.h"
+#endif
 #include "triton/Analysis/Allocation.h"
 #include "triton/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
@@ -194,6 +197,17 @@ static unsigned getNumScratchElemsSwizzledCvt(RankedTensorType srcTy,
 
 static unsigned getMusaScratchSizeInBytes(Operation *op,
                                           const TargetInfoBase &targetInfo) {
+#ifdef __TLE__
+  if (auto extract = dyn_cast<triton::musa_tle::ExtractTileOp>(op)) {
+    auto resultTy = cast<RankedTensorType>(extract.getResult().getType());
+    return product<int64_t>(resultTy.getShape()) * getBitwidth(resultTy) / 8;
+  }
+  if (auto insert = dyn_cast<triton::musa_tle::InsertTileOp>(op)) {
+    auto tileTy = cast<RankedTensorType>(insert.getTile().getType());
+    return product<int64_t>(tileTy.getShape()) * getBitwidth(tileTy) / 8;
+  }
+#endif
+
   auto cvtOp = dyn_cast<ConvertLayoutOp>(op);
   if (!cvtOp)
     return defaultAllocationAnalysisScratchSizeFn(op);

--- a/third_party/mthreads/python/test/unit/tle/benchmark/test_per_token_group_quant_fp8.py
+++ b/third_party/mthreads/python/test/unit/tle/benchmark/test_per_token_group_quant_fp8.py
@@ -1,0 +1,381 @@
+import argparse
+
+import pytest
+import torch
+import triton
+import triton.experimental.tle.language as tle
+import triton.language as tl
+
+DEFAULT_SHAPES = [
+    (64, 4096),
+    (128, 4096),
+    (256, 4096),
+    (1024, 4096),
+    (1024, 8192),
+    (1024, 11008),
+]
+
+DTYPES = {
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+    "fp32": torch.float32,
+}
+
+FP8_MAX = 448.0
+MIN_AMAX = 1.0e-4
+QUANT_STORAGE_DTYPE = torch.float16
+QUANT_STORAGE_NAME = "fp16"
+BENCH_COLUMNS = [
+    "M",
+    "N",
+    "Group Size",
+    "Groups/Program",
+    "TLE-TileOps (ms)",
+    "Triton-Quant (ms)",
+    "Torch-Quant (ms)",
+    "TLE vs Triton",
+    "TLE vs Torch",
+]
+PYTEST_BENCH_COLUMNS = ["DType", *BENCH_COLUMNS]
+_PYTEST_BENCH_ROWS = []
+
+
+def _musa_available():
+    return hasattr(torch, "musa") and torch.musa.is_available()
+
+
+def _environment_skip_reason():
+    if not _musa_available():
+        return "MUSA device is not available"
+    return None
+
+
+_SKIP_REASON = _environment_skip_reason()
+if _SKIP_REASON is not None and __name__ != "__main__":
+    pytest.skip(_SKIP_REASON, allow_module_level=True)
+
+
+# reference implementation from flaggems
+@triton.jit
+def _native_quant_kernel(
+    x_ptr,
+    q_ptr,
+    scale_ptr,
+    N: tl.constexpr,
+    NUM_GROUPS: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    FP8_MAX_VALUE: tl.constexpr,
+    MIN_AMAX_VALUE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    group = tl.program_id(1)
+    offsets = tl.arange(0, GROUP_SIZE)
+    cols = group * GROUP_SIZE + offsets
+
+    x = tl.load(x_ptr + row * N + cols).to(tl.float32)
+    amax = tl.max(tl.abs(x), axis=0)
+    amax = tl.maximum(amax, MIN_AMAX_VALUE)
+    scale = amax / FP8_MAX_VALUE
+    q = tl.clamp(x / scale, -FP8_MAX_VALUE, FP8_MAX_VALUE)
+
+    tl.store(q_ptr + row * N + cols, q)
+    tl.store(scale_ptr + row * NUM_GROUPS + group, scale)
+
+
+@triton.jit
+def _tle_quant_kernel(
+    x_ptr,
+    q_ptr,
+    scale_ptr,
+    N: tl.constexpr,
+    NUM_GROUPS: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    GROUPS_PER_PROGRAM: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    FP8_MAX_VALUE: tl.constexpr,
+    MIN_AMAX_VALUE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    group_block = tl.program_id(1)
+    first_group = group_block * GROUPS_PER_PROGRAM
+
+    offsets = tl.arange(0, BLOCK_N)
+    cols = first_group * GROUP_SIZE + offsets
+    mask = cols < N
+
+    row_values = tl.load(x_ptr + row * N + cols, mask=mask, other=0.0).to(tl.float32)
+    q_values = tl.full((BLOCK_N, ), 0.0, tl.float32)
+
+    for local_group in tl.static_range(0, GROUPS_PER_PROGRAM):
+        group_id = first_group + local_group
+        x_tile = tle.extract_tile(row_values, index=local_group, tile_shape=(GROUP_SIZE, ))
+        amax = tl.max(tl.abs(x_tile), axis=0)
+        amax = tl.maximum(amax, MIN_AMAX_VALUE)
+        scale = amax / FP8_MAX_VALUE
+        q_tile = tl.clamp(x_tile / scale, -FP8_MAX_VALUE, FP8_MAX_VALUE)
+        q_values = tle.insert_tile(q_values, q_tile, index=local_group)
+        tl.store(
+            scale_ptr + row * NUM_GROUPS + group_id,
+            scale,
+            mask=group_id < NUM_GROUPS,
+        )
+
+    tl.store(q_ptr + row * N + cols, q_values, mask=mask)
+
+
+def _torch_quant(x, group_size):
+    m, n = x.shape
+    num_groups = n // group_size
+    x_grouped = x.reshape(m, num_groups, group_size).to(torch.float32)
+    amax = torch.amax(torch.abs(x_grouped), dim=-1)
+    min_amax = torch.full_like(amax, MIN_AMAX)
+    scale = torch.maximum(amax, min_amax) / FP8_MAX
+    q = torch.clamp(x_grouped / scale[..., None], -FP8_MAX, FP8_MAX)
+    q = q.to(QUANT_STORAGE_DTYPE).reshape(m, n)
+    return q, scale
+
+
+def _launch_native(x, q, scale, group_size):
+    m, n = x.shape
+    num_groups = n // group_size
+    _native_quant_kernel[(m, num_groups)](
+        x,
+        q,
+        scale,
+        N=n,
+        NUM_GROUPS=num_groups,
+        GROUP_SIZE=group_size,
+        FP8_MAX_VALUE=FP8_MAX,
+        MIN_AMAX_VALUE=MIN_AMAX,
+        num_warps=4,
+    )
+    return q, scale
+
+
+def _launch_tle(x, q, scale, group_size, groups_per_program):
+    m, n = x.shape
+    num_groups = n // group_size
+    _tle_quant_kernel[(m, triton.cdiv(num_groups, groups_per_program))](
+        x,
+        q,
+        scale,
+        N=n,
+        NUM_GROUPS=num_groups,
+        GROUP_SIZE=group_size,
+        GROUPS_PER_PROGRAM=groups_per_program,
+        BLOCK_N=group_size * groups_per_program,
+        FP8_MAX_VALUE=FP8_MAX,
+        MIN_AMAX_VALUE=MIN_AMAX,
+        num_warps=4,
+    )
+    return q, scale
+
+
+def _native_quant(x, group_size):
+    m, n = x.shape
+    num_groups = n // group_size
+    q = torch.empty((m, n), device=x.device, dtype=QUANT_STORAGE_DTYPE)
+    scale = torch.empty((m, num_groups), device=x.device, dtype=torch.float32)
+    return _launch_native(x, q, scale, group_size)
+
+
+def _tle_quant(x, group_size, groups_per_program):
+    m, n = x.shape
+    num_groups = n // group_size
+    q = torch.empty((m, n), device=x.device, dtype=QUANT_STORAGE_DTYPE)
+    scale = torch.empty((m, num_groups), device=x.device, dtype=torch.float32)
+    return _launch_tle(x, q, scale, group_size, groups_per_program)
+
+
+def _parse_shape(value):
+    parts = value.split(",")
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError("shape must be M,N")
+    try:
+        m, n = int(parts[0]), int(parts[1])
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("shape must contain integers") from exc
+    if m <= 0 or n <= 0:
+        raise argparse.ArgumentTypeError("shape values must be positive")
+    return m, n
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description="Benchmark per-token group FP8 quant on MUSA.")
+    parser.add_argument("--dtype", choices=sorted(DTYPES), default="fp16")
+    parser.add_argument("--warmup", type=int, default=25)
+    parser.add_argument("--rep", type=int, default=100)
+    parser.add_argument("--shape", action="append", type=_parse_shape)
+    parser.add_argument("--group-size", type=int, default=128)
+    parser.add_argument("--groups-per-program", type=int, default=4, choices=(2, 4))
+    return parser.parse_args()
+
+
+def _require_musa():
+    if not _musa_available():
+        raise RuntimeError("MUSA device is not available")
+    return torch.device("musa")
+
+
+def _tolerances(dtype_name):
+    if dtype_name == "fp32":
+        return 1.0e-5, 1.0e-6
+    return 1.0e-2, 1.0e-2
+
+
+def _bench(fn, warmup, rep):
+    return float(triton.testing.do_bench(
+        fn,
+        device_type="musa",
+        warmup=warmup,
+        rep=rep,
+        return_mode="median",
+    ))
+
+
+def _format_table_value(column, value):
+    if column.endswith("(ms)"):
+        return f"{value:.5f}"
+    if column.startswith("TLE vs "):
+        return f"{value:.2f}"
+    if isinstance(value, (float, int)):
+        return f"{float(value):.1f}"
+    return str(value)
+
+
+def _speedup(reference_ms, tle_ms):
+    if tle_ms == 0.0:
+        return float("inf")
+    return reference_ms / tle_ms
+
+
+def _print_table(title, rows, columns):
+    string_rows = [[_format_table_value(column, row[column]) for column in columns] for row in rows]
+    widths = [max(len(column), *(len(row[i]) for row in string_rows)) for i, column in enumerate(columns)]
+    index_width = max(1, len(str(len(rows) - 1)))
+
+    print(f"{title}:")
+    print(" " * (index_width + 2) + "  ".join(f"{column:>{widths[i]}}" for i, column in enumerate(columns)))
+    for index, row in enumerate(string_rows):
+        print(f"{index:<{index_width}}  " + "  ".join(f"{value:>{widths[i]}}" for i, value in enumerate(row)))
+
+
+def _validate_shape(m, n, group_size):
+    if n % group_size != 0:
+        raise ValueError(f"shape ({m}, {n}) requires N divisible by group_size={group_size}")
+
+
+def _assert_quant_close(actual, expected):
+    torch.testing.assert_close(actual, expected, rtol=0.0, atol=1.0)
+
+
+def _run_shape(m, n, dtype_name, warmup, rep, group_size, groups_per_program, device):
+    _validate_shape(m, n, group_size)
+    dtype = DTYPES[dtype_name]
+    rtol, atol = _tolerances(dtype_name)
+    num_groups = n // group_size
+    torch.manual_seed(42)
+
+    x = (torch.randn((m, n), device=device, dtype=dtype) * 0.5).contiguous()
+    expected_q, expected_scale = _torch_quant(x, group_size)
+    native_q, native_scale = _native_quant(x, group_size)
+    tle_q, tle_scale = _tle_quant(x, group_size, groups_per_program)
+    torch.musa.synchronize()
+
+    _assert_quant_close(native_q, expected_q)
+    _assert_quant_close(tle_q, expected_q)
+    torch.testing.assert_close(native_scale, expected_scale, rtol=rtol, atol=atol)
+    torch.testing.assert_close(tle_scale, expected_scale, rtol=rtol, atol=atol)
+
+    native_q_out = torch.empty((m, n), device=device, dtype=QUANT_STORAGE_DTYPE)
+    native_scale_out = torch.empty((m, num_groups), device=device, dtype=torch.float32)
+    tle_q_out = torch.empty((m, n), device=device, dtype=QUANT_STORAGE_DTYPE)
+    tle_scale_out = torch.empty((m, num_groups), device=device, dtype=torch.float32)
+    _launch_native(x, native_q_out, native_scale_out, group_size)
+    _launch_tle(x, tle_q_out, tle_scale_out, group_size, groups_per_program)
+    torch.musa.synchronize()
+
+    torch_ms = _bench(lambda: _torch_quant(x, group_size), warmup, rep)
+    native_ms = _bench(
+        lambda: _launch_native(x, native_q_out, native_scale_out, group_size),
+        warmup,
+        rep,
+    )
+    tle_ms = _bench(
+        lambda: _launch_tle(x, tle_q_out, tle_scale_out, group_size, groups_per_program),
+        warmup,
+        rep,
+    )
+
+    return {
+        "DType": dtype_name,
+        "M": m,
+        "N": n,
+        "Group Size": group_size,
+        "Groups/Program": groups_per_program,
+        "TLE-TileOps (ms)": tle_ms,
+        "Triton-Quant (ms)": native_ms,
+        "Torch-Quant (ms)": torch_ms,
+        "TLE vs Triton": _speedup(native_ms, tle_ms),
+        "TLE vs Torch": _speedup(torch_ms, tle_ms),
+    }
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _print_pytest_bench_table_once():
+    _PYTEST_BENCH_ROWS.clear()
+    yield
+    if not _PYTEST_BENCH_ROWS:
+        return
+    _print_table(
+        f"tle-per-token-group-quant-fp8-vs-triton-vs-torch quant_storage={QUANT_STORAGE_NAME}",
+        _PYTEST_BENCH_ROWS,
+        PYTEST_BENCH_COLUMNS,
+    )
+
+
+@pytest.mark.parametrize("shape", DEFAULT_SHAPES)
+@pytest.mark.parametrize("dtype_name", tuple(DTYPES))
+@pytest.mark.parametrize("groups_per_program", (2, 4))
+def test_per_token_group_quant_fp8_correctness_and_bench(shape, dtype_name, groups_per_program):
+    row = _run_shape(
+        shape[0],
+        shape[1],
+        dtype_name,
+        warmup=1,
+        rep=1,
+        group_size=128,
+        groups_per_program=groups_per_program,
+        device=torch.device("musa"),
+    )
+    _PYTEST_BENCH_ROWS.append(row)
+
+
+def main():
+    args = _parse_args()
+    if args.group_size <= 0:
+        raise ValueError("--group-size must be positive")
+    device = _require_musa()
+    shapes = args.shape if args.shape else DEFAULT_SHAPES
+    rows = [
+        _run_shape(
+            m,
+            n,
+            args.dtype,
+            args.warmup,
+            args.rep,
+            args.group_size,
+            args.groups_per_program,
+            device,
+        ) for m, n in shapes
+    ]
+    _print_table(
+        ("tle-per-token-group-quant-fp8-vs-triton-vs-torch "
+         f"dtype={args.dtype} quant_storage={QUANT_STORAGE_NAME}"),
+        rows,
+        BENCH_COLUMNS,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/third_party/mthreads/python/test/unit/tle/test_tle.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle.py
@@ -59,6 +59,8 @@ def test_tle_copy_mthreads_bindings_are_backend_local():
     backend.load_dialects(context)
     builder = ir.builder(context)
 
+    assert hasattr(builder, "create_extract_tile")
+    assert hasattr(builder, "create_insert_tile")
     assert hasattr(builder, "create_local_pointers")
     assert hasattr(builder, "create_tma_copy")
     assert hasattr(libtriton, "mthreads")

--- a/third_party/mthreads/python/test/unit/tle/test_tle_cumsum.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_cumsum.py
@@ -1,0 +1,277 @@
+import re
+
+import pytest
+import torch
+import triton
+import triton.language as tl
+import triton.experimental.tle.language as tle
+from triton.compiler.errors import CompilationError
+
+from test_tle_utils import compile_musa, compile_to_ttir, mthreads_backend, require_mthreads_libtriton
+
+require_mthreads_libtriton()
+
+
+@triton.jit
+def _cumsum_kernel(src, exclusive_out, total_out, n: tl.constexpr, BLOCK: tl.constexpr, REVERSE: tl.constexpr):
+    offsets = tl.arange(0, BLOCK)
+    mask = offsets < n
+    values = tl.load(src + offsets, mask=mask, other=0)
+    exclusive, total = tle.cumsum(values, axis=0, reverse=REVERSE)
+    tl.store(exclusive_out + offsets, exclusive, mask=mask)
+    tl.store(total_out, total)
+
+
+@triton.jit
+def _cumsum_2d_axis_kernel(src, out, ROWS: tl.constexpr, COLS: tl.constexpr):
+    rows = tl.arange(0, ROWS)[:, None]
+    cols = tl.arange(0, COLS)[None, :]
+    values = tl.load(src + rows * COLS + cols)
+    exclusive, _ = tle.cumsum(values, axis=1)
+    tl.store(out + rows * COLS + cols, exclusive)
+
+
+@triton.jit(noinline=True)
+def _shared_cumsum_callee(buf, BLOCK: tl.constexpr):
+    offsets = tl.arange(0, BLOCK)
+    ptrs = tle.gpu.local_ptr(buf, (offsets, ))
+    values = tl.load(ptrs)
+    exclusive, _ = tle.cumsum(values, axis=0)
+    tl.store(ptrs, exclusive)
+
+
+@triton.jit
+def _shared_noinline_sentinel_kernel(out, sentinel_out, BLOCK: tl.constexpr):
+    offsets = tl.arange(0, BLOCK)
+    buf = tle.gpu.alloc((BLOCK * 2, ), dtype=tl.int32, nv_mma_shared_layout=False)
+    ptrs = tle.gpu.local_ptr(buf, (offsets, ))
+    sentinel = tle.gpu.local_ptr(buf, (BLOCK, ))
+    tl.store(ptrs, tl.full((BLOCK, ), 1, tl.int32))
+    tl.store(sentinel, 123456)
+    _shared_cumsum_callee(buf, BLOCK)
+    tl.store(out + offsets, tl.load(ptrs))
+    tl.store(sentinel_out, tl.load(sentinel))
+
+
+@triton.jit
+def _shared_scalar_base_addptr_sentinel_kernel(out, sentinel_out, BLOCK: tl.constexpr):
+    offsets = tl.arange(0, BLOCK)
+    buf = tle.gpu.alloc((BLOCK * 2, ), dtype=tl.int32, nv_mma_shared_layout=False)
+    base = tle.gpu.local_ptr(buf, (0, ))
+    ptrs = base + offsets
+    sentinel = tle.gpu.local_ptr(buf, (BLOCK, ))
+    tl.store(ptrs, tl.full((BLOCK, ), 1, tl.int32))
+    tl.store(sentinel, 654321)
+    values = tl.load(ptrs)
+    exclusive, _ = tle.cumsum(values, axis=0)
+    tl.store(ptrs, exclusive)
+    tl.store(out + offsets, tl.load(ptrs))
+    tl.store(sentinel_out, tl.load(sentinel))
+
+
+def test_tle_cumsum_builder_binding_is_backend_local():
+    from triton._C import libtriton
+    from triton._C.libtriton import ir
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    builder = ir.builder(context)
+
+    assert hasattr(builder, "create_exclusive_cumsum")
+    assert hasattr(libtriton, "mthreads")
+    assert not hasattr(libtriton, "tle")
+
+
+def test_tle_cumsum_ttir_uses_musa_tle_op():
+    ttir = compile_to_ttir(
+        _cumsum_kernel,
+        signature={
+            "src": "*fp32",
+            "exclusive_out": "*fp32",
+            "total_out": "*fp32",
+            "n": "constexpr",
+            "BLOCK": "constexpr",
+            "REVERSE": "constexpr",
+        },
+        constexprs={"n": 127, "BLOCK": 128, "REVERSE": False},
+    )
+
+    assert "musa_tle.exclusive_cumsum" in ttir, ttir
+    assert re.search(r"(?<!musa_)\btle\.exclusive_cumsum\b", ttir) is None, ttir
+
+
+def test_tle_cumsum_ttgir_lowers_to_scan_reduce():
+    compiled = compile_musa(
+        _cumsum_kernel,
+        signature={
+            "src": "*fp32",
+            "exclusive_out": "*fp32",
+            "total_out": "*fp32",
+            "n": "constexpr",
+            "BLOCK": "constexpr",
+            "REVERSE": "constexpr",
+        },
+        constexprs={"n": 127, "BLOCK": 128, "REVERSE": False},
+    )
+    ttgir = compiled.asm["ttgir"]
+
+    assert "musa_tle.exclusive_cumsum" not in ttgir, ttgir
+    assert '"tt.scan"' in ttgir, ttgir
+    assert '"tt.reduce"' in ttgir, ttgir
+    assert ("arith.subi" in ttgir) or ("arith.subf" in ttgir), ttgir
+
+
+def test_tle_cumsum_reverse_ttgir_uses_reverse_scan():
+    compiled = compile_musa(
+        _cumsum_kernel,
+        signature={
+            "src": "*fp32",
+            "exclusive_out": "*fp32",
+            "total_out": "*fp32",
+            "n": "constexpr",
+            "BLOCK": "constexpr",
+            "REVERSE": "constexpr",
+        },
+        constexprs={"n": 127, "BLOCK": 128, "REVERSE": True},
+    )
+    ttgir = compiled.asm["ttgir"]
+
+    assert '"tt.scan"' in ttgir, ttgir
+    assert "reverse = true" in ttgir, ttgir
+
+
+def test_tle_cumsum_no_musa_tle_reaches_llir():
+    compiled = compile_musa(
+        _cumsum_kernel,
+        signature={
+            "src": "*fp32",
+            "exclusive_out": "*fp32",
+            "total_out": "*fp32",
+            "n": "constexpr",
+            "BLOCK": "constexpr",
+            "REVERSE": "constexpr",
+        },
+        constexprs={"n": 127, "BLOCK": 128, "REVERSE": False},
+    )
+
+    assert "musa_tle.exclusive_cumsum" not in compiled.asm["llir"], compiled.asm["llir"]
+
+
+def test_tle_cumsum_rejects_2d_axis_1(capfd):
+    with pytest.raises((CompilationError, RuntimeError)) as excinfo:
+        compile_musa(
+            _cumsum_2d_axis_kernel,
+            signature={
+                "src": "*fp32",
+                "out": "*fp32",
+                "ROWS": "constexpr",
+                "COLS": "constexpr",
+            },
+            constexprs={"ROWS": 16, "COLS": 16},
+        )
+    diagnostics = str(excinfo.value) + capfd.readouterr().err
+    assert ("currently only rank-1 tensors are supported" in diagnostics
+            or "currently only axis=0 is supported" in diagnostics
+            or "PassManager::run failed" in diagnostics), diagnostics
+
+
+def _runtime_reference(x, n, reverse, out_dtype):
+    valid = x[:n].cpu()
+    if valid.dtype in (torch.int8, torch.int16, torch.int32):
+        work = valid.to(torch.int32)
+        if reverse:
+            exclusive = torch.flip(torch.cumsum(torch.flip(work, (0, )), 0, dtype=torch.int32), (0, )) - work
+        else:
+            exclusive = torch.cumsum(work, 0, dtype=torch.int32) - work
+        total = work.sum(dtype=torch.int32)
+    else:
+        work = valid.to(torch.float32)
+        if reverse:
+            exclusive = torch.flip(torch.cumsum(torch.flip(work, (0, )), 0), (0, )) - work
+        else:
+            exclusive = torch.cumsum(work, 0) - work
+        exclusive = exclusive.to(out_dtype)
+        total = work.sum().to(out_dtype)
+    return exclusive.to(out_dtype), total.reshape((1, ))
+
+
+def _make_runtime_input(n, torch_dtype):
+    if torch_dtype in (torch.float16, torch.float32, torch.bfloat16):
+        return torch.randint(0, 4, (n, ), device="musa").to(torch_dtype)
+    return torch.randint(-3, 4, (n, ), device="musa", dtype=torch_dtype)
+
+
+def _supports_musa_bfloat16():
+    if not torch.musa.is_available():
+        return False
+    try:
+        torch.empty((1, ), device="musa", dtype=torch.bfloat16)
+    except Exception:
+        return False
+    return True
+
+
+@pytest.mark.skipif(not torch.musa.is_available(), reason="MUSA device is not available")
+@pytest.mark.parametrize(
+    "dtype_name,torch_dtype,signature_dtype,out_dtype,out_signature",
+    [
+        ("int8", torch.int8, "*i8", torch.int32, "*i32"),
+        ("int16", torch.int16, "*i16", torch.int32, "*i32"),
+        ("int32", torch.int32, "*i32", torch.int32, "*i32"),
+        ("float16", torch.float16, "*fp16", torch.float16, "*fp16"),
+        ("float32", torch.float32, "*fp32", torch.float32, "*fp32"),
+        ("bfloat16", torch.bfloat16, "*bf16", torch.float32, "*fp32"),
+    ],
+)
+@pytest.mark.parametrize("block,n", [(128, 127), (256, 256), (512, 511)])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_tle_cumsum_runtime_matches_torch(dtype_name, torch_dtype, signature_dtype, out_dtype, out_signature, block, n,
+                                          reverse):
+    if dtype_name == "bfloat16" and not _supports_musa_bfloat16():
+        pytest.skip("MUSA bfloat16 is not available")
+
+    x = _make_runtime_input(n, torch_dtype)
+    exclusive_out = torch.empty((n, ), device="musa", dtype=out_dtype)
+    total_out = torch.empty((1, ), device="musa", dtype=out_dtype)
+
+    _cumsum_kernel[(1, )](
+        x,
+        exclusive_out,
+        total_out,
+        n,
+        BLOCK=block,
+        REVERSE=reverse,
+        num_warps=8,
+    )
+
+    expected_exclusive, expected_total = _runtime_reference(x, n, reverse, out_dtype)
+    atol = 0 if out_dtype in (torch.int32, torch.float32) else 1e-3
+    rtol = 0 if out_dtype in (torch.int32, torch.float32) else 1e-3
+    torch.testing.assert_close(exclusive_out.cpu(), expected_exclusive, rtol=rtol, atol=atol)
+    torch.testing.assert_close(total_out.cpu(), expected_total, rtol=rtol, atol=atol)
+
+
+@pytest.mark.skipif(not torch.musa.is_available(), reason="MUSA device is not available")
+def test_tle_cumsum_shared_noinline_preserves_adjacent_sentinel():
+    block = 128
+    out = torch.empty((block, ), device="musa", dtype=torch.int32)
+    sentinel = torch.empty((1, ), device="musa", dtype=torch.int32)
+
+    _shared_noinline_sentinel_kernel[(1, )](out, sentinel, BLOCK=block, num_warps=4)
+
+    torch.testing.assert_close(out.cpu(), torch.arange(0, block, dtype=torch.int32), rtol=0, atol=0)
+    torch.testing.assert_close(sentinel.cpu(), torch.tensor([123456], dtype=torch.int32), rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.musa.is_available(), reason="MUSA device is not available")
+def test_tle_cumsum_shared_scalar_base_addptr_preserves_adjacent_sentinel():
+    block = 128
+    out = torch.empty((block, ), device="musa", dtype=torch.int32)
+    sentinel = torch.empty((1, ), device="musa", dtype=torch.int32)
+
+    _shared_scalar_base_addptr_sentinel_kernel[(1, )](out, sentinel, BLOCK=block, num_warps=4)
+
+    torch.testing.assert_close(out.cpu(), torch.arange(0, block, dtype=torch.int32), rtol=0, atol=0)
+    torch.testing.assert_close(sentinel.cpu(), torch.tensor([654321], dtype=torch.int32), rtol=0, atol=0)

--- a/third_party/mthreads/python/test/unit/tle/test_tle_tile_ops.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_tile_ops.py
@@ -1,0 +1,444 @@
+import pytest
+import torch
+import triton
+import triton.language as tl
+import triton.experimental.tle.language as tle
+
+from test_tle_utils import compile_musa, mthreads_backend, require_mthreads_libtriton
+
+require_mthreads_libtriton()
+
+
+@triton.jit
+def _extract_static_scalar_kernel(x_ptr, out_ptr, sxm: tl.constexpr, sxn: tl.constexpr):
+    rows = tl.arange(0, 32)[:, None]
+    cols = tl.arange(0, 32)[None, :]
+    src = tl.load(x_ptr + rows * sxm + cols * sxn)
+    tile = tle.extract_tile(src, index=0, tile_shape=(16, 16))
+    tr = tl.arange(0, 16)[:, None]
+    tc = tl.arange(0, 16)[None, :]
+    tl.store(out_ptr + tr * 16 + tc, tile)
+
+
+@triton.jit
+def _extract_static_multidim_kernel(x_ptr, out_ptr, sxm: tl.constexpr, sxn: tl.constexpr):
+    rows = tl.arange(0, 32)[:, None]
+    cols = tl.arange(0, 32)[None, :]
+    src = tl.load(x_ptr + rows * sxm + cols * sxn)
+    tile = tle.extract_tile(src, index=[1, 1], tile_shape=(16, 16))
+    tr = tl.arange(0, 16)[:, None]
+    tc = tl.arange(0, 16)[None, :]
+    tl.store(out_ptr + tr * 16 + tc, tile)
+
+
+@triton.jit
+def _extract_dynamic_scalar_kernel(x_ptr, out_ptr, sxm: tl.constexpr, sxn: tl.constexpr):
+    rows = tl.arange(0, 32)[:, None]
+    cols = tl.arange(0, 32)[None, :]
+    src = tl.load(x_ptr + rows * sxm + cols * sxn)
+    index = tl.program_id(0)
+    tile = tle.extract_tile(src, index=index, tile_shape=(16, 16))
+    tr = tl.arange(0, 16)[:, None]
+    tc = tl.arange(0, 16)[None, :]
+    tl.store(out_ptr + tr * 16 + tc, tile)
+
+
+@triton.jit
+def _extract_dynamic_multidim_kernel(x_ptr, out_ptr, sxm: tl.constexpr, sxn: tl.constexpr):
+    rows = tl.arange(0, 32)[:, None]
+    cols = tl.arange(0, 32)[None, :]
+    src = tl.load(x_ptr + rows * sxm + cols * sxn)
+    idx_m = tl.program_id(0)
+    idx_n = tl.program_id(1)
+    tile = tle.extract_tile(src, index=[idx_m, idx_n], tile_shape=(16, 16))
+    tr = tl.arange(0, 16)[:, None]
+    tc = tl.arange(0, 16)[None, :]
+    tl.store(out_ptr + tr * 16 + tc, tile)
+
+
+@triton.jit
+def _insert_static_scalar_kernel(x_ptr, tile_ptr, out_ptr, sxm: tl.constexpr, sxn: tl.constexpr):
+    rows = tl.arange(0, 32)[:, None]
+    cols = tl.arange(0, 32)[None, :]
+    src = tl.load(x_ptr + rows * sxm + cols * sxn)
+    tr = tl.arange(0, 16)[:, None]
+    tc = tl.arange(0, 16)[None, :]
+    tile = tl.load(tile_ptr + tr * 16 + tc)
+    result = tle.insert_tile(src, tile, index=0)
+    tl.store(out_ptr + rows * 32 + cols, result)
+
+
+@triton.jit
+def _insert_static_multidim_kernel(x_ptr, tile_ptr, out_ptr, sxm: tl.constexpr, sxn: tl.constexpr):
+    rows = tl.arange(0, 32)[:, None]
+    cols = tl.arange(0, 32)[None, :]
+    src = tl.load(x_ptr + rows * sxm + cols * sxn)
+    tr = tl.arange(0, 16)[:, None]
+    tc = tl.arange(0, 16)[None, :]
+    tile = tl.load(tile_ptr + tr * 16 + tc)
+    result = tle.insert_tile(src, tile, index=[1, 1])
+    tl.store(out_ptr + rows * 32 + cols, result)
+
+
+@triton.jit
+def _insert_static_2x32_same_encoding_runtime_kernel(x_ptr, tile_ptr, out_ptr, sxm: tl.constexpr, sxn: tl.constexpr):
+    rows = tl.arange(0, 32)[:, None]
+    cols = tl.arange(0, 32)[None, :]
+    src = tl.load(x_ptr + rows * sxm + cols * sxn)
+    tr = tl.arange(0, 2)[:, None]
+    tc = tl.arange(0, 32)[None, :]
+    tile = tl.load(tile_ptr + tr * 32 + tc)
+    result = tle.insert_tile(src, tile, index=0)
+    tl.store(out_ptr + rows * 32 + cols, result)
+
+
+@triton.jit
+def _insert_dynamic_scalar_kernel(x_ptr, tile_ptr, out_ptr, sxm: tl.constexpr, sxn: tl.constexpr):
+    rows = tl.arange(0, 32)[:, None]
+    cols = tl.arange(0, 32)[None, :]
+    src = tl.load(x_ptr + rows * sxm + cols * sxn)
+    tr = tl.arange(0, 16)[:, None]
+    tc = tl.arange(0, 16)[None, :]
+    tile = tl.load(tile_ptr + tr * 16 + tc)
+    index = tl.program_id(0)
+    result = tle.insert_tile(src, tile, index=index)
+    tl.store(out_ptr + rows * 32 + cols, result)
+
+
+@triton.jit
+def _insert_dynamic_multidim_kernel(x_ptr, tile_ptr, out_ptr, sxm: tl.constexpr, sxn: tl.constexpr):
+    rows = tl.arange(0, 32)[:, None]
+    cols = tl.arange(0, 32)[None, :]
+    src = tl.load(x_ptr + rows * sxm + cols * sxn)
+    tr = tl.arange(0, 16)[:, None]
+    tc = tl.arange(0, 16)[None, :]
+    tile = tl.load(tile_ptr + tr * 16 + tc)
+    idx_m = tl.program_id(0)
+    idx_n = tl.program_id(1)
+    result = tle.insert_tile(src, tile, index=[idx_m, idx_n])
+    tl.store(out_ptr + rows * 32 + cols, result)
+
+
+@triton.jit
+def _extract_runtime_kernel(x_ptr, out_ptr, sxm: tl.constexpr, sxn: tl.constexpr, INDEX: tl.constexpr):
+    rows = tl.arange(0, 32)[:, None]
+    cols = tl.arange(0, 32)[None, :]
+    src = tl.load(x_ptr + rows * sxm + cols * sxn)
+    tile = tle.extract_tile(src, index=INDEX, tile_shape=(16, 16))
+    tr = tl.arange(0, 16)[:, None]
+    tc = tl.arange(0, 16)[None, :]
+    tl.store(out_ptr + tr * 16 + tc, tile)
+
+
+@triton.jit
+def _insert_runtime_kernel(x_ptr, tile_ptr, out_ptr, sxm: tl.constexpr, sxn: tl.constexpr, INDEX: tl.constexpr):
+    rows = tl.arange(0, 32)[:, None]
+    cols = tl.arange(0, 32)[None, :]
+    src = tl.load(x_ptr + rows * sxm + cols * sxn)
+    tr = tl.arange(0, 16)[:, None]
+    tc = tl.arange(0, 16)[None, :]
+    tile = tl.load(tile_ptr + tr * 16 + tc)
+    result = tle.insert_tile(src, tile, index=INDEX)
+    tl.store(out_ptr + rows * 32 + cols, result)
+
+
+@triton.jit
+def _extract_dynamic_runtime_kernel(x_ptr, out_ptr, sxm: tl.constexpr, sxn: tl.constexpr):
+    rows = tl.arange(0, 32)[:, None]
+    cols = tl.arange(0, 32)[None, :]
+    src = tl.load(x_ptr + rows * sxm + cols * sxn)
+    index = tl.program_id(0)
+    tile = tle.extract_tile(src, index=index, tile_shape=(16, 16))
+    tr = tl.arange(0, 16)[:, None]
+    tc = tl.arange(0, 16)[None, :]
+    tl.store(out_ptr + index * 16 * 16 + tr * 16 + tc, tile)
+
+
+@triton.jit
+def _insert_dynamic_runtime_kernel(x_ptr, tile_ptr, out_ptr, sxm: tl.constexpr, sxn: tl.constexpr):
+    rows = tl.arange(0, 32)[:, None]
+    cols = tl.arange(0, 32)[None, :]
+    src = tl.load(x_ptr + rows * sxm + cols * sxn)
+    tr = tl.arange(0, 16)[:, None]
+    tc = tl.arange(0, 16)[None, :]
+    index = tl.program_id(0)
+    tile = tl.load(tile_ptr + index * 16 * 16 + tr * 16 + tc)
+    result = tle.insert_tile(src, tile, index=index)
+    tl.store(out_ptr + index * 32 * 32 + rows * 32 + cols, result)
+
+
+def _compile(fn):
+    return compile_musa(
+        fn,
+        signature={
+            "x_ptr": "*fp32",
+            "tile_ptr": "*fp32",
+            "out_ptr": "*fp32",
+            "sxm": "constexpr",
+            "sxn": "constexpr",
+        },
+        constexprs={"sxm": 32, "sxn": 1},
+    )
+
+
+def _compile_extract(fn):
+    return compile_musa(
+        fn,
+        signature={"x_ptr": "*fp32", "out_ptr": "*fp32", "sxm": "constexpr", "sxn": "constexpr"},
+        constexprs={"sxm": 32, "sxn": 1},
+    )
+
+
+def _assert_static_non_cta_default_blocked_tile(ttgir, *, tile_shape=(16, 16), same_tile_encoding=True):
+    tile_m, tile_n = tile_shape
+    assert f"tile_shape = array<i64: {tile_m}, {tile_n}>" in ttgir, ttgir
+    assert "tensor<32x32xf32, #blocked>" in ttgir, ttgir
+    if same_tile_encoding:
+        assert f"tensor<{tile_m}x{tile_n}xf32, #blocked>" in ttgir, ttgir
+    assert "sizePerThread = [1, 1]" in ttgir, ttgir
+    assert "threadsPerWarp = [1, 32]" in ttgir, ttgir
+    assert "warpsPerCTA = [4, 1]" in ttgir, ttgir
+
+
+_SAME_THREAD_EXTRACT_TTGIR = """
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "musa:ph1", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @same_thread_extract(%x_ptr: !tt.ptr<f32>, %out_ptr: !tt.ptr<f32>) attributes {noinline = false} {
+    %cst32 = arith.constant dense<32> : tensor<32x1xi32, #blocked>
+    %cst32_2 = arith.constant dense<32> : tensor<2x1xi32, #blocked>
+    %c0_i32 = arith.constant 0 : i32
+    %rows32 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %rows32_1 = tt.expand_dims %rows32 {axis = 1 : i32} : tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<32x1xi32, #blocked>
+    %cols32 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %cols32_1 = tt.expand_dims %cols32 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked>
+    %src_row_off = arith.muli %rows32_1, %cst32 : tensor<32x1xi32, #blocked>
+    %x_splat = tt.splat %x_ptr : !tt.ptr<f32> -> tensor<32x1x!tt.ptr<f32>, #blocked>
+    %x_row_ptr = tt.addptr %x_splat, %src_row_off : tensor<32x1x!tt.ptr<f32>, #blocked>, tensor<32x1xi32, #blocked>
+    %x_row_ptr_b = tt.broadcast %x_row_ptr : tensor<32x1x!tt.ptr<f32>, #blocked> -> tensor<32x32x!tt.ptr<f32>, #blocked>
+    %cols32_b = tt.broadcast %cols32_1 : tensor<1x32xi32, #blocked> -> tensor<32x32xi32, #blocked>
+    %x_ptrs = tt.addptr %x_row_ptr_b, %cols32_b : tensor<32x32x!tt.ptr<f32>, #blocked>, tensor<32x32xi32, #blocked>
+    %src = tt.load %x_ptrs : tensor<32x32x!tt.ptr<f32>, #blocked>
+    %tile = musa_tle.extract_tile %src[%c0_i32] {tile_shape = array<i64: 2, 32>} : tensor<32x32xf32, #blocked>, i32 -> tensor<2x32xf32, #blocked>
+    %rows2 = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %rows2_1 = tt.expand_dims %rows2 {axis = 1 : i32} : tensor<2xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<2x1xi32, #blocked>
+    %out_row_off = arith.muli %rows2_1, %cst32_2 : tensor<2x1xi32, #blocked>
+    %out_splat = tt.splat %out_ptr : !tt.ptr<f32> -> tensor<2x1x!tt.ptr<f32>, #blocked>
+    %out_row_ptr = tt.addptr %out_splat, %out_row_off : tensor<2x1x!tt.ptr<f32>, #blocked>, tensor<2x1xi32, #blocked>
+    %out_row_ptr_b = tt.broadcast %out_row_ptr : tensor<2x1x!tt.ptr<f32>, #blocked> -> tensor<2x32x!tt.ptr<f32>, #blocked>
+    %cols32_out = tt.broadcast %cols32_1 : tensor<1x32xi32, #blocked> -> tensor<2x32xi32, #blocked>
+    %out_ptrs = tt.addptr %out_row_ptr_b, %cols32_out : tensor<2x32x!tt.ptr<f32>, #blocked>, tensor<2x32xi32, #blocked>
+    tt.store %out_ptrs, %tile : tensor<2x32x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+"""
+
+_SAME_THREAD_INSERT_TTGIR = """
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "musa:ph1", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @same_thread_insert(%x_ptr: !tt.ptr<f32>, %tile_ptr: !tt.ptr<f32>, %out_ptr: !tt.ptr<f32>) attributes {noinline = false} {
+    %cst32 = arith.constant dense<32> : tensor<32x1xi32, #blocked>
+    %cst32_2 = arith.constant dense<32> : tensor<2x1xi32, #blocked>
+    %c0_i32 = arith.constant 0 : i32
+    %rows32 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %rows32_1 = tt.expand_dims %rows32 {axis = 1 : i32} : tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<32x1xi32, #blocked>
+    %cols32 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %cols32_1 = tt.expand_dims %cols32 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked>
+    %src_row_off = arith.muli %rows32_1, %cst32 : tensor<32x1xi32, #blocked>
+    %x_splat = tt.splat %x_ptr : !tt.ptr<f32> -> tensor<32x1x!tt.ptr<f32>, #blocked>
+    %x_row_ptr = tt.addptr %x_splat, %src_row_off : tensor<32x1x!tt.ptr<f32>, #blocked>, tensor<32x1xi32, #blocked>
+    %x_row_ptr_b = tt.broadcast %x_row_ptr : tensor<32x1x!tt.ptr<f32>, #blocked> -> tensor<32x32x!tt.ptr<f32>, #blocked>
+    %cols32_b = tt.broadcast %cols32_1 : tensor<1x32xi32, #blocked> -> tensor<32x32xi32, #blocked>
+    %x_ptrs = tt.addptr %x_row_ptr_b, %cols32_b : tensor<32x32x!tt.ptr<f32>, #blocked>, tensor<32x32xi32, #blocked>
+    %src = tt.load %x_ptrs : tensor<32x32x!tt.ptr<f32>, #blocked>
+    %rows2 = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %rows2_1 = tt.expand_dims %rows2 {axis = 1 : i32} : tensor<2xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<2x1xi32, #blocked>
+    %tile_row_off = arith.muli %rows2_1, %cst32_2 : tensor<2x1xi32, #blocked>
+    %tile_splat = tt.splat %tile_ptr : !tt.ptr<f32> -> tensor<2x1x!tt.ptr<f32>, #blocked>
+    %tile_row_ptr = tt.addptr %tile_splat, %tile_row_off : tensor<2x1x!tt.ptr<f32>, #blocked>, tensor<2x1xi32, #blocked>
+    %tile_row_ptr_b = tt.broadcast %tile_row_ptr : tensor<2x1x!tt.ptr<f32>, #blocked> -> tensor<2x32x!tt.ptr<f32>, #blocked>
+    %cols32_tile = tt.broadcast %cols32_1 : tensor<1x32xi32, #blocked> -> tensor<2x32xi32, #blocked>
+    %tile_ptrs = tt.addptr %tile_row_ptr_b, %cols32_tile : tensor<2x32x!tt.ptr<f32>, #blocked>, tensor<2x32xi32, #blocked>
+    %tile = tt.load %tile_ptrs : tensor<2x32x!tt.ptr<f32>, #blocked>
+    %result = musa_tle.insert_tile %src[%c0_i32] = %tile {tile_shape = array<i64: 2, 32>} : tensor<32x32xf32, #blocked>, i32, tensor<2x32xf32, #blocked> -> tensor<32x32xf32, #blocked>
+    %out_splat = tt.splat %out_ptr : !tt.ptr<f32> -> tensor<32x1x!tt.ptr<f32>, #blocked>
+    %out_row_ptr = tt.addptr %out_splat, %src_row_off : tensor<32x1x!tt.ptr<f32>, #blocked>, tensor<32x1xi32, #blocked>
+    %out_row_ptr_b = tt.broadcast %out_row_ptr : tensor<32x1x!tt.ptr<f32>, #blocked> -> tensor<32x32x!tt.ptr<f32>, #blocked>
+    %out_ptrs = tt.addptr %out_row_ptr_b, %cols32_b : tensor<32x32x!tt.ptr<f32>, #blocked>, tensor<32x32xi32, #blocked>
+    tt.store %out_ptrs, %result : tensor<32x32x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+"""
+
+
+def _lower_ttgir_fixture_to_llvm(tmp_path, ttgir):
+    from triton._C import libtriton
+    from triton._C.libtriton import ir, passes
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+
+    fixture_path = tmp_path / "tile_fixture.ttgir"
+    fixture_path.write_text(ttgir)
+    module = ir.parse_mlir_module(str(fixture_path), context)
+
+    pm = ir.pass_manager(context)
+    passes.convert.add_scf_to_cf(pm)
+    passes.convert.add_index_to_llvmir(pm)
+    libtriton.mthreads.passes.ttgpuir.add_allocate_shared_memory(pm, 31)
+    libtriton.mthreads.passes.ttgpuir.add_mtgpu_to_llvm(pm, 31)
+    libtriton.mthreads.passes.ttgpuir.add_to_llvmir(pm, 31)
+    passes.common.add_canonicalizer(pm)
+    passes.common.add_cse(pm)
+    passes.convert.add_cf_to_llvmir(pm)
+    passes.convert.add_arith_to_llvmir(pm)
+    passes.common.add_canonicalizer(pm)
+    passes.common.add_cse(pm)
+    passes.common.add_symbol_dce(pm)
+    pm.run(module, "lower_tile_fixture")
+    return module.str()
+
+
+@pytest.mark.parametrize(
+    "kernel",
+    [
+        _extract_static_scalar_kernel,
+        _extract_static_multidim_kernel,
+        _extract_dynamic_scalar_kernel,
+        _extract_dynamic_multidim_kernel,
+    ],
+)
+def test_extract_tile_compiles_through_mthreads_tle(kernel):
+    compiled = _compile_extract(kernel)
+    ttgir = compiled.asm["ttgir"]
+    llir = compiled.asm["llir"]
+
+    assert "musa_tle.extract_tile" in ttgir, ttgir
+    assert "musa_tle.extract_tile" not in llir, llir
+    assert "nvvm" not in llir.lower(), llir
+
+
+@pytest.mark.parametrize(
+    "kernel",
+    [
+        _insert_static_scalar_kernel,
+        _insert_static_multidim_kernel,
+        _insert_dynamic_scalar_kernel,
+        _insert_dynamic_multidim_kernel,
+    ],
+)
+def test_insert_tile_compiles_through_mthreads_tle(kernel):
+    compiled = _compile(kernel)
+    ttgir = compiled.asm["ttgir"]
+    llir = compiled.asm["llir"]
+
+    assert "musa_tle.insert_tile" in ttgir, ttgir
+    assert "musa_tle.insert_tile" not in llir, llir
+    assert "nvvm" not in llir.lower(), llir
+
+
+def test_dynamic_tile_ops_lower_with_musa_local_barriers():
+    extract = _compile_extract(_extract_dynamic_scalar_kernel)
+    insert = _compile(_insert_dynamic_scalar_kernel)
+
+    assert "llvm.musa.syncthreads.lm" in extract.asm["llir"], extract.asm["llir"]
+    assert "llvm.musa.syncthreads.lm" in insert.asm["llir"], insert.asm["llir"]
+
+
+def test_static_non_cta_extract_lowers_with_smem_barrier(tmp_path):
+    llir = _lower_ttgir_fixture_to_llvm(tmp_path, _SAME_THREAD_EXTRACT_TTGIR)
+
+    assert "musa_tle.extract_tile" in _SAME_THREAD_EXTRACT_TTGIR
+    _assert_static_non_cta_default_blocked_tile(_SAME_THREAD_EXTRACT_TTGIR, tile_shape=(2, 32))
+    assert "musa_tle.extract_tile" not in llir, llir
+    assert "llvm.musa.syncthreads.lm" in llir, llir
+
+
+def test_static_non_cta_insert_lowers_with_smem_barrier(tmp_path):
+    llir = _lower_ttgir_fixture_to_llvm(tmp_path, _SAME_THREAD_INSERT_TTGIR)
+
+    assert "musa_tle.insert_tile" in _SAME_THREAD_INSERT_TTGIR
+    _assert_static_non_cta_default_blocked_tile(_SAME_THREAD_INSERT_TTGIR, tile_shape=(2, 32))
+    assert "musa_tle.insert_tile" not in llir, llir
+    assert "llvm.musa.syncthreads.lm" in llir, llir
+
+
+def test_static_non_cta_insert_encoding_mismatch_uses_smem_barrier():
+    compiled = _compile(_insert_static_scalar_kernel)
+
+    _assert_static_non_cta_default_blocked_tile(compiled.asm["ttgir"], same_tile_encoding=False)
+    assert "tensor<16x16xf32, #blocked1>" in compiled.asm["ttgir"], compiled.asm["ttgir"]
+    assert "llvm.musa.syncthreads.lm" in compiled.asm["llir"], compiled.asm["llir"]
+
+
+@pytest.mark.skipif(not torch.musa.is_available(), reason="MUSA device is not available")
+@pytest.mark.parametrize("index, row, col", [(0, 0, 0), (3, 16, 16)])
+def test_extract_tile_runtime_matches_source_tile(index, row, col):
+    x = torch.arange(32 * 32, device="musa", dtype=torch.float32).reshape(32, 32)
+    out = torch.empty((16, 16), device="musa", dtype=torch.float32)
+
+    _extract_runtime_kernel[(1, )](x, out, x.stride(0), x.stride(1), INDEX=index, num_warps=4)
+
+    torch.testing.assert_close(out.cpu(), x[row:row + 16, col:col + 16].cpu(), rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.musa.is_available(), reason="MUSA device is not available")
+def test_insert_tile_runtime_updates_selected_region_only():
+    x = torch.arange(32 * 32, device="musa", dtype=torch.float32).reshape(32, 32)
+    tile = torch.full((16, 16), 777.0, device="musa", dtype=torch.float32)
+    out = torch.empty_like(x)
+
+    _insert_runtime_kernel[(1, )](x, tile, out, x.stride(0), x.stride(1), INDEX=3, num_warps=4)
+
+    expected = x.clone()
+    expected[16:32, 16:32] = tile
+    torch.testing.assert_close(out.cpu(), expected.cpu(), rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.musa.is_available(), reason="MUSA device is not available")
+def test_insert_tile_static_2x32_same_encoding_runtime_updates_selected_region_only():
+    x = torch.arange(32 * 32, device="musa", dtype=torch.float32).reshape(32, 32)
+    tile = torch.full((2, 32), 777.0, device="musa", dtype=torch.float32)
+    out = torch.empty_like(x)
+
+    _insert_static_2x32_same_encoding_runtime_kernel[(1, )](x, tile, out, x.stride(0), x.stride(1), num_warps=2)
+
+    expected = x.clone()
+    expected[0:2, 0:32] = tile
+    torch.testing.assert_close(out.cpu(), expected.cpu(), rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.musa.is_available(), reason="MUSA device is not available")
+def test_extract_tile_dynamic_runtime_matches_all_source_tiles():
+    x = torch.arange(32 * 32, device="musa", dtype=torch.float32).reshape(32, 32)
+    out = torch.empty((4, 16, 16), device="musa", dtype=torch.float32)
+
+    _extract_dynamic_runtime_kernel[(4, )](x, out, x.stride(0), x.stride(1), num_warps=4)
+
+    expected = torch.stack([
+        x[0:16, 0:16],
+        x[0:16, 16:32],
+        x[16:32, 0:16],
+        x[16:32, 16:32],
+    ])
+    torch.testing.assert_close(out.cpu(), expected.cpu(), rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.musa.is_available(), reason="MUSA device is not available")
+def test_insert_tile_dynamic_runtime_updates_each_selected_region():
+    x = torch.arange(32 * 32, device="musa", dtype=torch.float32).reshape(32, 32)
+    tile = torch.arange(4 * 16 * 16, device="musa", dtype=torch.float32).reshape(4, 16, 16)
+    tile = tile + 10000
+    out = torch.empty((4, 32, 32), device="musa", dtype=torch.float32)
+
+    _insert_dynamic_runtime_kernel[(4, )](x, tile, out, x.stride(0), x.stride(1), num_warps=4)
+
+    expected = x.expand(4, 32, 32).clone()
+    expected[0, 0:16, 0:16] = tile[0]
+    expected[1, 0:16, 16:32] = tile[1]
+    expected[2, 16:32, 0:16] = tile[2]
+    expected[3, 16:32, 16:32] = tile[3]
+    torch.testing.assert_close(out.cpu(), expected.cpu(), rtol=0, atol=0)

--- a/third_party/mthreads/tle/dialect/include/Conversion/MUSATLEToLLVM/LocalPointersOpToLLVM.h
+++ b/third_party/mthreads/tle/dialect/include/Conversion/MUSATLEToLLVM/LocalPointersOpToLLVM.h
@@ -11,6 +11,13 @@ void populateMUSATLEToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                    RewritePatternSet &patterns,
                                    PatternBenefit benefit);
 
+#ifdef __TLE__
+void populateMUSATLETileOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
+                                         const TargetInfoBase &targetInfo,
+                                         RewritePatternSet &patterns,
+                                         PatternBenefit benefit);
+#endif // __TLE__
+
 } // namespace mlir::triton::musa_tle
 
 #endif // MTHREADS_MUSATLE_CONVERSION_MUSATLETOLLVM_LOCALPOINTERSOPTOLLVM_H

--- a/third_party/mthreads/tle/dialect/include/Dialect/MUSATLE/IR/MUSATLEOps.td
+++ b/third_party/mthreads/tle/dialect/include/Dialect/MUSATLE/IR/MUSATLEOps.td
@@ -21,6 +21,32 @@ def MUSATLE_LocalPointersOp : MUSATLE_Op<"local_pointers", [Pure]> {
   let results = (outs MUSATLE_LocalPointerResultType:$result);
   let hasVerifier = 1;
 }
+
+def MUSATLE_ExtractTileOp : MUSATLE_Op<"extract_tile", [Pure]> {
+  let arguments = (ins TT_Tensor:$src, TT_IntLike:$index,
+      DenseI64ArrayAttr:$tile_shape);
+  let results = (outs TT_Tensor:$result);
+  let builders = [OpBuilder<(ins "Value":$src, "Value":$index,
+      "ArrayRef<int64_t>":$tileShape)>];
+  let assemblyFormat = [{
+    $src `[` $index `]` attr-dict `:` qualified(type($src)) `,` qualified(type($index)) `->` qualified(type($result))
+  }];
+  let hasVerifier = 1;
+}
+
+def MUSATLE_InsertTileOp
+    : MUSATLE_Op<"insert_tile", [Pure,
+                                 DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+  let arguments = (ins TT_Tensor:$src, TT_Tensor:$tile, TT_IntLike:$index,
+      DenseI64ArrayAttr:$tile_shape);
+  let results = (outs TT_Tensor:$result);
+  let builders = [OpBuilder<(ins "Value":$src, "Value":$tile,
+      "Value":$index)>];
+  let assemblyFormat = [{
+    $src `[` $index `]` `=` $tile attr-dict `:` qualified(type($src)) `,` qualified(type($index)) `,` qualified(type($tile)) `->` qualified(type($result))
+  }];
+  let hasVerifier = 1;
+}
 #endif // __TLE__
 
 #endif // MUSA_TLE_OPS

--- a/third_party/mthreads/tle/dialect/include/Dialect/MUSATLE/IR/MUSATLEOps.td
+++ b/third_party/mthreads/tle/dialect/include/Dialect/MUSATLE/IR/MUSATLEOps.td
@@ -47,6 +47,15 @@ def MUSATLE_InsertTileOp
   }];
   let hasVerifier = 1;
 }
+
+def MUSATLE_ExclusiveCumsumOp
+    : MUSATLE_Op<"exclusive_cumsum",
+                 [Pure, SameOperandsAndResultEncoding]> {
+  let arguments = (ins TT_Tensor:$src, I32Attr:$axis, BoolAttr:$reverse);
+  let results = (outs TT_Tensor:$exclusive, TT_Type:$total);
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($exclusive) `,` type($total)";
+  let hasVerifier = 1;
+}
 #endif // __TLE__
 
 #endif // MUSA_TLE_OPS

--- a/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
+++ b/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
@@ -71,4 +71,22 @@ def TritonMUSAGPUTLEOptimizeLocalPointerAsyncStores
   ];
 }
 
+def TritonMUSAGPUTLELowerExclusiveCumsum
+    : Pass<"tritonmusa-tle-lower-exclusive-cumsum", "mlir::ModuleOp"> {
+  let summary = "Lower musa_tle.exclusive_cumsum to Triton scan and reduce ops";
+
+  let description = [{
+    Lower ``musa_tle.exclusive_cumsum`` into ``tt.scan`` for prefix
+    accumulation, subtract the original input to form the exclusive sum, and use
+    an index-select ``tt.reduce`` over the inclusive result to produce the
+    total sum.
+  }];
+
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::triton::TritonDialect",
+    "mlir::triton::musa_tle::MUSATLEDialect"
+  ];
+}
+
 #endif // MUSA_TLE_TRANSFORMS_PASSES

--- a/third_party/mthreads/tle/dialect/lib/Conversion/MUSATLEToLLVM/CMakeLists.txt
+++ b/third_party/mthreads/tle/dialect/lib/Conversion/MUSATLEToLLVM/CMakeLists.txt
@@ -1,5 +1,14 @@
+if(FLAGTREE_MTHREADS_TLE)
+  set(_MUSATLE_TILE_TO_LLVM_SOURCES
+      TileOpUtils.cpp
+      TileOpsToLLVM.cpp)
+else()
+  set(_MUSATLE_TILE_TO_LLVM_SOURCES "")
+endif()
+
 add_triton_library(MUSATLEToLLVM
   LocalPointersOpToLLVM.cpp
+  ${_MUSATLE_TILE_TO_LLVM_SOURCES}
 
   DEPENDS
   MUSATLETableGen

--- a/third_party/mthreads/tle/dialect/lib/Conversion/MUSATLEToLLVM/LocalPointersOpToLLVM.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Conversion/MUSATLEToLLVM/LocalPointersOpToLLVM.cpp
@@ -276,6 +276,8 @@ void populateMUSATLEToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                    RewritePatternSet &patterns,
                                    PatternBenefit benefit) {
   patterns.add<LocalPointersOpConversion>(typeConverter, targetInfo, benefit);
+  populateMUSATLETileOpToLLVMPatterns(typeConverter, targetInfo, patterns,
+                                      benefit);
 }
 
 } // namespace mlir::triton::musa_tle

--- a/third_party/mthreads/tle/dialect/lib/Conversion/MUSATLEToLLVM/TileOpUtils.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Conversion/MUSATLEToLLVM/TileOpUtils.cpp
@@ -1,0 +1,143 @@
+#ifdef __TLE__
+
+#include "TileOpUtils.h"
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+using namespace mlir;
+
+namespace mlir::triton::musa_tle {
+
+namespace ttg = mlir::triton::gpu;
+
+SmallVector<unsigned> getCTATileOrder(RankedTensorType type) {
+  if (auto blocked = dyn_cast<ttg::BlockedEncodingAttr>(type.getEncoding())) {
+    auto order = blocked.getOrder();
+    return SmallVector<unsigned>(order.begin(), order.end());
+  }
+
+  unsigned rank = type.getRank();
+  SmallVector<unsigned> order;
+  order.reserve(rank);
+  for (unsigned i = 0; i < rank; ++i)
+    order.push_back(rank - 1 - i);
+  return order;
+}
+
+SmallVector<unsigned> delinearize(unsigned linearIndex,
+                                  ArrayRef<unsigned> shape,
+                                  ArrayRef<unsigned> order) {
+  SmallVector<unsigned> result(shape.size(), 0);
+  unsigned idx = linearIndex;
+  for (unsigned dim : order) {
+    result[dim] = idx % shape[dim];
+    idx /= shape[dim];
+  }
+  return result;
+}
+
+unsigned linearize(ArrayRef<unsigned> coords, ArrayRef<unsigned> shape,
+                   ArrayRef<unsigned> order) {
+  unsigned result = 0;
+  unsigned stride = 1;
+  for (unsigned dim : order) {
+    result += coords[dim] * stride;
+    stride *= shape[dim];
+  }
+  return result;
+}
+
+SmallVector<unsigned> getShapePerCTATile(RankedTensorType type) {
+  auto encoding = type.getEncoding();
+  if (!encoding)
+    llvm_unreachable("tile op requires tensor with encoding");
+
+  auto shape = type.getShape();
+  if (auto blocked = dyn_cast<ttg::BlockedEncodingAttr>(encoding)) {
+    auto sizePerThread = blocked.getSizePerThread();
+    auto threadsPerWarp = blocked.getThreadsPerWarp();
+    auto warpsPerCTA = blocked.getWarpsPerCTA();
+
+    SmallVector<unsigned> result;
+    result.reserve(shape.size());
+    for (size_t i = 0; i < shape.size(); ++i) {
+      result.push_back(static_cast<unsigned>(sizePerThread[i]) *
+                       static_cast<unsigned>(threadsPerWarp[i]) *
+                       static_cast<unsigned>(warpsPerCTA[i]));
+    }
+    return result;
+  }
+
+  llvm_unreachable("tile op only supports BlockedEncoding");
+}
+
+SmallVector<Value> computeThreadOffsets(Location loc, OpBuilder &rewriter,
+                                        RankedTensorType tensorType) {
+  auto blocked = cast<ttg::BlockedEncodingAttr>(tensorType.getEncoding());
+  auto sizePerThread = blocked.getSizePerThread();
+  auto threadsPerWarp = blocked.getThreadsPerWarp();
+  auto warpsPerCTA = blocked.getWarpsPerCTA();
+  auto order = blocked.getOrder();
+  int rank = tensorType.getRank();
+
+  auto i32Ty = rewriter.getIntegerType(32);
+  Value threadId = getThreadId(rewriter, loc);
+
+  unsigned warpSize = 1;
+  for (unsigned threads : threadsPerWarp)
+    warpSize *= threads;
+  Value warpSizeV = LLVM::ConstantOp::create(
+      rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(warpSize));
+
+  Value laneId =
+      LLVM::URemOp::create(rewriter, loc, i32Ty, threadId, warpSizeV);
+  Value warpId =
+      LLVM::UDivOp::create(rewriter, loc, i32Ty, threadId, warpSizeV);
+
+  SmallVector<Value> laneInDim(rank);
+  {
+    Value rem = laneId;
+    for (int i = 0; i < rank; ++i) {
+      unsigned dim = order[i];
+      Value count = LLVM::ConstantOp::create(
+          rewriter, loc, i32Ty,
+          rewriter.getI32IntegerAttr(threadsPerWarp[dim]));
+      laneInDim[dim] = LLVM::URemOp::create(rewriter, loc, i32Ty, rem, count);
+      rem = LLVM::UDivOp::create(rewriter, loc, i32Ty, rem, count);
+    }
+  }
+
+  SmallVector<Value> warpInDim(rank);
+  {
+    Value rem = warpId;
+    for (int i = 0; i < rank; ++i) {
+      unsigned dim = order[i];
+      Value count = LLVM::ConstantOp::create(
+          rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(warpsPerCTA[dim]));
+      warpInDim[dim] = LLVM::URemOp::create(rewriter, loc, i32Ty, rem, count);
+      rem = LLVM::UDivOp::create(rewriter, loc, i32Ty, rem, count);
+    }
+  }
+
+  SmallVector<Value> threadOffsets(rank);
+  for (int d = 0; d < rank; ++d) {
+    Value threads = LLVM::ConstantOp::create(
+        rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(threadsPerWarp[d]));
+    Value elems = LLVM::ConstantOp::create(
+        rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(sizePerThread[d]));
+    Value warpContrib =
+        LLVM::MulOp::create(rewriter, loc, i32Ty, warpInDim[d], threads);
+    Value threadCoord =
+        LLVM::AddOp::create(rewriter, loc, i32Ty, warpContrib, laneInDim[d]);
+    threadOffsets[d] =
+        LLVM::MulOp::create(rewriter, loc, i32Ty, threadCoord, elems);
+  }
+
+  return threadOffsets;
+}
+
+} // namespace mlir::triton::musa_tle
+
+#endif // __TLE__

--- a/third_party/mthreads/tle/dialect/lib/Conversion/MUSATLEToLLVM/TileOpUtils.h
+++ b/third_party/mthreads/tle/dialect/lib/Conversion/MUSATLEToLLVM/TileOpUtils.h
@@ -1,0 +1,46 @@
+#ifndef MTHREADS_MUSATLE_CONVERSION_MUSATLETOLLVM_TILEOPUTILS_H
+#define MTHREADS_MUSATLE_CONVERSION_MUSATLETOLLVM_TILEOPUTILS_H
+
+#ifdef __TLE__
+
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <cassert>
+
+namespace mlir::triton::musa_tle {
+
+template <typename T1, typename T2, typename BinaryOp>
+llvm::SmallVector<T2> multiDimElementwise(llvm::ArrayRef<T1> lhs,
+                                          llvm::ArrayRef<T2> rhs, BinaryOp op) {
+  assert(lhs.size() == rhs.size() && "dimensions must match");
+  llvm::SmallVector<T2> result;
+  result.reserve(lhs.size());
+  for (size_t i = 0; i < lhs.size(); ++i)
+    result.push_back(static_cast<T2>(op(lhs[i], rhs[i])));
+  return result;
+}
+
+llvm::SmallVector<unsigned> getCTATileOrder(RankedTensorType type);
+
+llvm::SmallVector<unsigned> delinearize(unsigned linearIndex,
+                                        llvm::ArrayRef<unsigned> shape,
+                                        llvm::ArrayRef<unsigned> order);
+
+unsigned linearize(llvm::ArrayRef<unsigned> coords,
+                   llvm::ArrayRef<unsigned> shape,
+                   llvm::ArrayRef<unsigned> order);
+
+llvm::SmallVector<unsigned> getShapePerCTATile(RankedTensorType type);
+
+llvm::SmallVector<Value> computeThreadOffsets(Location loc, OpBuilder &rewriter,
+                                              RankedTensorType tensorType);
+
+} // namespace mlir::triton::musa_tle
+
+#endif // __TLE__
+
+#endif // MTHREADS_MUSATLE_CONVERSION_MUSATLETOLLVM_TILEOPUTILS_H

--- a/third_party/mthreads/tle/dialect/lib/Conversion/MUSATLEToLLVM/TileOpsToLLVM.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Conversion/MUSATLEToLLVM/TileOpsToLLVM.cpp
@@ -1,0 +1,643 @@
+#ifdef __TLE__
+
+#include "TileOpUtils.h"
+
+#include "Conversion/MUSATLEToLLVM/LocalPointersOpToLLVM.h"
+#include "Dialect/MUSATLE/IR/Dialect.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
+#include "llvm/ADT/STLExtras.h"
+
+#include <functional>
+#include <numeric>
+#include <optional>
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace {
+
+namespace ttg = mlir::triton::gpu;
+namespace musa_tle = mlir::triton::musa_tle;
+
+static SmallVector<int64_t> getTileShape(ArrayRef<int64_t> tileShape) {
+  SmallVector<int64_t> result;
+  llvm::append_range(result, tileShape);
+  return result;
+}
+
+static SmallVector<int64_t> getTileShape(musa_tle::ExtractTileOp op) {
+  return getTileShape(op.getTileShape());
+}
+
+static SmallVector<int64_t> getTileShape(musa_tle::InsertTileOp op) {
+  return getTileShape(op.getTileShape());
+}
+
+template <typename OpT> static std::optional<int64_t> getStaticIndex(OpT op) {
+  auto constOp = op.getIndex().template getDefiningOp<arith::ConstantOp>();
+  if (constOp) {
+    auto intAttr = dyn_cast<IntegerAttr>(constOp.getValue());
+    if (intAttr)
+      return intAttr.getInt();
+  }
+  auto llvmConstOp = op.getIndex().template getDefiningOp<LLVM::ConstantOp>();
+  if (llvmConstOp) {
+    auto intAttr = dyn_cast<IntegerAttr>(llvmConstOp.getValue());
+    if (intAttr)
+      return intAttr.getInt();
+  }
+  return std::nullopt;
+}
+
+static Value convertIndexToI32(Location loc, Value index,
+                               ConversionPatternRewriter &rewriter) {
+  auto i32Ty = rewriter.getI32Type();
+  if (index.getType() == i32Ty)
+    return index;
+  if (auto intTy = dyn_cast<IntegerType>(index.getType())) {
+    if (intTy.getWidth() > 32)
+      return LLVM::TruncOp::create(rewriter, loc, i32Ty, index);
+    return LLVM::ZExtOp::create(rewriter, loc, i32Ty, index);
+  }
+  if (index.getType().isIndex())
+    return arith::IndexCastOp::create(rewriter, loc, i32Ty, index);
+  return index;
+}
+
+static int64_t getByteWidth(Type type) {
+  int bitWidth = mlir::getIntOrFloatOrPtrBitWidth(type);
+  return (bitWidth + 7) / 8;
+}
+
+static SmallVector<int64_t> getRowMajorSuffix(ArrayRef<int64_t> logicalGrid) {
+  SmallVector<int64_t> suffix(logicalGrid.size(), 1);
+  for (int d = static_cast<int>(logicalGrid.size()) - 2; d >= 0; --d)
+    suffix[d] = suffix[d + 1] * logicalGrid[d + 1];
+  return suffix;
+}
+
+static void computeTileStartEnd(Location loc,
+                                ConversionPatternRewriter &rewriter,
+                                Value linearIndex, ArrayRef<int64_t> srcShape,
+                                ArrayRef<int64_t> tileShape,
+                                SmallVectorImpl<Value> &tileStartVals,
+                                SmallVectorImpl<Value> &tileEndVals) {
+  auto i32Ty = rewriter.getI32Type();
+  int rank = srcShape.size();
+  SmallVector<int64_t> logicalGrid(rank);
+  for (int d = 0; d < rank; ++d)
+    logicalGrid[d] = srcShape[d] / tileShape[d];
+  SmallVector<int64_t> suffix = getRowMajorSuffix(logicalGrid);
+
+  Value index = convertIndexToI32(loc, linearIndex, rewriter);
+  tileStartVals.resize(rank);
+  tileEndVals.resize(rank);
+  for (int d = 0; d < rank; ++d) {
+    Value suffixV = LLVM::ConstantOp::create(
+        rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(suffix[d]));
+    Value gridV = LLVM::ConstantOp::create(
+        rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(logicalGrid[d]));
+    Value tileV = LLVM::ConstantOp::create(
+        rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(tileShape[d]));
+    Value coord = LLVM::UDivOp::create(rewriter, loc, i32Ty, index, suffixV);
+    coord = LLVM::URemOp::create(rewriter, loc, i32Ty, coord, gridV);
+    tileStartVals[d] = LLVM::MulOp::create(rewriter, loc, i32Ty, coord, tileV);
+    tileEndVals[d] =
+        LLVM::AddOp::create(rewriter, loc, i32Ty, tileStartVals[d], tileV);
+  }
+}
+
+template <typename OpT>
+static bool isCTATileAligned(OpT op, int64_t linearIndex,
+                             RankedTensorType srcTy,
+                             ArrayRef<int64_t> tileShape) {
+  auto srcShape = srcTy.getShape();
+  auto ctaTile = musa_tle::getShapePerCTATile(srcTy);
+  int rank = srcShape.size();
+
+  SmallVector<int64_t> logicalGrid(rank), tileCoords(rank);
+  for (int i = 0; i < rank; ++i)
+    logicalGrid[i] = srcShape[i] / tileShape[i];
+
+  int64_t remain = linearIndex;
+  for (int i = rank - 1; i >= 0; --i) {
+    tileCoords[i] = remain % logicalGrid[i];
+    remain /= logicalGrid[i];
+  }
+
+  for (int i = 0; i < rank; ++i) {
+    int64_t off = tileCoords[i] * tileShape[i];
+    if (tileShape[i] % static_cast<int64_t>(ctaTile[i]) != 0)
+      return false;
+    if (off % static_cast<int64_t>(ctaTile[i]) != 0)
+      return false;
+  }
+  return true;
+}
+
+static LogicalResult lowerExtractTileStaticCTAAligned(
+    musa_tle::ExtractTileOp op, musa_tle::ExtractTileOp::Adaptor adaptor,
+    ConversionPatternRewriter &rewriter, const LLVMTypeConverter *typeConverter,
+    int64_t linearIndex) {
+  Location loc = op.getLoc();
+  auto srcTy = cast<RankedTensorType>(op.getSrc().getType());
+  auto dstTy = cast<RankedTensorType>(op.getType());
+  auto srcShape = srcTy.getShape();
+  auto dstShape = dstTy.getShape();
+  auto tileShape = getTileShape(op);
+  int rank = srcShape.size();
+
+  SmallVector<Value> vals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
+  auto shapePerCTATile = musa_tle::getShapePerCTATile(srcTy);
+  auto srcCTAShape = musa_tle::multiDimElementwise<int64_t, unsigned>(
+      srcShape, shapePerCTATile, std::divides<unsigned>());
+  auto dstCTAShape = musa_tle::multiDimElementwise<int64_t, unsigned>(
+      dstShape, shapePerCTATile, std::divides<unsigned>());
+
+  SmallVector<int64_t> logicalGrid(rank), logicalCoords(rank),
+      elementCoords(rank);
+  for (int i = 0; i < rank; ++i)
+    logicalGrid[i] = srcShape[i] / tileShape[i];
+  int64_t remain = linearIndex;
+  for (int i = rank - 1; i >= 0; --i) {
+    logicalCoords[i] = remain % logicalGrid[i];
+    remain /= logicalGrid[i];
+  }
+  for (int i = 0; i < rank; ++i)
+    elementCoords[i] = logicalCoords[i] * tileShape[i];
+
+  auto firstTileCoord = musa_tle::multiDimElementwise<int64_t, unsigned>(
+      elementCoords, shapePerCTATile, std::divides<unsigned>());
+  auto srcCTAOrder = musa_tle::getCTATileOrder(srcTy);
+  auto dstCTAOrder = musa_tle::getCTATileOrder(dstTy);
+
+  unsigned totalSrcCTAs = std::accumulate(
+      srcCTAShape.begin(), srcCTAShape.end(), 1u, std::multiplies<>());
+  unsigned elemsPerCTA = ttg::getTotalElemsPerThread(srcTy) / totalSrcCTAs;
+  unsigned numDstCTAs = std::accumulate(dstCTAShape.begin(), dstCTAShape.end(),
+                                        1u, std::multiplies<>());
+
+  SmallVector<Value> resultVals;
+  resultVals.reserve(ttg::getTotalElemsPerThread(dstTy));
+  for (unsigned i = 0; i < numDstCTAs; ++i) {
+    auto coordInDst = musa_tle::delinearize(i, dstCTAShape, dstCTAOrder);
+    auto coordInSrc = musa_tle::multiDimElementwise<unsigned, unsigned>(
+        coordInDst, firstTileCoord, std::plus<unsigned>());
+    unsigned linearInSrc =
+        musa_tle::linearize(coordInSrc, srcCTAShape, srcCTAOrder);
+    size_t startIdx = linearInSrc * elemsPerCTA;
+    if (startIdx + elemsPerCTA > vals.size())
+      return op.emitError("static extract_tile register index out of bounds");
+    llvm::append_range(resultVals,
+                       ArrayRef<Value>(vals).slice(startIdx, elemsPerCTA));
+  }
+
+  Value ret = packLLElements(loc, typeConverter, resultVals, rewriter, dstTy);
+  rewriter.replaceOp(op, ret);
+  return success();
+}
+
+static LogicalResult lowerExtractTileViaSMEM(
+    musa_tle::ExtractTileOp op, musa_tle::ExtractTileOp::Adaptor adaptor,
+    ConversionPatternRewriter &rewriter, const LLVMTypeConverter *typeConverter,
+    const TargetInfoBase &targetInfo) {
+  Location loc = op.getLoc();
+  auto srcTy = cast<RankedTensorType>(op.getSrc().getType());
+  auto dstTy = cast<RankedTensorType>(op.getType());
+  auto srcShape = srcTy.getShape();
+  auto dstShape = dstTy.getShape();
+  auto tileShape = getTileShape(op);
+  int rank = srcShape.size();
+
+  auto i1Ty = rewriter.getI1Type();
+  auto i8Ty = rewriter.getI8Type();
+  auto i32Ty = rewriter.getI32Type();
+  Type llvmElemTy = typeConverter->convertType(srcTy.getElementType());
+  if (!llvmElemTy)
+    return op.emitError("failed to convert extract_tile element type");
+  int64_t elemBytes = getByteWidth(llvmElemTy);
+
+  auto srcOffsets = mlir::emitOffsetForLayout(srcTy.getEncoding(), srcTy);
+  auto dstOffsets = mlir::emitOffsetForLayout(dstTy.getEncoding(), dstTy);
+  unsigned srcElemsPerThread = ttg::getTotalElemsPerThread(srcTy);
+  unsigned dstElemsPerThread = ttg::getTotalElemsPerThread(dstTy);
+  if (srcOffsets.size() != srcElemsPerThread)
+    return op.emitError("extract_tile source offsets size mismatch");
+  if (dstOffsets.size() != dstElemsPerThread)
+    return op.emitError("extract_tile result offsets size mismatch");
+
+  auto dstOrder = musa_tle::getCTATileOrder(dstTy);
+  SmallVector<int64_t> smemStrides(rank, 0);
+  int64_t stride = 1;
+  for (int i = 0; i < rank; ++i) {
+    unsigned dim = dstOrder[i];
+    smemStrides[dim] = stride;
+    stride *= dstShape[dim];
+  }
+
+  auto srcThreadOffsets = musa_tle::computeThreadOffsets(loc, rewriter, srcTy);
+  auto dstThreadOffsets = musa_tle::computeThreadOffsets(loc, rewriter, dstTy);
+
+  auto smemPtrTy = LLVM::LLVMPointerType::get(
+      rewriter.getContext(), targetInfo.getSharedAddressSpace());
+  Value smemBase =
+      LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
+
+  SmallVector<Value> tileStartVals, tileEndVals;
+  computeTileStartEnd(loc, rewriter, adaptor.getIndex(), srcShape, tileShape,
+                      tileStartVals, tileEndVals);
+
+  SmallVector<Value> srcVals =
+      unpackLLElements(loc, adaptor.getSrc(), rewriter);
+  for (unsigned i = 0; i < srcElemsPerThread; ++i) {
+    Value inRange = LLVM::ConstantOp::create(rewriter, loc, i1Ty,
+                                             rewriter.getIntegerAttr(i1Ty, 1));
+    Value smemByteOffset = LLVM::ConstantOp::create(
+        rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(0));
+
+    for (int d = 0; d < rank; ++d) {
+      Value baseOff = LLVM::ConstantOp::create(
+          rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(srcOffsets[i][d]));
+      Value globalCoord = LLVM::AddOp::create(rewriter, loc, i32Ty, baseOff,
+                                              srcThreadOffsets[d]);
+
+      Value ge = LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::uge,
+                                      globalCoord, tileStartVals[d]);
+      Value lt = LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::ult,
+                                      globalCoord, tileEndVals[d]);
+      Value dimInRange = LLVM::AndOp::create(rewriter, loc, ge, lt);
+      inRange = LLVM::AndOp::create(rewriter, loc, dimInRange, inRange);
+
+      Value localCoord = LLVM::SubOp::create(rewriter, loc, i32Ty, globalCoord,
+                                             tileStartVals[d]);
+      Value strideBytes = LLVM::ConstantOp::create(
+          rewriter, loc, i32Ty,
+          rewriter.getI32IntegerAttr(smemStrides[d] * elemBytes));
+      Value dimOffset =
+          LLVM::MulOp::create(rewriter, loc, i32Ty, localCoord, strideBytes);
+      smemByteOffset =
+          LLVM::AddOp::create(rewriter, loc, i32Ty, smemByteOffset, dimOffset);
+    }
+
+    Block *current = rewriter.getInsertionBlock();
+    Block *thenBlock =
+        rewriter.splitBlock(current, rewriter.getInsertionPoint());
+    Block *mergeBlock = rewriter.splitBlock(thenBlock, thenBlock->begin());
+
+    rewriter.setInsertionPointToEnd(current);
+    LLVM::CondBrOp::create(rewriter, loc, inRange, thenBlock, mergeBlock);
+
+    rewriter.setInsertionPointToStart(thenBlock);
+    Value ptr = LLVM::GEPOp::create(rewriter, loc, smemPtrTy, i8Ty, smemBase,
+                                    ValueRange{smemByteOffset},
+                                    LLVM::GEPNoWrapFlags::inbounds);
+    LLVM::StoreOp::create(rewriter, loc, srcVals[i], ptr, elemBytes);
+    LLVM::BrOp::create(rewriter, loc, mergeBlock);
+
+    rewriter.setInsertionPointToStart(mergeBlock);
+  }
+
+  targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
+
+  SmallVector<Value> dstVals;
+  dstVals.reserve(dstElemsPerThread);
+  for (unsigned i = 0; i < dstElemsPerThread; ++i) {
+    Value smemByteOffset = LLVM::ConstantOp::create(
+        rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(0));
+
+    for (int d = 0; d < rank; ++d) {
+      Value baseOff = LLVM::ConstantOp::create(
+          rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(dstOffsets[i][d]));
+      Value globalCoord = LLVM::AddOp::create(rewriter, loc, i32Ty, baseOff,
+                                              dstThreadOffsets[d]);
+      Value tileShapeV = LLVM::ConstantOp::create(
+          rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(tileShape[d]));
+      Value tileLocal =
+          LLVM::URemOp::create(rewriter, loc, i32Ty, globalCoord, tileShapeV);
+      Value strideBytes = LLVM::ConstantOp::create(
+          rewriter, loc, i32Ty,
+          rewriter.getI32IntegerAttr(smemStrides[d] * elemBytes));
+      Value dimOffset =
+          LLVM::MulOp::create(rewriter, loc, i32Ty, tileLocal, strideBytes);
+      smemByteOffset =
+          LLVM::AddOp::create(rewriter, loc, i32Ty, smemByteOffset, dimOffset);
+    }
+
+    Value ptr = LLVM::GEPOp::create(rewriter, loc, smemPtrTy, i8Ty, smemBase,
+                                    ValueRange{smemByteOffset},
+                                    LLVM::GEPNoWrapFlags::inbounds);
+    dstVals.push_back(
+        LLVM::LoadOp::create(rewriter, loc, llvmElemTy, ptr, elemBytes));
+  }
+
+  targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
+
+  Value ret = packLLElements(loc, typeConverter, dstVals, rewriter, dstTy);
+  rewriter.replaceOp(op, ret);
+  return success();
+}
+
+static LogicalResult lowerInsertTileStaticCTAAligned(
+    musa_tle::InsertTileOp op, musa_tle::InsertTileOp::Adaptor adaptor,
+    ConversionPatternRewriter &rewriter, const LLVMTypeConverter *typeConverter,
+    int64_t linearIndex) {
+  Location loc = op.getLoc();
+  auto srcTy = cast<RankedTensorType>(op.getSrc().getType());
+  auto tileTy = cast<RankedTensorType>(op.getTile().getType());
+  auto dstTy = cast<RankedTensorType>(op.getType());
+
+  SmallVector<Value> srcVals =
+      unpackLLElements(loc, adaptor.getSrc(), rewriter);
+  SmallVector<Value> tileVals =
+      unpackLLElements(loc, adaptor.getTile(), rewriter);
+
+  auto srcShape = srcTy.getShape();
+  auto tileShape = getTileShape(op);
+  auto shapePerCTATile = musa_tle::getShapePerCTATile(srcTy);
+  auto srcCTAShape = musa_tle::multiDimElementwise<int64_t, unsigned>(
+      srcShape, shapePerCTATile, std::divides<unsigned>());
+  auto tileCTAShape = musa_tle::multiDimElementwise<int64_t, unsigned>(
+      tileShape, shapePerCTATile, std::divides<unsigned>());
+
+  SmallVector<int64_t> logicalGrid(srcShape.size(), 0);
+  for (size_t i = 0; i < srcShape.size(); ++i)
+    logicalGrid[i] = srcShape[i] / tileShape[i];
+
+  SmallVector<int64_t> logicalCoords(srcShape.size(), 0);
+  int64_t remain = linearIndex;
+  for (int i = static_cast<int>(srcShape.size()) - 1; i >= 0; --i) {
+    logicalCoords[i] = remain % logicalGrid[i];
+    remain /= logicalGrid[i];
+  }
+
+  SmallVector<int64_t> elementCoords(srcShape.size(), 0);
+  for (size_t i = 0; i < srcShape.size(); ++i)
+    elementCoords[i] = logicalCoords[i] * tileShape[i];
+
+  auto firstTileCoord = musa_tle::multiDimElementwise<int64_t, unsigned>(
+      elementCoords, shapePerCTATile, std::divides<unsigned>());
+  auto srcCTAOrder = musa_tle::getCTATileOrder(srcTy);
+  auto tileCTAOrder = musa_tle::getCTATileOrder(tileTy);
+
+  unsigned totalSrcCTAs = std::accumulate(
+      srcCTAShape.begin(), srcCTAShape.end(), 1u, std::multiplies<>());
+  unsigned totalTileCTAs = std::accumulate(
+      tileCTAShape.begin(), tileCTAShape.end(), 1u, std::multiplies<>());
+  unsigned srcElemsPerCTA = ttg::getTotalElemsPerThread(srcTy) / totalSrcCTAs;
+  unsigned tileElemsPerCTA =
+      ttg::getTotalElemsPerThread(tileTy) / totalTileCTAs;
+  if (srcElemsPerCTA != tileElemsPerCTA)
+    return op.emitError("insert_tile source/tile per-CTA element mismatch");
+
+  unsigned numTileCTAs = totalTileCTAs;
+  SmallVector<Value> resultVals(srcVals.begin(), srcVals.end());
+  for (unsigned i = 0; i < numTileCTAs; ++i) {
+    auto tileCoord = musa_tle::delinearize(i, tileCTAShape, tileCTAOrder);
+    auto srcCoord = musa_tle::multiDimElementwise<unsigned, unsigned>(
+        tileCoord, firstTileCoord, std::plus<unsigned>());
+    unsigned srcLinear =
+        musa_tle::linearize(srcCoord, srcCTAShape, srcCTAOrder);
+    unsigned tileLinear =
+        musa_tle::linearize(tileCoord, tileCTAShape, tileCTAOrder);
+    size_t srcStart = srcLinear * srcElemsPerCTA;
+    size_t tileStart = tileLinear * tileElemsPerCTA;
+    if (srcStart + srcElemsPerCTA > resultVals.size() ||
+        tileStart + tileElemsPerCTA > tileVals.size())
+      return op.emitError("static insert_tile register index out of bounds");
+    llvm::copy(ArrayRef<Value>(tileVals).slice(tileStart, srcElemsPerCTA),
+               resultVals.begin() + srcStart);
+  }
+
+  Value ret = packLLElements(loc, typeConverter, resultVals, rewriter, dstTy);
+  rewriter.replaceOp(op, ret);
+  return success();
+}
+
+static LogicalResult lowerInsertTileViaSMEM(
+    musa_tle::InsertTileOp op, musa_tle::InsertTileOp::Adaptor adaptor,
+    ConversionPatternRewriter &rewriter, const LLVMTypeConverter *typeConverter,
+    const TargetInfoBase &targetInfo) {
+  Location loc = op.getLoc();
+  auto srcTy = cast<RankedTensorType>(op.getSrc().getType());
+  auto tileTy = cast<RankedTensorType>(op.getTile().getType());
+  auto dstTy = cast<RankedTensorType>(op.getType());
+  auto srcShape = srcTy.getShape();
+  auto tileShape = getTileShape(op);
+  int rank = srcShape.size();
+
+  auto i1Ty = rewriter.getI1Type();
+  auto i8Ty = rewriter.getI8Type();
+  auto i32Ty = rewriter.getI32Type();
+  Type llvmElemTy = typeConverter->convertType(srcTy.getElementType());
+  if (!llvmElemTy)
+    return op.emitError("failed to convert insert_tile element type");
+  int64_t elemBytes = getByteWidth(llvmElemTy);
+
+  auto srcOffsets = mlir::emitOffsetForLayout(srcTy.getEncoding(), srcTy);
+  auto tileOffsets = mlir::emitOffsetForLayout(tileTy.getEncoding(), tileTy);
+  unsigned srcElemsPerThread = ttg::getTotalElemsPerThread(srcTy);
+  unsigned tileElemsPerThread = ttg::getTotalElemsPerThread(tileTy);
+  if (srcOffsets.size() != srcElemsPerThread)
+    return op.emitError("insert_tile source offsets size mismatch");
+  if (tileOffsets.size() != tileElemsPerThread)
+    return op.emitError("insert_tile tile offsets size mismatch");
+
+  auto tileOrder = musa_tle::getCTATileOrder(tileTy);
+  SmallVector<int64_t> smemStrides(rank, 0);
+  int64_t stride = 1;
+  for (int i = 0; i < rank; ++i) {
+    unsigned dim = tileOrder[i];
+    smemStrides[dim] = stride;
+    stride *= tileShape[dim];
+  }
+
+  auto srcThreadOffsets = musa_tle::computeThreadOffsets(loc, rewriter, srcTy);
+  auto tileThreadOffsets =
+      musa_tle::computeThreadOffsets(loc, rewriter, tileTy);
+
+  auto smemPtrTy = LLVM::LLVMPointerType::get(
+      rewriter.getContext(), targetInfo.getSharedAddressSpace());
+  Value smemBase =
+      LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
+
+  SmallVector<Value> tileStartVals, tileEndVals;
+  computeTileStartEnd(loc, rewriter, adaptor.getIndex(), srcShape, tileShape,
+                      tileStartVals, tileEndVals);
+
+  SmallVector<Value> tileVals =
+      unpackLLElements(loc, adaptor.getTile(), rewriter);
+  for (unsigned i = 0; i < tileElemsPerThread; ++i) {
+    Value smemByteOffset = LLVM::ConstantOp::create(
+        rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(0));
+
+    for (int d = 0; d < rank; ++d) {
+      Value baseOff = LLVM::ConstantOp::create(
+          rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(tileOffsets[i][d]));
+      Value globalCoord = LLVM::AddOp::create(rewriter, loc, i32Ty, baseOff,
+                                              tileThreadOffsets[d]);
+      Value tileShapeV = LLVM::ConstantOp::create(
+          rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(tileShape[d]));
+      Value tileLocal =
+          LLVM::URemOp::create(rewriter, loc, i32Ty, globalCoord, tileShapeV);
+      Value strideBytes = LLVM::ConstantOp::create(
+          rewriter, loc, i32Ty,
+          rewriter.getI32IntegerAttr(smemStrides[d] * elemBytes));
+      Value dimOffset =
+          LLVM::MulOp::create(rewriter, loc, i32Ty, tileLocal, strideBytes);
+      smemByteOffset =
+          LLVM::AddOp::create(rewriter, loc, i32Ty, smemByteOffset, dimOffset);
+    }
+
+    Value ptr = LLVM::GEPOp::create(rewriter, loc, smemPtrTy, i8Ty, smemBase,
+                                    ValueRange{smemByteOffset},
+                                    LLVM::GEPNoWrapFlags::inbounds);
+    LLVM::StoreOp::create(rewriter, loc, tileVals[i], ptr, elemBytes);
+  }
+
+  targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
+
+  SmallVector<Value> srcVals =
+      unpackLLElements(loc, adaptor.getSrc(), rewriter);
+  SmallVector<Value> resultVals;
+  resultVals.reserve(srcElemsPerThread);
+  for (unsigned i = 0; i < srcElemsPerThread; ++i) {
+    Value inRange = LLVM::ConstantOp::create(rewriter, loc, i1Ty,
+                                             rewriter.getIntegerAttr(i1Ty, 1));
+    Value smemByteOffset = LLVM::ConstantOp::create(
+        rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(0));
+
+    for (int d = 0; d < rank; ++d) {
+      Value baseOff = LLVM::ConstantOp::create(
+          rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(srcOffsets[i][d]));
+      Value globalCoord = LLVM::AddOp::create(rewriter, loc, i32Ty, baseOff,
+                                              srcThreadOffsets[d]);
+
+      Value ge = LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::uge,
+                                      globalCoord, tileStartVals[d]);
+      Value lt = LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::ult,
+                                      globalCoord, tileEndVals[d]);
+      Value dimInRange = LLVM::AndOp::create(rewriter, loc, ge, lt);
+      inRange = LLVM::AndOp::create(rewriter, loc, dimInRange, inRange);
+
+      Value tileShapeV = LLVM::ConstantOp::create(
+          rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(tileShape[d]));
+      Value tileLocal =
+          LLVM::URemOp::create(rewriter, loc, i32Ty, globalCoord, tileShapeV);
+      Value strideBytes = LLVM::ConstantOp::create(
+          rewriter, loc, i32Ty,
+          rewriter.getI32IntegerAttr(smemStrides[d] * elemBytes));
+      Value dimOffset =
+          LLVM::MulOp::create(rewriter, loc, i32Ty, tileLocal, strideBytes);
+      smemByteOffset =
+          LLVM::AddOp::create(rewriter, loc, i32Ty, smemByteOffset, dimOffset);
+    }
+
+    Value ptr = LLVM::GEPOp::create(rewriter, loc, smemPtrTy, i8Ty, smemBase,
+                                    ValueRange{smemByteOffset},
+                                    LLVM::GEPNoWrapFlags::inbounds);
+    Value tileLoaded =
+        LLVM::LoadOp::create(rewriter, loc, llvmElemTy, ptr, elemBytes);
+    resultVals.push_back(
+        LLVM::SelectOp::create(rewriter, loc, inRange, tileLoaded, srcVals[i]));
+  }
+
+  targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
+
+  Value ret = packLLElements(loc, typeConverter, resultVals, rewriter, dstTy);
+  rewriter.replaceOp(op, ret);
+  return success();
+}
+
+struct ExtractTileOpConversion
+    : public ConvertOpToLLVMPattern<musa_tle::ExtractTileOp> {
+  ExtractTileOpConversion(LLVMTypeConverter &typeConverter,
+                          const TargetInfoBase &targetInfo,
+                          PatternBenefit benefit)
+      : ConvertOpToLLVMPattern(typeConverter, benefit), targetInfo(targetInfo) {
+  }
+
+  LogicalResult
+  matchAndRewrite(musa_tle::ExtractTileOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto srcTy = dyn_cast<RankedTensorType>(op.getSrc().getType());
+    auto dstTy = dyn_cast<RankedTensorType>(op.getType());
+    if (!srcTy || !dstTy)
+      return op.emitError("extract_tile operands must be ranked tensors");
+    if (!srcTy.getEncoding() || !dstTy.getEncoding())
+      return op.emitError("extract_tile requires tensors with encoding");
+    if (!isa<ttg::BlockedEncodingAttr>(srcTy.getEncoding()) ||
+        !isa<ttg::BlockedEncodingAttr>(dstTy.getEncoding()))
+      return op.emitError("extract_tile only supports BlockedEncodingAttr");
+
+    auto staticIndex = getStaticIndex(op);
+    auto tileShape = getTileShape(op);
+    if (staticIndex && isCTATileAligned(op, *staticIndex, srcTy, tileShape))
+      return lowerExtractTileStaticCTAAligned(op, adaptor, rewriter,
+                                              getTypeConverter(), *staticIndex);
+    return lowerExtractTileViaSMEM(op, adaptor, rewriter, getTypeConverter(),
+                                   targetInfo);
+  }
+
+private:
+  const TargetInfoBase &targetInfo;
+};
+
+struct InsertTileOpConversion
+    : public ConvertOpToLLVMPattern<musa_tle::InsertTileOp> {
+  InsertTileOpConversion(LLVMTypeConverter &typeConverter,
+                         const TargetInfoBase &targetInfo,
+                         PatternBenefit benefit)
+      : ConvertOpToLLVMPattern(typeConverter, benefit), targetInfo(targetInfo) {
+  }
+
+  LogicalResult
+  matchAndRewrite(musa_tle::InsertTileOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto srcTy = dyn_cast<RankedTensorType>(op.getSrc().getType());
+    auto tileTy = dyn_cast<RankedTensorType>(op.getTile().getType());
+    auto dstTy = dyn_cast<RankedTensorType>(op.getType());
+    if (!srcTy || !tileTy || !dstTy)
+      return op.emitError("insert_tile operands must be ranked tensors");
+    if (!srcTy.getEncoding() || !tileTy.getEncoding() || !dstTy.getEncoding())
+      return op.emitError("insert_tile requires tensors with encoding");
+    if (!isa<ttg::BlockedEncodingAttr>(srcTy.getEncoding()) ||
+        !isa<ttg::BlockedEncodingAttr>(tileTy.getEncoding()) ||
+        !isa<ttg::BlockedEncodingAttr>(dstTy.getEncoding()))
+      return op.emitError("insert_tile only supports BlockedEncodingAttr");
+
+    auto staticIndex = getStaticIndex(op);
+    auto tileShape = getTileShape(op);
+    if (staticIndex && isCTATileAligned(op, *staticIndex, srcTy, tileShape))
+      return lowerInsertTileStaticCTAAligned(op, adaptor, rewriter,
+                                             getTypeConverter(), *staticIndex);
+    return lowerInsertTileViaSMEM(op, adaptor, rewriter, getTypeConverter(),
+                                  targetInfo);
+  }
+
+private:
+  const TargetInfoBase &targetInfo;
+};
+
+} // namespace
+
+namespace mlir::triton::musa_tle {
+
+void populateMUSATLETileOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
+                                         const TargetInfoBase &targetInfo,
+                                         RewritePatternSet &patterns,
+                                         PatternBenefit benefit) {
+  patterns.add<ExtractTileOpConversion, InsertTileOpConversion>(
+      typeConverter, targetInfo, benefit);
+}
+
+} // namespace mlir::triton::musa_tle
+
+#endif // __TLE__

--- a/third_party/mthreads/tle/dialect/lib/IR/Dialect.cpp
+++ b/third_party/mthreads/tle/dialect/lib/IR/Dialect.cpp
@@ -8,6 +8,8 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "llvm/ADT/STLExtras.h"
+#include <cstdint>
+#include <limits>
 #include <optional>
 
 // clang-format off
@@ -275,6 +277,40 @@ LogicalResult LocalPointersOp::verify() {
     }
     return emitOpError() << "scalar result expects scalar integer indices";
   }
+
+  return success();
+}
+
+LogicalResult ExclusiveCumsumOp::verify() {
+  auto srcTy = dyn_cast<RankedTensorType>(getSrc().getType());
+  if (!srcTy)
+    return emitOpError() << "expects src to be a ranked tensor";
+
+  auto exclusiveTy = dyn_cast<RankedTensorType>(getExclusive().getType());
+  if (!exclusiveTy)
+    return emitOpError() << "expects exclusive result to be a ranked tensor";
+  if (exclusiveTy != srcTy)
+    return emitOpError() << "expects exclusive result type to match src type";
+
+  if (srcTy.getRank() != 1)
+    return emitOpError() << "currently only rank-1 tensors are supported";
+  int64_t axisExtent = srcTy.getShape()[0];
+  if (ShapedType::isDynamic(axisExtent) || axisExtent <= 0)
+    return emitOpError() << "currently only static, positive axis extent is "
+                            "supported";
+  if (axisExtent > static_cast<int64_t>(std::numeric_limits<uint32_t>::max()))
+    return emitOpError() << "axis extent is too large";
+
+  const int64_t rank = srcTy.getRank();
+  int64_t axis = static_cast<int64_t>(getAxis());
+  if (axis < 0)
+    axis += rank;
+  if (axis != 0)
+    return emitOpError() << "currently only axis=0 is supported";
+
+  if (getTotal().getType() != srcTy.getElementType())
+    return emitOpError() << "expects total result type to match src element "
+                            "type";
 
   return success();
 }

--- a/third_party/mthreads/tle/dialect/lib/IR/Dialect.cpp
+++ b/third_party/mthreads/tle/dialect/lib/IR/Dialect.cpp
@@ -1,10 +1,14 @@
 #ifdef __TLE__
 
 #include "Dialect/MUSATLE/IR/Dialect.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpImplementation.h"
 #include "triton/Dialect/Triton/IR/Types.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/ADT/STLExtras.h"
+#include <optional>
 
 // clang-format off
 #include "Dialect/MUSATLE/IR/Dialect.cpp.inc"
@@ -34,7 +38,153 @@ constexpr int kSharedMemoryAddressSpace = 3;
 static bool isRank0BackingMemDesc(ttg::MemDescType memDescTy) {
   return memDescTy.getShape().size() == 1 && memDescTy.getShape().front() == 1;
 }
+
+static SmallVector<int64_t> getDenseI64Array(Attribute attr) {
+  SmallVector<int64_t> values;
+  if (auto dense = dyn_cast_or_null<DenseI64ArrayAttr>(attr))
+    llvm::append_range(values, dense.asArrayRef());
+  return values;
+}
+
+static LogicalResult verifyTileShape(Operation *op, ArrayRef<int64_t> srcShape,
+                                     ArrayRef<int64_t> tileShape,
+                                     StringRef attrName) {
+  if (tileShape.size() != srcShape.size())
+    return op->emitOpError() << attrName << " rank must match source rank";
+  for (size_t idx = 0; idx < srcShape.size(); ++idx) {
+    int64_t srcDim = srcShape[idx];
+    int64_t tileDim = tileShape[idx];
+    if (tileDim <= 0)
+      return op->emitOpError()
+             << attrName << " must be positive at dimension " << idx;
+    if (srcDim % tileDim != 0)
+      return op->emitOpError()
+             << "source shape must be divisible by " << attrName
+             << " at dimension " << idx << " (source=" << srcDim
+             << ", tile=" << tileDim << ")";
+  }
+  return success();
+}
+
+static std::optional<int64_t> getConstantIndex(Value index) {
+  auto constOp = index.getDefiningOp<arith::ConstantOp>();
+  if (!constOp)
+    return std::nullopt;
+  auto intAttr = dyn_cast<IntegerAttr>(constOp.getValue());
+  if (!intAttr)
+    return std::nullopt;
+  return intAttr.getInt();
+}
+
+static LogicalResult verifyStaticTileIndex(Operation *op, Value index,
+                                           ArrayRef<int64_t> srcShape,
+                                           ArrayRef<int64_t> tileShape) {
+  std::optional<int64_t> staticIndex = getConstantIndex(index);
+  if (!staticIndex)
+    return success();
+
+  int64_t totalTiles = 1;
+  for (auto [srcDim, tileDim] : llvm::zip_equal(srcShape, tileShape))
+    totalTiles *= srcDim / tileDim;
+  if (*staticIndex < 0 || *staticIndex >= totalTiles)
+    return op->emitOpError("index out of bounds for tile grid: index=")
+           << *staticIndex << ", total_tiles=" << totalTiles;
+  return success();
+}
 } // namespace
+
+void ExtractTileOp::build(OpBuilder &builder, OperationState &state, Value src,
+                          Value index, ArrayRef<int64_t> tileShape) {
+  auto srcTy = cast<RankedTensorType>(src.getType());
+  auto resultTy = RankedTensorType::get(tileShape, srcTy.getElementType(),
+                                        srcTy.getEncoding());
+  state.addOperands({src, index});
+  state.addAttribute("tile_shape", builder.getDenseI64ArrayAttr(tileShape));
+  state.addTypes(resultTy);
+}
+
+LogicalResult ExtractTileOp::verify() {
+  auto srcTy = dyn_cast<RankedTensorType>(getSrc().getType());
+  auto resultTy = dyn_cast<RankedTensorType>(getResult().getType());
+  if (!srcTy || !resultTy)
+    return emitOpError("expects source and result to be ranked tensors");
+
+  SmallVector<int64_t> tileShape =
+      getDenseI64Array(getOperation()->getAttr("tile_shape"));
+  if (failed(verifyTileShape(getOperation(), srcTy.getShape(), tileShape,
+                             "tile_shape")))
+    return failure();
+  if (srcTy.getElementType() != resultTy.getElementType())
+    return emitOpError("result element type must match source element type");
+  if (srcTy.getRank() != resultTy.getRank())
+    return emitOpError("result rank must match source rank");
+  if (resultTy.getShape() != ArrayRef<int64_t>(tileShape))
+    return emitOpError("result shape must equal tile_shape");
+  if (srcTy.getEncoding() && resultTy.getEncoding() &&
+      srcTy.getEncoding() != resultTy.getEncoding())
+    return emitOpError("result encoding must match source encoding");
+  return verifyStaticTileIndex(getOperation(), getIndex(), srcTy.getShape(),
+                               tileShape);
+}
+
+void InsertTileOp::build(OpBuilder &builder, OperationState &state, Value src,
+                         Value tile, Value index) {
+  auto srcTy = cast<RankedTensorType>(src.getType());
+  auto tileTy = cast<RankedTensorType>(tile.getType());
+  SmallVector<int64_t> tileShape(tileTy.getShape());
+  state.addOperands({src, tile, index});
+  state.addAttribute("tile_shape", builder.getDenseI64ArrayAttr(tileShape));
+  state.addTypes(srcTy);
+}
+
+LogicalResult InsertTileOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> location, ValueRange operands,
+    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
+    SmallVectorImpl<Type> &inferredReturnTypes) {
+  if (operands.size() < 3)
+    return failure();
+  auto srcTy = dyn_cast<RankedTensorType>(operands[0].getType());
+  auto tileTy = dyn_cast<RankedTensorType>(operands[1].getType());
+  if (!srcTy || !tileTy)
+    return failure();
+  if (srcTy.getElementType() != tileTy.getElementType() ||
+      srcTy.getRank() != tileTy.getRank())
+    return failure();
+  inferredReturnTypes.clear();
+  inferredReturnTypes.push_back(srcTy);
+  return success();
+}
+
+LogicalResult InsertTileOp::verify() {
+  auto srcTy = dyn_cast<RankedTensorType>(getSrc().getType());
+  auto tileTy = dyn_cast<RankedTensorType>(getTile().getType());
+  auto resultTy = dyn_cast<RankedTensorType>(getResult().getType());
+  if (!srcTy || !tileTy || !resultTy)
+    return emitOpError("expects source, tile, and result to be ranked tensors");
+
+  SmallVector<int64_t> tileShape =
+      getDenseI64Array(getOperation()->getAttr("tile_shape"));
+  if (failed(verifyTileShape(getOperation(), srcTy.getShape(), tileShape,
+                             "tile_shape")))
+    return failure();
+  if (tileTy.getShape() != ArrayRef<int64_t>(tileShape))
+    return emitOpError("tile shape must equal tile_shape");
+  if (srcTy.getElementType() != tileTy.getElementType())
+    return emitOpError("tile element type must match source element type");
+  if (srcTy.getElementType() != resultTy.getElementType())
+    return emitOpError("result element type must match source element type");
+  if (srcTy.getRank() != tileTy.getRank())
+    return emitOpError("tile rank must match source rank");
+  if (srcTy.getRank() != resultTy.getRank())
+    return emitOpError("result rank must match source rank");
+  if (resultTy.getShape() != srcTy.getShape())
+    return emitOpError("result shape must equal source shape");
+  if (srcTy.getEncoding() && resultTy.getEncoding() &&
+      srcTy.getEncoding() != resultTy.getEncoding())
+    return emitOpError("result encoding must match source encoding");
+  return verifyStaticTileIndex(getOperation(), getIndex(), srcTy.getShape(),
+                               tileShape);
+}
 
 LogicalResult LocalPointersOp::verify() {
   auto memDescTy = dyn_cast<ttg::MemDescType>(getSrc().getType());

--- a/third_party/mthreads/tle/dialect/lib/Transforms/CMakeLists.txt
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_triton_library(MUSATLETransforms
   InsertLocalPointerBarriers.cpp
+  LowerExclusiveCumsum.cpp
   OptimizeLocalPointerAsyncStores.cpp
   OptimizeLocalPointerLoads.cpp
   OptimizeLocalPointerStores.cpp

--- a/third_party/mthreads/tle/dialect/lib/Transforms/LowerExclusiveCumsum.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/LowerExclusiveCumsum.cpp
@@ -1,0 +1,174 @@
+#ifdef __TLE__
+
+#include "Dialect/MUSATLE/IR/Dialect.h"
+#include "TritonMUSAGPUTransforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include <cstdint>
+#include <limits>
+
+namespace mlir {
+
+#define GEN_PASS_DEF_TRITONMUSAGPUTLELOWEREXCLUSIVECUMSUM
+#include "TritonMUSAGPUTransforms/Passes.h.inc"
+
+namespace {
+
+static Value createAddOp(OpBuilder &builder, Location loc, Value lhs, Value rhs,
+                         Type elemTy) {
+  if (isa<FloatType>(elemTy))
+    return arith::AddFOp::create(builder, loc, lhs, rhs).getResult();
+  if (elemTy.isIntOrIndex())
+    return arith::AddIOp::create(builder, loc, lhs, rhs).getResult();
+  return nullptr;
+}
+
+static Value createSubOp(OpBuilder &builder, Location loc, Value lhs, Value rhs,
+                         Type elemTy) {
+  if (isa<FloatType>(elemTy))
+    return arith::SubFOp::create(builder, loc, lhs, rhs).getResult();
+  if (elemTy.isIntOrIndex())
+    return arith::SubIOp::create(builder, loc, lhs, rhs).getResult();
+  return nullptr;
+}
+
+static LogicalResult buildScanAddRegion(OpBuilder &builder, triton::ScanOp scan,
+                                        Type elemTy, Location loc) {
+  OpBuilder::InsertionGuard guard(builder);
+  Block *block = builder.createBlock(&scan.getCombineOp());
+  block->addArgument(elemTy, loc);
+  block->addArgument(elemTy, loc);
+  builder.setInsertionPointToEnd(block);
+  Value sum = createAddOp(builder, loc, block->getArgument(0),
+                          block->getArgument(1), elemTy);
+  if (!sum)
+    return failure();
+  triton::ScanReturnOp::create(builder, loc, ValueRange{sum});
+  return success();
+}
+
+static LogicalResult buildReduceSelectByIndexRegion(OpBuilder &builder,
+                                                    triton::ReduceOp reduce,
+                                                    Type elemTy, Location loc,
+                                                    bool pickMaxIndex) {
+  OpBuilder::InsertionGuard guard(builder);
+  Block *block = builder.createBlock(&reduce.getCombineOp());
+  Type idxTy = builder.getI32Type();
+  block->addArgument(idxTy, loc);
+  block->addArgument(elemTy, loc);
+  block->addArgument(idxTy, loc);
+  block->addArgument(elemTy, loc);
+  builder.setInsertionPointToEnd(block);
+
+  Value lhsIdx = block->getArgument(0);
+  Value lhsVal = block->getArgument(1);
+  Value rhsIdx = block->getArgument(2);
+  Value rhsVal = block->getArgument(3);
+
+  arith::CmpIPredicate pred =
+      pickMaxIndex ? arith::CmpIPredicate::sgt : arith::CmpIPredicate::slt;
+  Value chooseLhs = arith::CmpIOp::create(builder, loc, pred, lhsIdx, rhsIdx);
+  Value selectedIdx =
+      arith::SelectOp::create(builder, loc, chooseLhs, lhsIdx, rhsIdx);
+  Value selectedVal =
+      arith::SelectOp::create(builder, loc, chooseLhs, lhsVal, rhsVal);
+  triton::ReduceReturnOp::create(builder, loc,
+                                 ValueRange{selectedIdx, selectedVal});
+  return success();
+}
+
+class LowerExclusiveCumsumPass
+    : public impl::TritonMUSAGPUTLELowerExclusiveCumsumBase<
+          LowerExclusiveCumsumPass> {
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    SmallVector<triton::musa_tle::ExclusiveCumsumOp> ops;
+    module.walk(
+        [&](triton::musa_tle::ExclusiveCumsumOp op) { ops.push_back(op); });
+
+    for (triton::musa_tle::ExclusiveCumsumOp op : ops) {
+      if (!op)
+        continue;
+
+      auto srcTy = dyn_cast<RankedTensorType>(op.getSrc().getType());
+      if (!srcTy) {
+        op.emitOpError("expects ranked tensor input");
+        signalPassFailure();
+        return;
+      }
+      int64_t axisExtent = srcTy.getShape()[0];
+      if (ShapedType::isDynamic(axisExtent) || axisExtent <= 0) {
+        op.emitOpError("expects static, positive axis extent");
+        signalPassFailure();
+        return;
+      }
+      if (axisExtent >
+          static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
+        op.emitOpError("axis extent is too large for tt.make_range");
+        signalPassFailure();
+        return;
+      }
+
+      const Type elemTy = srcTy.getElementType();
+      OpBuilder builder(op);
+
+      auto scan = triton::ScanOp::create(
+          builder, op.getLoc(), ValueRange{op.getSrc()},
+          static_cast<int>(op.getAxis()), op.getReverse());
+      if (failed(buildScanAddRegion(builder, scan, elemTy, op.getLoc()))) {
+        op.emitOpError("failed to build add combiner for triton.scan");
+        signalPassFailure();
+        return;
+      }
+      Value inclusive = scan.getResult()[0];
+      Value exclusive =
+          createSubOp(builder, op.getLoc(), inclusive, op.getSrc(), elemTy);
+      if (!exclusive) {
+        op.emitOpError("unsupported element type for exclusive subtraction");
+        signalPassFailure();
+        return;
+      }
+
+      RankedTensorType idxTy = RankedTensorType::get(
+          srcTy.getShape(), builder.getI32Type(), srcTy.getEncoding());
+      Value indices =
+          triton::MakeRangeOp::create(builder, op.getLoc(), idxTy, /*start=*/0u,
+                                      /*end=*/static_cast<uint32_t>(axisExtent))
+              .getResult();
+      auto reduce = triton::ReduceOp::create(builder, op.getLoc(),
+                                             ValueRange{indices, inclusive},
+                                             static_cast<int>(op.getAxis()));
+      bool pickMaxIndex = !op.getReverse();
+      if (failed(buildReduceSelectByIndexRegion(builder, reduce, elemTy,
+                                                op.getLoc(), pickMaxIndex))) {
+        op.emitOpError(
+            "failed to build index-select combiner for triton.reduce");
+        signalPassFailure();
+        return;
+      }
+      Value total = reduce.getResult()[1];
+
+      if (exclusive.getType() != op.getExclusive().getType() ||
+          total.getType() != op.getTotal().getType()) {
+        op.emitOpError("lowered value types do not match op result types");
+        signalPassFailure();
+        return;
+      }
+
+      op.getExclusive().replaceAllUsesWith(exclusive);
+      op.getTotal().replaceAllUsesWith(total);
+      op.erase();
+    }
+  }
+};
+
+} // namespace
+} // namespace mlir
+
+#endif // __TLE__

--- a/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
+++ b/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
@@ -171,6 +171,14 @@ void init_triton_musa_tle_ir(py::module m) {
              return self.create<mlir::triton::musa_tle::LocalPointersOp>(
                  resultTy, memDesc, indices);
            })
+      .def("create_exclusive_cumsum",
+           [](TritonOpBuilder &self, mlir::Type exclusiveTy, mlir::Type totalTy,
+              mlir::Value src, int axis, bool reverse) -> mlir::OpState {
+             auto &builder = self.getBuilder();
+             return self.create<mlir::triton::musa_tle::ExclusiveCumsumOp>(
+                 mlir::TypeRange{exclusiveTy, totalTy}, src,
+                 builder.getI32IntegerAttr(axis), builder.getBoolAttr(reverse));
+           })
       .def("create_extract_tile",
            [](TritonOpBuilder &self, mlir::Value input, mlir::Value index,
               std::vector<int64_t> tileShape) -> mlir::Value {
@@ -190,6 +198,8 @@ void init_triton_musa_tle_ir(py::module m) {
 void init_triton_musa_tle_dialect_passes_ttgpuir(py::module m) {
   ADD_PASS_WRAPPER_0("add_tle_select_encodings",
                      mlir::createTritonMUSAGPUTLESelectEncodings);
+  ADD_PASS_WRAPPER_0("add_tle_lower_exclusive_cumsum",
+                     mlir::createTritonMUSAGPUTLELowerExclusiveCumsum);
   ADD_PASS_WRAPPER_0("add_tle_insert_local_pointer_barriers",
                      mlir::createTritonMUSAGPUTLEInsertLocalPointerBarriers);
   ADD_PASS_WRAPPER_0("add_tle_optimize_local_pointer_loads",

--- a/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
+++ b/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
@@ -170,6 +170,20 @@ void init_triton_musa_tle_ir(py::module m) {
                indices.push_back(py::cast<mlir::Value>(arg));
              return self.create<mlir::triton::musa_tle::LocalPointersOp>(
                  resultTy, memDesc, indices);
+           })
+      .def("create_extract_tile",
+           [](TritonOpBuilder &self, mlir::Value input, mlir::Value index,
+              std::vector<int64_t> tileShape) -> mlir::Value {
+             auto op = self.create<mlir::triton::musa_tle::ExtractTileOp>(
+                 input, index, tileShape);
+             return op.getResult();
+           })
+      .def("create_insert_tile",
+           [](TritonOpBuilder &self, mlir::Value input, mlir::Value tile,
+              mlir::Value index) -> mlir::Value {
+             auto op = self.create<mlir::triton::musa_tle::InsertTileOp>(
+                 input, tile, index);
+             return op.getResult();
            });
 }
 


### PR DESCRIPTION
<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->
## MTHREADS backend support for the main TLE Lite primitives in this patch:

  - `tle.extract_tile(x, index, tile_shape)`
    - Extracts a tile of shape `tile_shape` from a register tensor at a tile-grid index.
    - Supported index forms:
      - Multi-dimensional static (tuple/list of int/constexpr), linearized at compile time.
      - Scalar static (int/constexpr), treated as the linearized tile index.
      - Scalar dynamic (scalar i32/i64 `tl.tensor`), lowered through the shared-memory relay path.
      - Multi-dimensional dynamic (tuple/list containing `tl.tensor`), row-major linearized automatically in the frontend.
    - `tile_shape` must be compile-time constants, match the source rank, and divide the source shape evenly along each dimension.

  - `tle.insert_tile(x, tile, index)`
    - Inserts a register tile into a source tensor at a tile-grid index; result type equals the source type.
    - Index forms and constraints are the same as `extract_tile`; the tile shape is derived from the tile operand and must divide the source shape evenly.

  - `tle.cumsum(input, axis=0, reverse=False, dtype=None)`
    - Returns `(exclusive_sum, total_sum)` over a rank-1 tensor in one call:
      `exclusive_sum[i] = sum(input[:i])`, `total_sum = sum(input)`.
    - `reverse=True` produces the reverse-exclusive prefix with the same total.
    - dtype promotion follows the shared frontend: int8/int16 -> int32, uint8/uint16 -> uint32, bf16 -> fp32; int32/fp16/fp32 stay unchanged.
    - Limitations: only rank-1 tensors with axis=0 and static positive extent are supported; scalar input short-circuits to `(0, input)` in the frontend.

## Lowering path

  Key differences from native Triton:
  - All three primitives are backend-local `musa_tle` ops (`musa_tle.extract_tile`, `musa_tle.insert_tile`, `musa_tle.exclusive_cumsum`); the shared `tle` dialect is not linked into the mthreads build.
  - Tile ops keep their op identity through TTIR -> TTGIR and lower in MUSATLEToLLVM either through register shuffles (aligned static index) or a shared-memory relay (dynamic index), with scratch sized in `AllocateSharedMemory`.
  - `musa_tle.exclusive_cumsum` is lowered at TTGIR level by `tritonmusa-tle-lower-exclusive-cumsum` into one add-combiner `tt.scan`, an elementwise subtract for the exclusive result, and an index-select `tt.reduce` for the total.

## Performance Data
  Benchmark source:
  -  third_party/mthreads/python/test/unit/tle/benchmark/test_per_token_group_quant_fp8.py

  Environment:
  - Driver: 4.3.5
  - SDK: 5.1.0
  - Torch: 2.9.0

  TLE vs Triton Native: 1.25x SpeedUp on large shape
  test cmd: `python  third_party/mthreads/python/test/unit/tle/benchmark/test_per_token_group_quant_fp8.py --dtype bf16 --shape 1024,11008`
