### PR TITLE
[TLE] Fix FP8 WGMMA operand reuse and loop-carried WGMMA waits

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -175,6 +175,23 @@ static SmallVector<int64_t> getPermutedAllocShape(MemDescType srcTy,
                     srcTy.getAllocShape().end() - order.size());
   return allocShape;
 }
+
+static bool supportsWGMMAOperandTranspose(Type elementType) {
+  return elementType.isF16() || elementType.isBF16();
+}
+
+static bool isLegalWGMMAOperandDescriptorLayout(MemDescType type,
+                                                int operandIdx) {
+  auto nvmma = dyn_cast<NVMMASharedEncodingAttr>(type.getEncoding());
+  if (!nvmma || supportsWGMMAOperandTranspose(type.getElementType()))
+    return true;
+
+  if (operandIdx == 0)
+    return !nvmma.getTransposed();
+  if (operandIdx == 1)
+    return nvmma.getTransposed();
+  return false;
+}
 #endif
 
 // Given
@@ -305,6 +322,8 @@ public:
       if (srcMemDescTy && srcMemDescTy.getShape() == srcTy.getShape() &&
           srcMemDescTy.getElementType() == srcTy.getElementType() &&
           isBackedByLocalAlloc(srcMemDesc)) {
+        if (!supportsWGMMAOperandTranspose(srcMemDescTy.getElementType()))
+          return failure();
         Attribute viewEncoding;
         Dialect &srcDialect = srcMemDescTy.getEncoding().getDialect();
         auto srcInferLayoutInterface =
@@ -391,6 +410,8 @@ public:
     if (srcMemDescTy.getShape() != localLoadTy.getShape() ||
         srcMemDescTy.getElementType() != localLoadTy.getElementType())
       return failure();
+    if (!supportsWGMMAOperandTranspose(srcMemDescTy.getElementType()))
+      return failure();
     if (!isBackedByLocalAlloc(srcMemDesc))
       return failure();
 
@@ -474,6 +495,8 @@ public:
 
     if (srcMemDescTy.getShape() != localLoadTy.getShape() ||
         srcMemDescTy.getElementType() != localLoadTy.getElementType())
+      return failure();
+    if (!supportsWGMMAOperandTranspose(srcMemDescTy.getElementType()))
       return failure();
 
     auto transposedShape =
@@ -565,6 +588,8 @@ public:
 
     if (srcMemDescTy.getShape() != localLoadTy.getShape() ||
         srcMemDescTy.getElementType() != localLoadTy.getElementType())
+      return failure();
+    if (!supportsWGMMAOperandTranspose(srcMemDescTy.getElementType()))
       return failure();
 
     auto transposedShape =
@@ -661,6 +686,8 @@ public:
     if (srcMemDescTy.getShape() != srcLocalLoadTy.getShape() ||
         srcMemDescTy.getElementType() != srcLocalLoadTy.getElementType())
       return failure();
+    if (!supportsWGMMAOperandTranspose(srcMemDescTy.getElementType()))
+      return failure();
 
     auto transposedShape =
         applyPermutation(srcMemDescTy.getShape(), trans.getOrder());
@@ -748,6 +775,8 @@ public:
     if (!isa<NVMMASharedEncodingAttr, SharedLinearEncodingAttr>(
             srcMemDescTy.getEncoding()))
       return failure();
+    if (!isLegalWGMMAOperandDescriptorLayout(srcMemDescTy, /*operandIdx=*/0))
+      return failure();
 
     auto newDot = triton::nvidia_gpu::WarpGroupDotOp::create(
         rewriter, dotOp.getLoc(), dotOp.getD().getType(), srcMemDesc,
@@ -797,6 +826,8 @@ public:
         srcMemDescTy.getElementType() != allocTy.getElementType() ||
         srcMemDescTy.getMemorySpace() != allocTy.getMemorySpace() ||
         srcMemDescTy.getEncoding() != allocTy.getEncoding())
+      return failure();
+    if (!isLegalWGMMAOperandDescriptorLayout(srcMemDescTy, /*operandIdx=*/1))
       return failure();
 
     if (!llvm::all_of(allocOp->getUsers(), [](Operation *user) {

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
@@ -732,6 +732,40 @@ insertWgmmaWaitBefore(Operation *op, unsigned lastCompletedGroup,
   return wait;
 }
 
+static SmallVector<Value, 4> getPendingGroupResultValues(
+    ArrayRef<PendingSharedWgmmaGroup> pendingGroups) {
+  SmallVector<Value, 4> values;
+  for (const PendingSharedWgmmaGroup &group : pendingGroups) {
+    assert(!group.dots.empty() &&
+           "pending WGMMA group must contain at least one dot");
+    values.push_back(group.dots.back()->getResult(0));
+  }
+  return values;
+}
+
+static ttng::WarpGroupDotWaitOp insertWgmmaDepthWaitAfterLastPendingDot(
+    SmallVectorImpl<PendingSharedWgmmaGroup> &pendingGroups) {
+  // Keep loop-carried accumulator groups bounded across iterations without
+  // materializing the current iteration's WGMMA result. The final wait_group 0
+  // is emitted after the loop, so the pending groups remain tracked here.
+  assert(!pendingGroups.empty() && "expected at least one pending group");
+  ttng::WarpGroupDotOp lastDot = pendingGroups.back().dots.back();
+  Operation *anchor = lastDot.getOperation();
+  if (Operation *next = anchor->getNextNode();
+      next && isa<ttng::WarpGroupDotCommitOp>(next))
+    anchor = next;
+
+  IRRewriter builder(anchor->getContext());
+  builder.setInsertionPointAfter(anchor);
+  auto wait = ttng::WarpGroupDotWaitOp::create(
+      builder, anchor->getLoc(), ArrayRef<Value>{}, pendingGroups.size());
+
+  SmallVector<Value, 4> waitOperands =
+      getPendingGroupResultValues(pendingGroups);
+  ::threadValuesThroughWait(wait, waitOperands);
+  return wait;
+}
+
 static void
 consumeExistingWait(ttng::WarpGroupDotWaitOp wait,
                     SmallVectorImpl<PendingSharedWgmmaGroup> &pendingGroups) {
@@ -822,7 +856,8 @@ recordPendingDot(ttng::WarpGroupDotOp dot,
 static void scheduleTleWgmmaWaitsInBlock(
     Block *block, const TlePipeResourceAnalysis &resources,
     const TleWgmmaScheduleAnalysis &analysis,
-    SmallVectorImpl<PendingSharedWgmmaGroup> &pendingGroups) {
+    SmallVectorImpl<PendingSharedWgmmaGroup> &pendingGroups,
+    bool deferLoopCarriedYield = false) {
   for (Operation &bodyOp : llvm::make_early_inc_range(*block)) {
     Operation *op = &bodyOp;
     if (op->hasTrait<OpTrait::IsTerminator>())
@@ -874,10 +909,37 @@ static void scheduleTleWgmmaWaitsInBlock(
   Operation *terminator = block->getTerminator();
   if (!terminator)
     return;
+  if (deferLoopCarriedYield && isa<scf::YieldOp>(terminator)) {
+    if (!pendingGroups.empty())
+      insertWgmmaDepthWaitAfterLastPendingDot(pendingGroups);
+    return;
+  }
   drainForMaterializedOperands(terminator, analysis, pendingGroups);
   if (!pendingGroups.empty())
     insertWgmmaWaitBefore(terminator, pendingGroups.size() - 1, pendingGroups,
                           /*forwardedValues=*/{});
+}
+
+static void insertFinalWgmmaWaitAfterLoop(
+    scf::ForOp forOp,
+    SmallVectorImpl<PendingSharedWgmmaGroup> &pendingGroups) {
+  if (pendingGroups.empty())
+    return;
+
+  SmallVector<Value, 4> waitOperands;
+  if (auto yield = dyn_cast<scf::YieldOp>(forOp.getBody()->getTerminator())) {
+    for (auto indexed : llvm::enumerate(yield.getOperands())) {
+      if (findPendingGroupForValue(indexed.value(), pendingGroups))
+        waitOperands.push_back(forOp.getResult(indexed.index()));
+    }
+  }
+
+  IRRewriter builder(forOp.getContext());
+  builder.setInsertionPointAfter(forOp);
+  auto wait = ttng::WarpGroupDotWaitOp::create(
+      builder, forOp.getLoc(), ArrayRef<Value>{}, /*pendings=*/0);
+  ::threadValuesThroughWait(wait, waitOperands);
+  pendingGroups.clear();
 }
 
 static void
@@ -911,7 +973,9 @@ void scheduleTleWgmmaAsyncLaunch(scf::ForOp forOp) {
   SmallVector<PendingSharedWgmmaGroup, 4> pendingGroups;
 
   scheduleTleWgmmaWaitsInBlock(forOp.getBody(), resources, analysis,
-                               pendingGroups);
+                               pendingGroups,
+                               /*deferLoopCarriedYield=*/true);
+  insertFinalWgmmaWaitAfterLoop(forOp, pendingGroups);
   markTleExplicitWgmmaCommitGroups(forOp, analysis);
 }
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
@@ -732,8 +732,8 @@ insertWgmmaWaitBefore(Operation *op, unsigned lastCompletedGroup,
   return wait;
 }
 
-static SmallVector<Value, 4> getPendingGroupResultValues(
-    ArrayRef<PendingSharedWgmmaGroup> pendingGroups) {
+static SmallVector<Value, 4>
+getPendingGroupResultValues(ArrayRef<PendingSharedWgmmaGroup> pendingGroups) {
   SmallVector<Value, 4> values;
   for (const PendingSharedWgmmaGroup &group : pendingGroups) {
     assert(!group.dots.empty() &&
@@ -921,8 +921,7 @@ static void scheduleTleWgmmaWaitsInBlock(
 }
 
 static void insertFinalWgmmaWaitAfterLoop(
-    scf::ForOp forOp,
-    SmallVectorImpl<PendingSharedWgmmaGroup> &pendingGroups) {
+    scf::ForOp forOp, SmallVectorImpl<PendingSharedWgmmaGroup> &pendingGroups) {
   if (pendingGroups.empty())
     return;
 

--- a/third_party/tle/test/GPU/test_tle_optimize_dot_operands_fp8_wgmma_view.mlir
+++ b/third_party/tle/test/GPU/test_tle_optimize_dot_operands_fp8_wgmma_view.mlir
@@ -1,0 +1,33 @@
+// RUN: triton-opt %s -split-input-file --tritongpu-optimize-dot-operands | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tt.func @keep_fp8_transposed_wgmma_a_staging_alloc
+  tt.func @keep_fp8_transposed_wgmma_a_staging_alloc(
+      %b: !ttg.memdesc<64x128xf8E4M3FN, #shared2, #smem, mutable>) -> tensor<128x128xf32, #mma> {
+    %c0 = arith.constant 0 : i32
+    %acc = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #mma>
+
+    %a_smem = ttg.local_alloc : () -> !ttg.memdesc<1x64x128xf8E4M3FN, #shared, #smem, mutable>
+    %a_slot = ttg.memdesc_index %a_smem[%c0] : !ttg.memdesc<1x64x128xf8E4M3FN, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf8E4M3FN, #shared, #smem, mutable>
+    %a = ttg.local_load %a_slot : !ttg.memdesc<64x128xf8E4M3FN, #shared, #smem, mutable> -> tensor<64x128xf8E4M3FN, #blocked>
+    %a_t = tt.trans %a {order = array<i32: 1, 0>} : tensor<64x128xf8E4M3FN, #blocked> -> tensor<128x64xf8E4M3FN, #blocked1>
+
+    // CHECK-NOT: tle.memdesc_wgmma_view
+    // CHECK: %[[A_ALLOC:.+]] = ttg.local_alloc {{.*}} : (tensor<128x64xf8E4M3FN
+    // CHECK-NOT: tle.memdesc_wgmma_view
+    // CHECK: %[[A_DOT:.+]] = ttg.local_load %[[A_ALLOC]]
+    // CHECK-NOT: tle.memdesc_wgmma_view
+    // CHECK: ttng.warp_group_dot %[[A_DOT]], %arg0, {{.*}}
+    %a_alloc = ttg.local_alloc %a_t : (tensor<128x64xf8E4M3FN, #blocked1>) -> !ttg.memdesc<128x64xf8E4M3FN, #shared1, #smem>
+    %a_dot = ttg.local_load %a_alloc : !ttg.memdesc<128x64xf8E4M3FN, #shared1, #smem> -> tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+    %out = ttng.warp_group_dot %a_dot, %b, %acc {inputPrecision = 0 : i32, maxNumImpreciseAcc = 1073741824 : i32} : tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>> * !ttg.memdesc<64x128xf8E4M3FN, #shared2, #smem, mutable> -> tensor<128x128xf32, #mma>
+    tt.return %out : tensor<128x128xf32, #mma>
+  }
+}

--- a/third_party/tle/test/GPU/test_tle_wgmma_pipeline_accumulator_chain.mlir
+++ b/third_party/tle/test/GPU/test_tle_wgmma_pipeline_accumulator_chain.mlir
@@ -670,15 +670,20 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     %c1 = arith.constant 1 : index
     %c8 = arith.constant 8 : index
     %zero = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma>
+    // CHECK: %[[RES:.+]] = scf.for
     %res = scf.for %iv = %c0 to %c8 step %c1 iter_args(%acc = %zero) -> (tensor<64x64xf32, #mma>) {
       // CHECK: %[[DOT:.+]] = ttng.warp_group_dot
       %dot = ttng.warp_group_dot %a, %b, %acc {inputPrecision = 0 : i32} : !ttg.memdesc<64x64xbf16, #shared, #smem> * !ttg.memdesc<64x64xbf16, #shared1, #smem, mutable> -> tensor<64x64xf32, #mma>
       // CHECK-NEXT: ttng.warp_group_dot_commit
+      // CHECK-NEXT: %[[DEPTH:.+]]:{{.*}} = ttng.warp_group_dot_wait %[[DOT]]{{.*}} {pendings = 1 : i32}
       // CHECK-NEXT: ttng.arrive_barrier {{.*}} {release_fence = true}
-      // CHECK-NEXT: %[[WAIT:.+]]:{{.*}} = ttng.warp_group_dot_wait %[[DOT]]{{.*}} {pendings = 0 : i32}
       ttng.arrive_barrier %barrier, 128 {release_fence = true} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+      // CHECK-NEXT: scf.yield %[[DEPTH]]#0
       scf.yield %dot : tensor<64x64xf32, #mma>
     }
+    // CHECK-NEXT: }
+    // CHECK-NEXT: %[[FINAL:.+]] = ttng.warp_group_dot_wait %[[RES]] {pendings = 0 : i32}
+    // CHECK-NEXT: tt.store %{{.*}}, %[[FINAL]]
     tt.store %out, %res : tensor<64x64x!tt.ptr<f32>, #mma>
     tt.return
   }


### PR DESCRIPTION
## Summary

Fixes #653.

This PR fixes two related TLE WGMMA issues:

- Avoid reusing a transposed staged local load as a `tle.memdesc_wgmma_view` for FP8 WGMMA operands, because FP8 WGMMA does not support the transposed operand form used by that rewrite.
- Preserve explicit WGMMA commit scheduling while moving the final `warp_group_dot_wait {pendings = 0}` drain out of the top-level `scf.for` body. The loop now keeps a loop-carried depth wait and emits the lifetime-draining wait after the loop.

## Problem

Issue #653 exposed a compile failure in the FP8 WGMMA path. The TLE dot operand optimization treated a transposed local-load staging allocation as reusable through `tle.memdesc_wgmma_view`. That is valid only for supported descriptor/layout combinations, and not for FP8 transpose.

A follow-up performance investigation found that the explicit WGMMA commit scheduler could insert `warp_group_dot_wait {pendings = 0}` inside the loop when the top-level loop body yielded an accumulator value. That fully drained the WGMMA group every iteration and prevented the expected loop-carried async depth.

Root cause locations:

- `lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp`: WGMMA view reuse did not gate transposed reuse by operand element type and descriptor-layout support.
- `lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp`: `scheduleTleWgmmaWaitsInBlock()` treated the top-level `scf.yield` as a materializing terminator and inserted a full drain inside the loop.

## Fix

- Restrict transposed WGMMA view reuse to supported f16/bf16 descriptor-layout cases. FP8 transposed staging remains materialized instead of being rewritten into an unsupported WGMMA view.
- Keep explicit `ttng.warp_group_dot_commit`, but distinguish top-level `scf.for` yields from true nested materialization boundaries:
  - emit a loop-internal depth wait using the pending group depth,
  - thread the yielded accumulator through that depth wait,
  - emit the final `warp_group_dot_wait {pendings = 0}` after the loop.
- Add TLE MLIR regression coverage for the FP8 operand rewrite and the top-level loop wait placement.

## Correctness Validation

Passed locally:

```bash
conda run -n flagtree ninja -C build/cmake.linux-x86_64-cpython-3.10 triton-opt libtriton.so
```

```bash
conda run -n flagtree sh -lc 'build/cmake.linux-x86_64-cpython-3.10/bin/triton-opt third_party/tle/test/GPU/test_tle_wgmma_pipeline_accumulator_chain.mlir -split-input-file -tritongpu-assign-latencies -tritongpu-schedule-loops -tritongpu-pipeline -canonicalize | /root/repos/llvm-f6ded0be-ubuntu-x64/bin/FileCheck third_party/tle/test/GPU/test_tle_wgmma_pipeline_accumulator_chain.mlir'
```

```bash
conda run -n flagtree sh -lc 'build/cmake.linux-x86_64-cpython-3.10/bin/triton-opt third_party/tle/test/GPU/test_tle_optimize_dot_operands_fp8_wgmma_view.mlir -split-input-file -tritongpu-optimize-dot-operands | /root/repos/llvm-f6ded0be-ubuntu-x64/bin/FileCheck third_party/tle/test/GPU/test_tle_optimize_dot_operands_fp8_wgmma_view.mlir'
```

Also validated that the issue #653 FP8 reproducer compiles and launches after rebuilding `triton-opt` and `libtriton.so`.

## Performance Validation

Ran the issue-mentioned benchmark command against the FlagGems benchmark file:

```bash
CUDA_VISIBLE_DEVICES=0 \
TRITON_BACKENDS_IN_TREE=1 \
TRITON_CACHE_DIR=/tmp/triton_issue653_current_waitfix \
PYTHONPATH=/root/repos/flagtree/python:/root/repos/FlagGems/src \
conda run -n flagtree pytest benchmark/test_fused_moe.py -vs
```

This was run as one cold-cache run plus three warmed-cache runs.

Current branch vs good parent, three-run median:

- Overall geomean: +1.44% runtime
- bf16: +1.05% runtime
- fp16: +1.83% runtime

Current branch vs commit `8f591fc427899fcd16d11bbfead0497328240600`, three-run median:

- Overall geomean: +0.85% runtime
- bf16: +0.97% runtime
- fp16: +0.73% runtime

No broad fused_moe regression was observed. The only >5% median outliers were small-batch/noisy cases, especially `[4,4096], experts=8, topk=2`, where raw timings fluctuated across runs for both the current branch and the baseline. These should be treated as noise unless reproduced with fixed clocks and a dedicated higher-iteration profiler run.

TTGIR/PTX checks:

- Scanned 32 WGMMA loops in the fused_moe cache. The fixed branch emits loop-internal `warp_group_dot_wait {pendings = 1}` and the final `warp_group_dot_wait {pendings = 0}` after the loop.
- For the fused_moe kernels, after ignoring the intentional explicit-commit attribute/op difference, the fixed TTGIR wait placement matches the good parent.
- PTX WGMMA instruction counts match the good parent for `wgmma.mma_async`, `wgmma.commit_group`, `wgmma.wait_group 1/0`, and `cp.async` commit/wait forms.

## Risk / Scope

The change is scoped to TLE-specific WGMMA operand rewriting and explicit WGMMA scheduling. Nested control-flow materialization remains conservative; the new after-loop drain path is only used for the top-level `scf.for` case where carrying async depth across iterations is valid and expected.
