### PR TITLE
[BACKEND] Remove Iluvatar ext_Autotuner_key autotune hook

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -155,9 +155,6 @@ class Autotuner(KernelInterface):
                 if hasattr(arg, "dtype"):
                     key.append(str(arg.dtype))
             key = tuple(key)
-            # flagtree backend specialization
-            from triton.runtime.driver import spec
-            key = spec("ext_Autotuner_key", self, _args, *args) or key
             if key not in self.cache:
                 # prune configs
                 used_cached_result = False

--- a/third_party/iluvatar/backend/spec/__init__.py
+++ b/third_party/iluvatar/backend/spec/__init__.py
@@ -33,7 +33,6 @@ __all__ = [
     "atomic_add_int64",
     "add_Autotuner_attributes",
     "ext_Autotuner_bench",
-    "ext_Autotuner_key",
     "handle_only_save_best_config_cache",
     "get_cc",
     "get_temp_path_in_FileCacheManager_put",

--- a/third_party/iluvatar/backend/spec/triton/runtime/autotuner.py
+++ b/third_party/iluvatar/backend/spec/triton/runtime/autotuner.py
@@ -28,19 +28,6 @@ def ext_Autotuner_bench(autotuner):
     autotuner.cache_fn_map[cache_key][1].append(so_path)
 
 
-def ext_Autotuner_key(autotuner, _args, *args):
-    key = [_args[i] for i in autotuner.key_idx]
-    divisibility = 16
-    for arg in args:
-        if hasattr(arg, "data_ptr"):
-            key.append(arg.dtype)
-            key.append(arg.data_ptr() % divisibility == 0)
-        elif isinstance(arg, int):
-            key.append(arg)
-    key = tuple(key)
-    return key
-
-
 def build_best_config_hash(args_names, key):
     import os
     import hashlib


### PR DESCRIPTION
### Summary
Remove the Iluvatar-only ext_Autotuner_key autotune hook and its call site in autotuner.py.

That hook added all int kernel arguments (including philox_offset) to the autotune cache key, so RNG ops such as randn missed the cache on every call and re-ran autotuning (~680ms). Autotune now uses the upstream key logic (key_idx fields + tensor dtypes only).

Test plan

- pre-commit on changed files

- Rebuilt and installed with FLAGTREE_BACKEND=iluvatar

- Verified randn steady-state latency on Iluvatar MR-V100 (~0.15ms vs ~680ms before)