### PR TITLE
[RPU][CI] Stop a wedged launch_kernel dispatch from failing the board smoke

### DIFF
--- a/.github/workflows/rpu3.6-build-and-test.yml
+++ b/.github/workflows/rpu3.6-build-and-test.yml
@@ -78,5 +78,15 @@ jobs:
           ssh -tt -o BatchMode=yes -o StrictHostKeyChecking=no rpuboard 'set -e
             cd ~/FlagTree-ci
             source ~/env.sh
+            # Reap any leaked launch_kernel_runner from an earlier wedged run:
+            # an orphan holding /dev/rpu leaves run_work stuck in the RPU queue
+            # and makes every dispatch here time out. Only kill ones alive far
+            # longer than the 120s per-case cap -- a healthy dispatch finishes
+            # in seconds, so this never touches a concurrent job on the shared
+            # board.
+            for pid in $(pgrep -f launch_kernel_runner 2>/dev/null); do
+              et=$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d " ")
+              if [ -n "$et" ] && [ "$et" -gt 130 ]; then sudo -n kill -9 "$pid" 2>/dev/null || true; fi
+            done
             pytest -q third_party/rpu/python/test/unit
             python3 third_party/rpu/python/test/board/lk_board_smoke.py --require-board -v'

--- a/third_party/rpu/python/test/board/lk_board_smoke.py
+++ b/third_party/rpu/python/test/board/lk_board_smoke.py
@@ -346,7 +346,9 @@ def _kill_dispatch(proc, case_dir, use_sudo):
     if use_sudo:
         subprocess.run(
             ["sudo", "-n", "pkill", "-9", "-f", str(case_dir)],
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
         )
     try:
         proc.wait(timeout=5)
@@ -361,8 +363,12 @@ def _run_cli(runner, case_dir, elf_name, kernel_name, specs):
     # start_new_session so the dispatch is its own process group and a hang can
     # be torn down as a group (see _kill_dispatch) instead of leaking an orphan.
     proc = subprocess.Popen(
-        cmd, cwd=case_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        text=True, start_new_session=True,
+        cmd,
+        cwd=case_dir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
     )
     try:
         out, err = proc.communicate(timeout=120)

--- a/third_party/rpu/python/test/board/lk_board_smoke.py
+++ b/third_party/rpu/python/test/board/lk_board_smoke.py
@@ -59,6 +59,7 @@ Exit codes: 0 = pass (or skip when not required); 1 = failure.
 import argparse
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -326,11 +327,49 @@ def _stage_lk_case(case_dir, elf, args, out_index, out_elems):
     return specs
 
 
+def _kill_dispatch(proc, case_dir, use_sudo):
+    """Tear down a hung launch_kernel dispatch so it cannot wedge the device.
+
+    A plain ``subprocess`` timeout only SIGKILLs the direct child (``sudo``);
+    sudo runs the real dispatcher (``launch_kernel_runner``) in its own pty
+    session, so it survives as an orphan that keeps ``/dev/rpu`` open and
+    leaves ``run_work`` stuck in the RPU driver queue -- every later case then
+    times out too. Kill the whole spawned process group, then reap any runner
+    still matching this case's unique work dir (its argv carries the
+    ``kernel.ref`` path, so the match is surgical and never touches a
+    concurrent job on a shared board).
+    """
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+    if use_sudo:
+        subprocess.run(
+            ["sudo", "-n", "pkill", "-9", "-f", str(case_dir)],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False,
+        )
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pass
+
+
 def _run_cli(runner, case_dir, elf_name, kernel_name, specs):
     use_sudo = os.environ.get("RPU_LK_SUDO", "1") not in ("0", "OFF", "FALSE", "NO")
     cmd = (["sudo", "-n"] if use_sudo else []) + [runner, str(Path(case_dir) / elf_name), kernel_name]
     cmd += [f"{role}:{size}:{path}" for role, size, path in specs]
-    return subprocess.run(cmd, cwd=case_dir, capture_output=True, text=True, timeout=120)
+    # start_new_session so the dispatch is its own process group and a hang can
+    # be torn down as a group (see _kill_dispatch) instead of leaking an orphan.
+    proc = subprocess.Popen(
+        cmd, cwd=case_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, start_new_session=True,
+    )
+    try:
+        out, err = proc.communicate(timeout=120)
+    except subprocess.TimeoutExpired:
+        _kill_dispatch(proc, case_dir, use_sudo)
+        raise
+    return subprocess.CompletedProcess(cmd, proc.returncode, out, err)
 
 
 def _compare(out_path, golden, n_elements, compare):


### PR DESCRIPTION
## Problem
When a `launch_kernel` dispatch on the RPU board hangs, the board smoke's 120s subprocess timeout only SIGKILLs the direct child (`sudo`). sudo runs the real `launch_kernel_runner` in its own pty session, so it survives as an orphan that keeps `/dev/rpu` open and leaves `run_work` stuck in the RPU driver queue. Every later case then opens the device, hits `run_work was already in queue`, and times out too -- one hung dispatch turns into `0/N passed`, and only a board reboot clears it. (Observed in CI: all 11 board-smoke cases `TimeoutExpired` while the unit suite stayed green.)

## Fix
- **`lk_board_smoke.py`**: run each dispatch via `Popen(start_new_session=True)`; on timeout, kill the whole process group and surgically reap any runner still matching the case's unique work dir, so a concurrent job on a shared board is never touched. The happy path still returns a `CompletedProcess` unchanged.
- **`rpu3.6` workflow**: before testing, reap any `launch_kernel_runner` alive far longer than the 120s per-case cap (a healthy dispatch finishes in seconds), clearing a pre-existing wedge without killing a concurrent dispatch.

## Verification
- `py_compile` + workflow YAML parse OK.
- Unit-tested the happy path (returns `CompletedProcess`) and the timeout teardown (process group fully reaped, no surviving runner).
- Board smoke is green 11/11 on the physical board; this patch leaves the dispatch happy-path identical and only changes timeout teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
