### PR TITLE
[TLE][HCU] Support the main TLE structure primitives

### DIFF
--- a/.github/workflows/hcu3.6-build-and-test.yml
+++ b/.github/workflows/hcu3.6-build-and-test.yml
@@ -47,3 +47,8 @@ jobs:
           set -x
           source ~/env.sh
           python3 -m pytest -s third_party/hcu/python/test/unit
+          python3 -m pytest -s python/test/tle/integration/test_tle_local_store.py
+          python3 -m pytest -s python/test/tle/integration/test_tle_gemm.py
+          python3 -m pytest -s python/test/tle/integration/test_tle_pipeline_e2e.py
+          python3 -m pytest -s python/test/tle/unit/test_tle_gpu_local_ptr.py
+          python3 -m pytest -s python/test/tle/unit/test_tle_gpu_slot.py

--- a/python/test/tle/integration/test_tle_local_store.py
+++ b/python/test/tle/integration/test_tle_local_store.py
@@ -107,7 +107,7 @@ def elementwise_add(A, B, C, XBLOCK=32, YBLOCK=64):
 class TestTLELocalStore:
     """TLE Local Store Integration Tests"""
 
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA GPU")
+    @pytest.mark.skipif(torch.cuda.device_count() == 0, reason="Requires CUDA GPU")
     def test_local_store_basic(self):
         """Test basic local store functionality with element-wise addition"""
         torch.manual_seed(42)  # Ensure reproducibility

--- a/python/test/tle/integration/test_tle_local_store.py
+++ b/python/test/tle/integration/test_tle_local_store.py
@@ -107,7 +107,7 @@ def elementwise_add(A, B, C, XBLOCK=32, YBLOCK=64):
 class TestTLELocalStore:
     """TLE Local Store Integration Tests"""
 
-    @pytest.mark.skipif(torch.cuda.device_count() == 0, reason="Requires CUDA GPU")
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA GPU")
     def test_local_store_basic(self):
         """Test basic local store functionality with element-wise addition"""
         torch.manual_seed(42)  # Ensure reproducibility

--- a/python/test/tle/unit/test_tle_gpu_local_ptr.py
+++ b/python/test/tle/unit/test_tle_gpu_local_ptr.py
@@ -20,6 +20,11 @@ def _is_enflame_backend():
     return target.backend == "gcu"
 
 
+def _is_hcu_backend():
+    target = triton.runtime.driver.active.get_current_target()
+    return target.backend == "hip"
+
+
 def _require_cuda():
     try:
         if _is_enflame_backend():
@@ -376,6 +381,13 @@ class TestTLELocalPointerKernel:
         if _is_enflame_backend():
             gcuir = compiled.asm["gcuir"]
             line = next((line for line in gcuir.splitlines() if "tle.local_pointers" in line), None)
+            if line is not None:
+                line_lhs = line.split(":", 1)[0]
+                assert "tle.local_pointers" in line_lhs
+                assert "," not in line_lhs
+        elif _is_hcu_backend():
+            ttgir = compiled.asm["ttgir"]
+            line = next((line for line in ttgir.splitlines() if "tle.local_pointers" in line), None)
             if line is not None:
                 line_lhs = line.split(":", 1)[0]
                 assert "tle.local_pointers" in line_lhs

--- a/third_party/hcu/backend/compiler_hcu.py
+++ b/third_party/hcu/backend/compiler_hcu.py
@@ -422,14 +422,12 @@ class HIPBackend(BaseBackend):
         passes.ttgpuir.add_f32_dot_tc(pm, emuTF32)
         passes.ttgpuir.add_remove_layout_conversions(pm)
         passes.ttgpuir.add_optimize_thread_locality(pm)
-
         # begin flagtree tle
         tle.passes.add_select_encodings(pm)
         tle.passes.add_insert_local_pointer_barriers(pm)
         tle.passes.add_optimize_local_pointer_loads(pm)
         tle.passes.add_optimize_local_pointer_stores(pm)
         # end flagtree tle
-
         hcu.passes.ttgpuir.add_accelerate_matmul(pm, options.arch, options.matrix_instr_nonkdim, options.kpack,
                                                  options.mmac_layout_force)
         passes.ttgpuir.add_remove_layout_conversions(pm)

--- a/third_party/hcu/backend/compiler_hcu.py
+++ b/third_party/hcu/backend/compiler_hcu.py
@@ -418,9 +418,18 @@ class HIPBackend(BaseBackend):
         pm.enable_debug()
         emuTF32 = False
         passes.ttgpuir.add_coalesce(pm)
+        passes.ttgpuir.add_process_shared_memory_hint(pm)  # flagtree hints
         passes.ttgpuir.add_f32_dot_tc(pm, emuTF32)
         passes.ttgpuir.add_remove_layout_conversions(pm)
         passes.ttgpuir.add_optimize_thread_locality(pm)
