### PR TITLE
[Tsingmicro] Add missing environment variables for tsingmicro backend

### DIFF
--- a/.github/workflows/tsingmicro3.3-build-and-test.yml
+++ b/.github/workflows/tsingmicro3.3-build-and-test.yml
@@ -40,6 +40,12 @@ jobs:
           source ~/env.sh
           export FLAGTREE_BACKEND=tsingmicro
           export TRITON_APPEND_CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release"
+          export TX8_DEPS_ROOT=~/.flagtree/tsingmicro/tx8_deps
+          export LLVM_SYSPATH=~/.flagtree/tsingmicro/tsingmicro-llvm21-glibc2.30-glibcxx3.4.28-python3.10-x64
+          export LLVM_BINARY_DIR=${LLVM_SYSPATH}/bin
+          export PYTHONPATH=${LLVM_SYSPATH}/python_packages/mlir_core:$PYTHONPATH
+          export LD_LIBRARY_PATH=$TX8_DEPS_ROOT/lib:$LD_LIBRARY_PATH
+          export PATH=${LLVM_BINARY_DIR}:${PATH}
           cd python
           python3 -m pip install . --no-build-isolation
 

--- a/.github/workflows/tsingmicro3.3-delivery.yml
+++ b/.github/workflows/tsingmicro3.3-delivery.yml
@@ -38,7 +38,7 @@ on:
 
 jobs:
   call-delivery:
-    uses: flagos-ai/flagtree/.github/workflows/tsingmicro-delivery.yml@main
+    uses: flagos-ai/flagtree/.github/workflows/tsingmicro3.3-delivery.yml@main
     with:
       WHL_VER: ${{ inputs.WHL_VER }}
       PYTHON_VER: ${{ inputs.PYTHON_VER }}


### PR DESCRIPTION
Add the ${LLVM_BINARY_DIR} environment variable to $PATH to use the tsingmicro toolchain. Also, make sure to explicitly set the environment variables during the build and install phase.

<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->