+
+        # begin flagtree tle
+        tle.passes.add_select_encodings(pm)
+        tle.passes.add_insert_local_pointer_barriers(pm)
+        tle.passes.add_optimize_local_pointer_loads(pm)
+        tle.passes.add_optimize_local_pointer_stores(pm)
+        # end flagtree tle
+
         hcu.passes.ttgpuir.add_accelerate_matmul(pm, options.arch, options.matrix_instr_nonkdim, options.kpack,
                                                  options.mmac_layout_force)
         passes.ttgpuir.add_remove_layout_conversions(pm)

--- a/third_party/hcu/lib/TritonHCUGPUToLLVM/CMakeLists.txt
+++ b/third_party/hcu/lib/TritonHCUGPUToLLVM/CMakeLists.txt
@@ -1,3 +1,14 @@
+if(FLAGTREE_TLE)
+    set(_TLE_LIBS
+        TritonTLEAnalysis
+        TritonNVIDIAGPUToLLVM
+        TleToLLVM # flagtree tle raw
+        TritonTLETransforms
+    )
+else()
+    set(_TLE_LIBS "")
+endif()
+
 add_triton_library(TritonHCUGPUToLLVM
     AsyncUtility.cpp
     AtomicRMWOpsEmitter.cpp
@@ -43,7 +54,7 @@ add_triton_library(TritonHCUGPUToLLVM
     LINK_LIBS PUBLIC
     TritonGPUToLLVM
     TritonHCUGPUIR
-    TritonTLETransforms
+    ${_TLE_LIBS}
     LLVMCore
     LLVMPasses
     LLVMSupport

--- a/third_party/hcu/lib/TritonHCUGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/hcu/lib/TritonHCUGPUToLLVM/TritonGPUToLLVM.cpp
@@ -21,6 +21,7 @@
 #ifdef __TLE__
 #include "tle/dialect/include/IR/Dialect.h"
 #include "tle/dialect/include/Transforms/PatternTleToLLVM.h"
+#include "tle/dialect/include/Conversion/TleToLLVM/LocalPointersOpToLLVM.h"
 #endif
 #include "third_party/hcu/include/Analysis/AxisInfoExt.h"
 #include "third_party/hcu/include/Dialect/TritonHCUGPU/IR/Dialect.h"
@@ -211,6 +212,9 @@ struct ConvertTritonHCUGPUToLLVM
           patternBenefitPrioritizeOverLLVMConversions);
       mlir::triton::tle::populateInsertTileOpToLLVMPatterns(
           typeConverter, tlePatterns, targetInfo,
+          patternBenefitPrioritizeOverLLVMConversions);
+      mlir::triton::tle::populateLocalPointersOpToLLVMPatterns(
+          typeConverter, targetInfo, tlePatterns,
           patternBenefitPrioritizeOverLLVMConversions);
       if (failed(
               applyPartialConversion(mod, tleTarget, std::move(tlePatterns))))

--- a/third_party/hcu/lib/TritonHCUGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/hcu/lib/TritonHCUGPUToLLVM/TritonGPUToLLVM.cpp
@@ -19,9 +19,9 @@
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Pass/Pass.h"
 #ifdef __TLE__
+#include "tle/dialect/include/Conversion/TleToLLVM/LocalPointersOpToLLVM.h"
 #include "tle/dialect/include/IR/Dialect.h"
 #include "tle/dialect/include/Transforms/PatternTleToLLVM.h"
-#include "tle/dialect/include/Conversion/TleToLLVM/LocalPointersOpToLLVM.h"
 #endif
 #include "third_party/hcu/include/Analysis/AxisInfoExt.h"
 #include "third_party/hcu/include/Dialect/TritonHCUGPU/IR/Dialect.h"


### PR DESCRIPTION
## HCU backend support for the basic TLE Structure primitives in this patch:

  - `tle.gpu.alloc`
    - Not support `nv_mma_shared_layout=True`.
    - Not support `tmem`.

  - `tle.gpu.local_ptr`
    - Device K100/BW1000 does not support `cluster`, not support `remote` (tle.remote). `tle.gpu.local_ptr` is used to materialize the shared-memory pointer corresponding to the given buffered tensor.

  - `tle.gpu.copy`
    - Supports global-memory <-> shared-memory copies.
    - Not support TMA copy.

## Lowering path

  Lowering is performed via the conversions and transforms in `third_party/tle`.

## Performance Data
  Benchmark source: 
  - `python/tutorials/tle/01-fft.py`.

  Environment:
  - Docker: harbor.baai.ac.cn/flagtree/flagtree-hcu3.6-py310-torch2.4.1-ubuntu22.04:202604-base

  Performance:
  - TLE FFT vs Triton FFT: 2x speedup