### PR TITLE
[BUILD][XPU] Fix potential wheel build failure with setuptools package data

### DIFF
--- a/python/setup_tools/setup_helper.py
+++ b/python/setup_tools/setup_helper.py
@@ -16,43 +16,6 @@ downloader = utils.tools.DownloadManager()
 configs = configs
 flagtree_backend = configs.flagtree_backend
 
-
-def _patch_llvm_exports():
-    """Remove the cmake import-file existence check from LLVMExports.cmake.
-
-    Some trust/xtdk-llvm22 packages export targets whose build-only binaries
-    (llvm-tblgen/opt/llvm-link/...) are not shipped, which makes the cmake
-    "verify imported files exist" loop raise FATAL_ERROR during
-    find_package(MLIR). This patch disables that check.
-
-    Notes:
-    - Idempotent: a `[patched]` marker is written in place of the check block,
-      so re-running on an already-patched file is a no-op.
-    - Harmless when the check block is absent (e.g. the 20260615 package does
-      not register those binaries for checking, so nothing matches).
-    """
-    import re
-    import glob
-    syspath = os.environ.get('LLVM_SYSPATH', '')
-    if not syspath:
-        return
-    marker = "# [patched] import file check disabled - binaries not shipped in trust package"
-    for f in glob.glob(f"{syspath}/lib/cmake/llvm/LLVMExports*.cmake"):
-        with open(f) as fh:
-            content = fh.read()
-        if marker in content:
-            continue  # already patched; stay idempotent
-        # Non-greedy match of a single check block. The block always ends at
-        # the first `unset(_cmake_import_check_targets)`, so `.*?` cannot span
-        # into a following block.
-        patched = re.sub(r'# Loop over all imported files.*?unset\(_cmake_import_check_targets\)', marker, content,
-                         flags=re.DOTALL)
-        if patched != content:
-            with open(f, 'w') as fh:
-                fh.write(patched)
-            print(f"[XPU] patched LLVMExports: {f}")
-
-
 set_llvm_env = lambda path: set_env(
     {
         'LLVM_INCLUDE_DIRS': Path(path) / "include",
@@ -150,6 +113,7 @@ def write_flagtree_backend_file(triton_pkg_dir=None):
     if triton_pkg_dir is None:
         triton_pkg_dir = Path(__file__).resolve().parents[1] / "triton"
     backend_value = os.environ.get("FLAGTREE_BACKEND", "")
+    os.makedirs(triton_pkg_dir, exist_ok=True)
     dest_file = Path(triton_pkg_dir) / "FLAGTREE_BACKEND"
     dest_file.write_text(backend_value)
 
@@ -473,6 +437,30 @@ def check_env(env_val):
     return os.environ.get(env_val, '') != ''
 
 
+def register_backend_cache():
+    hook_call = get_hook_instance("register_cache")
+    if hook_call:
+        hook_call(cache=cache, flagtree_backend=flagtree_backend, check_env=check_env, set_llvm_env=set_llvm_env)
+
+
+def check_pybind11_abi():
+    hook_call = get_hook_instance("check_pybind11_abi")
+    if hook_call:
+        hook_call(cache=cache)
+
+
+def overlay_backend_runtime_so():
+    hook_call = get_hook_instance("overlay_runtime_so")
+    if hook_call:
+        hook_call(cache=cache)
+
+
+def write_backend_site_pth(dest_dir):
+    hook_call = get_hook_instance("write_site_pth")
+    if hook_call:
+        hook_call(dest_dir)
+
+
 def uninstall_triton():
     is_bdist_wheel = any(cmd in sys.argv for cmd in ['bdist_wheel', 'egg_info', 'sdist'])
     if is_bdist_wheel:
@@ -524,89 +512,7 @@ cache.store(
     "https://baai-cp-web.ks3-cn-beijing.ksyuncs.com/trans/iluvatarTritonPlugin-cpython3.10-glibc2.30-glibcxx3.4.28-cxxabi1.3.12-ubuntu-x86_64_v0.3.0.tar.gz",
     copy_dst_path=f"third_party/{flagtree_backend}", md5_digest="015b9af8")
 
-# klx xpu - upgraded to trust LLVM (llvm22) for Triton 3.6
-# 20260615 xtdk-llvm22 ships the full xpu3 device-codegen toolchain
-# (clang/ld.lld/xpu3-elfconv/xpu3-elfconv-triton/xpu-kernel.t/llvm-readelf/objdump/objcopy),
-# so kernel launch works. It omits build-only tools (llvm-tblgen/opt/llvm-link/llvm-as/
-# llvm-dis) that LLVMExports.cmake references, so _patch_llvm_exports() disables that check.
-# decompress() renames the extracted top-level dir to the `file=` name, so LLVM_SYSPATH
-# resolves to <cache>/xpu/llvm_trust regardless of the tarball's top-level name.
-cache.store(
-    file="llvm_trust",
-    condition=("xpu" == flagtree_backend),
-    url="https://klx-sdk-release-public.su.bcebos.com/XTriton/llvm22/20260615/xtdk-llvm22-ubuntu2004_x86_64.tar.gz",
-    pre_hook=lambda: check_env('LLVM_SYSPATH'),
-    post_hook=lambda path: (set_llvm_env(path), _patch_llvm_exports()),
-    version="20260615",
-)
-
-cache.store(file="xre-Linux-x86_64", condition=("xpu" == flagtree_backend),
-            url="https://baai-cp-web.ks3-cn-beijing.ksyuncs.com/trans/xre-Linux-x86_64_v0.3.0.tar.gz",
-            copy_dst_path='python/_deps/xre3', version="v0.3.0")
-
-# xpu device libs (liblaunch_shared.so, libxpujitc.so, LLVM-15, clang-cpp)
-cache.store(file="xpu-device-libs", condition=("xpu" == flagtree_backend),
-            url="https://klx-sdk-release-public.su.bcebos.com/XTriton/xpu-device-libs-ubuntu-x64_v0.3.6.1.1.tar.gz",
-            version="v0.3.6.1.1")
-
-cache.store(files=("liblaunch_shared.so", "libLLVM-15.so", "libclang-cpp.so.15", "libxpujitc.so"),
-            condition=("xpu" == flagtree_backend), copy_src_path=f"{cache.dir_path}/{flagtree_backend}/xpu-device-libs",
-            copy_dst_path=f"third_party/{flagtree_backend}/device")
-
-
-# xpu SDNN prebuilt objects + libTritonSharedForXPU.a (344MB compressed)
-def _install_xpu_sdnn_objects(cached_path):
-    """Copy prebuilt SDNN objects from cache to third_party/xpu/."""
-    flagtree_dir = str(Path(__file__).resolve().parents[2])
-    dst_root = os.path.join(flagtree_dir, "third_party", "xpu")
-    for item in os.listdir(cached_path):
-        src = os.path.join(str(cached_path), item)
-        dst = os.path.join(dst_root, item)
-        if os.path.isdir(src):
-            shutil.copytree(src, dst, dirs_exist_ok=True)
-        else:
-            shutil.copy(src, dst)
-    print(f"[XPU] SDNN prebuilt objects installed to {dst_root}")
-
-
-cache.store(file="xpu-sdnn-objects", condition=("xpu" == flagtree_backend),
-            url="https://klx-sdk-release-public.su.bcebos.com/XTriton/xpu-sdnn-objects_v0.3.6.1.1.tar.gz",
-            post_hook=_install_xpu_sdnn_objects)
-
-# xpu3 bin tools from LLVM (xtdk-llvm22 20260615 ships xpu3-elfconv-triton directly)
-cache.store(
-    files=("clang", "xpu-xxd", "xpu3-elfconv", "xpu3-elfconv-triton", "xpu-kernel.t", "ld.lld", "llvm-readelf",
-           "llvm-objdump", "llvm-objcopy"), condition=("xpu" == flagtree_backend),
-    copy_src_path=f"{os.environ.get('LLVM_SYSPATH','')}/bin", copy_dst_path="third_party/xpu/backend/xpu3/bin")
-
-
-# xpu3-elfconv-triton resolves llvm-readelf/objdump/objcopy from xpu3/ (parent of bin/),
-# see the elfconv script line ~110. Symlink them so the resolver finds them.
-def _link_elfconv_triton():
-    import os
-    xpu3_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "third_party",
-                            "xpu", "backend", "xpu3")
-    bin_dir = os.path.join(xpu3_dir, "bin")
-    for tool in ("llvm-readelf", "llvm-objdump", "llvm-objcopy"):
-        tool_src = os.path.join(bin_dir, tool)
-        tool_dst = os.path.join(xpu3_dir, tool)
-        if os.path.exists(tool_src) and not os.path.exists(tool_dst):
-            os.symlink(os.path.join("bin", tool), tool_dst)
-            print(f"Created symlink: {tool_dst} -> bin/{tool}")
-
-
-if "xpu" == flagtree_backend:
-    _link_elfconv_triton()
-
-# xpu3 builtins + new crt*.o / xpuprintf (trust LLVM additions)
-cache.store(
-    files=("libclang_rt.builtins-xpu3.a", "libclang_rt.builtins-xpu3s.a", "clang_rt.crtbegin-xpu3.o",
-           "clang_rt.crtend-xpu3.o", "libclang_rt.xpuprintf-xpu3.a", "libclang_rt.xpuprintfs-xpu3.a"),
-    condition=("xpu" == flagtree_backend), copy_src_path=f"{os.environ.get('LLVM_SYSPATH','')}/lib/linux",
-    copy_dst_path="third_party/xpu/backend/xpu3/lib/linux")
-
-cache.store(files=("include", "so"), condition=("xpu" == flagtree_backend),
-            copy_src_path=f"{cache.dir_path}/xpu/xre-Linux-x86_64", copy_dst_path="third_party/xpu/backend/xpu3")
+register_backend_cache()
 
 # mthreads
 cache.store(

--- a/python/setup_tools/utils/xpu.py
+++ b/python/setup_tools/utils/xpu.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import shutil
 import inspect
@@ -85,6 +86,15 @@ def _patch_xpu_cmdclass(existing_cmdclass):
 
     class XpuBuildPy(original_build_py):
 
+        def find_data_files(self, package, src_dir):
+            # setuptools >= 79 can include symlink directories themselves in the
+            # manifest file list (SOURCES.txt), which then causes build_py to
+            # attempt to copy a directory as if it were a regular file and fail
+            # with "can't copy '...': doesn't exist or not a regular file".
+            # Filter out anything that is not a regular file so that only actual
+            # .py / binary files are passed to the copy step.
+            return [path for path in super().find_data_files(package, src_dir) if Path(path).is_file()]
+
         def run(self):
             self.force = True
             build_triton_dir = Path(self.build_lib) / "triton"
@@ -94,6 +104,250 @@ def _patch_xpu_cmdclass(existing_cmdclass):
 
     cmdclass["build_py"] = XpuBuildPy
     return cmdclass
+
+
+def _patch_llvm_exports():
+    """Remove the cmake import-file existence check from LLVMExports.cmake.
+
+    Some trust/xtdk-llvm22 packages export targets whose build-only binaries
+    (llvm-tblgen/opt/llvm-link/...) are not shipped, which makes the cmake
+    "verify imported files exist" loop raise FATAL_ERROR during find_package(MLIR).
+    This patch disables that check.
+    """
+    import glob
+    import re
+    syspath = os.environ.get('LLVM_SYSPATH', '')
+    if not syspath:
+        return
+    marker = "# [patched] import file check disabled - binaries not shipped in trust package"
+    for f in glob.glob(f"{syspath}/lib/cmake/llvm/LLVMExports*.cmake"):
+        with open(f) as fh:
+            content = fh.read()
+        if marker in content:
+            continue
+        patched = re.sub(r'# Loop over all imported files.*?unset\(_cmake_import_check_targets\)', marker, content,
+                         flags=re.DOTALL)
+        if patched != content:
+            with open(f, 'w') as fh:
+                fh.write(patched)
+            print(f"[XPU] patched LLVMExports: {f}")
+
+
+def install_sdnn_objects(cached_path, flagtree_dir):
+    """Copy prebuilt SDNN objects from cache to third_party/xpu/."""
+    dst_root = os.path.join(flagtree_dir, "third_party", "xpu")
+    for item in os.listdir(cached_path):
+        src = os.path.join(str(cached_path), item)
+        dst = os.path.join(dst_root, item)
+        if os.path.isdir(src):
+            shutil.copytree(src, dst, dirs_exist_ok=True)
+        else:
+            shutil.copy(src, dst)
+
+    # The prebuilt tarball lays libTritonXPUAnalysisSDNN.a under lib/Analysis/SDNN,
+    # but lib/Analysis/NewAnalysis/CMakeLists.txt imports it from NewAnalysis/SDNN.
+    sdnn_lib_name = "libTritonXPUAnalysisSDNN.a"
+    sdnn_src = None
+    for cand in (os.path.join(dst_root, "lib", "Analysis", "SDNN",
+                              sdnn_lib_name), os.path.join(dst_root, sdnn_lib_name)):
+        if os.path.exists(cand):
+            sdnn_src = cand
+            break
+    if sdnn_src is not None:
+        sdnn_dst_dir = os.path.join(dst_root, "lib", "Analysis", "NewAnalysis", "SDNN")
+        os.makedirs(sdnn_dst_dir, exist_ok=True)
+        shutil.copy(sdnn_src, os.path.join(sdnn_dst_dir, sdnn_lib_name))
+    else:
+        print(f"[XPU] warning: {sdnn_lib_name} not found under {dst_root}")
+    print(f"[XPU] SDNN prebuilt objects installed to {dst_root}")
+
+
+def link_elfconv_triton(flagtree_dir):
+    # xpu3-elfconv-triton resolves llvm-readelf/objdump/objcopy from xpu3/ (parent of bin/).
+    xpu3_dir = os.path.join(flagtree_dir, "third_party", "xpu", "backend", "xpu3")
+    bin_dir = os.path.join(xpu3_dir, "bin")
+    for tool in ("llvm-readelf", "llvm-objdump", "llvm-objcopy"):
+        tool_src = os.path.join(bin_dir, tool)
+        tool_dst = os.path.join(xpu3_dir, tool)
+        if os.path.exists(tool_src) and not os.path.exists(tool_dst):
+            os.symlink(os.path.join("bin", tool), tool_dst)
+            print(f"Created symlink: {tool_dst} -> bin/{tool}")
+
+
+# pybind11 ABI versions provided by each PYBIND11_INTERNALS_VERSION. The prebuilt
+# SDNN objects hard-encode a pybind11 ABI (embedded __pybind11_internals_v<N>
+# symbol); libtriton must be built against a pybind11 whose internals version
+# matches.
+_PYBIND11_INTERNALS_TO_PIP = {
+    4: "pybind11>=2.6,<2.12",
+    5: "pybind11>=2.12,<3.0",
+    11: "pybind11>=3.0,<3.1",
+}
+
+
+def _read_pybind11_internals_from_dir(scan_dir):
+    """Return the PYBIND11_INTERNALS_VERSION embedded in the prebuilt SDNN objects."""
+    import mmap
+    import re
+    pat = re.compile(rb"__pybind11_internals_v(\d+)")
+    candidates = []
+    for root, _, filenames in os.walk(str(scan_dir)):
+        for fn in filenames:
+            if fn.endswith((".o", ".a", ".so")):
+                candidates.append(os.path.join(root, fn))
+    candidates.sort(key=lambda p: (os.path.basename(p) != "triton_xpu_sdnn.cc.o", os.path.getsize(p)))
+    for path in candidates:
+        try:
+            with open(path, "rb") as fh, mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ) as mm:
+                m = pat.search(mm)
+                if m:
+                    return int(m.group(1))
+        except (OSError, ValueError):
+            continue
+    return None
+
+
+def _installed_pybind11_internals():
+    """(internals_version, pybind11_version) for the pybind11 the build will use."""
+    import re
+    try:
+        import pybind11
+    except Exception:
+        return None, None
+    version = getattr(pybind11, "__version__", None)
+    hdr = os.path.join(pybind11.get_include(), "pybind11", "detail", "internals.h")
+    try:
+        m = re.search(r"#\s*define\s+PYBIND11_INTERNALS_VERSION\s+(\d+)", Path(hdr).read_text())
+    except OSError:
+        return None, version
+    return (int(m.group(1)) if m else None), version
+
+
+def ensure_pybind11_matches_sdnn(scan_dir):
+    """Verify the env pybind11 ABI against the prebuilt SDNN objects (check only)."""
+    required = _read_pybind11_internals_from_dir(scan_dir)
+    if required is None:
+        return
+    installed, version = _installed_pybind11_internals()
+    if installed == required:
+        print(f"[XPU] pybind11 ABI OK: env pybind11 {version} (internals v{installed}) "
+              f"matches prebuilt SDNN objects (internals v{required})")
+        return
+
+    pip_spec = _PYBIND11_INTERNALS_TO_PIP.get(required)
+    detail = (f"[XPU] pybind11 ABI mismatch: prebuilt SDNN objects require "
+              f"PYBIND11_INTERNALS_VERSION={required}, but the environment's pybind11 "
+              f"{version} provides {installed}. Building against a mismatched pybind11 makes "
+              f"`import triton._C.libtriton` fail with "
+              f"'Cannot overload existing non-function object ... with a function of the same name'.")
+    hint = (f" Install a matching pybind11 first, e.g. `pip install '{pip_spec}'`, then rebuild."
+            if pip_spec else " No known pybind11 release maps to that internals version.")
+    raise RuntimeError(detail + hint)
+
+
+def check_pybind11_abi(cache):
+    """Verify the env pybind11 ABI matches the prebuilt SDNN objects."""
+    scan_dir = None
+    try:
+        scan_dir = Path(cache.get("xpu-sdnn-objects"))
+    except KeyError:
+        scan_dir = None
+    if scan_dir is None or not scan_dir.is_dir():
+        scan_dir = Path(cache.flagtree_dir) / "third_party" / "xpu"
+    ensure_pybind11_matches_sdnn(scan_dir)
+
+
+def overlay_runtime_so(cache):
+    """Overwrite third_party/xpu/backend/xpu3/so with the fixed runtime .so set."""
+    try:
+        src = Path(cache.get("xpu-runtime-so"))
+    except KeyError:
+        return
+    if not src.is_dir():
+        print(f"[XPU] runtime-so overlay skipped: {src} not found")
+        return
+    dst = Path(cache.flagtree_dir) / "third_party" / "xpu" / "backend" / "xpu3" / "so"
+    if dst.exists():
+        shutil.rmtree(dst)
+    os.makedirs(dst, exist_ok=True)
+    for item in os.listdir(src):
+        s = src / item
+        d = dst / item
+        if s.is_dir():
+            shutil.copytree(s, d, symlinks=True)
+        else:
+            shutil.copy2(s, d)
+    print(f"[XPU] runtime-so overlay applied: {src} -> {dst}")
+
+
+_XPU_LIBSTDCXX_PTH_NAME = "zzz_flagtree_xpu_libstdcxx.pth"
+_XPU_LIBSTDCXX_PTH_BODY = ("import sys; exec(\"try:\\n"
+                           " import os, ctypes\\n"
+                           " _p = os.path.join(sys.prefix, 'lib', 'libstdc++.so.6')\\n"
+                           " if os.path.isfile(_p) and b'GLIBCXX_3.4.30' in open(_p, 'rb').read(4194304):\\n"
+                           "  ctypes.CDLL(_p, mode=ctypes.RTLD_GLOBAL)\\n"
+                           "except Exception:\\n"
+                           " pass\")\n")
+
+
+def write_site_pth(dest_dir):
+    """Write the xpu libstdc++ preload .pth into dest_dir (build_lib root => site-packages)."""
+    if not dest_dir:
+        return
+    try:
+        os.makedirs(dest_dir, exist_ok=True)
+        out = os.path.join(dest_dir, _XPU_LIBSTDCXX_PTH_NAME)
+        with open(out, "w") as f:
+            f.write(_XPU_LIBSTDCXX_PTH_BODY)
+        print(f"[XPU] wrote libstdc++ preload pth: {out}")
+    except OSError as exc:
+        print(f"[XPU] could not write libstdc++ preload pth: {exc}")
+
+
+def register_cache(cache, flagtree_backend, check_env, set_llvm_env):
+    """Register all XPU cache artifacts and post-install hooks."""
+    is_xpu = "xpu" == flagtree_backend
+    cache.store(
+        file="llvm_trust",
+        condition=is_xpu,
+        url="https://klx-sdk-release-public.su.bcebos.com/XTriton/llvm22/20260615/xtdk-llvm22-ubuntu2004_x86_64.tar.gz",
+        pre_hook=lambda: check_env('LLVM_SYSPATH'),
+        post_hook=lambda path: (set_llvm_env(path), _patch_llvm_exports()),
+        version="20260615",
+    )
+    cache.store(file="xre-Linux-x86_64", condition=is_xpu,
+                url="https://baai-cp-web.ks3-cn-beijing.ksyuncs.com/trans/xre-Linux-x86_64_v0.3.0.tar.gz",
+                copy_dst_path='python/_deps/xre3', version="v0.3.0")
+    cache.store(file="xpu-device-libs", condition=is_xpu,
+                url="https://klx-sdk-release-public.su.bcebos.com/XTriton/xpu-device-libs-ubuntu-x64_v0.3.6.1.1.tar.gz",
+                version="v0.3.6.1.1")
+    cache.store(files=("liblaunch_shared.so", "libLLVM-15.so", "libclang-cpp.so.15", "libxpujitc.so"), condition=is_xpu,
+                copy_src_path=f"{cache.dir_path}/{flagtree_backend}/xpu-device-libs",
+                copy_dst_path=f"third_party/{flagtree_backend}/device")
+    cache.store(file="xpu-sdnn-objects", condition=is_xpu,
+                url="https://klx-sdk-release-public.su.bcebos.com/XTriton/xpu-sdnn-objects_v0.3.6.2.0.tar.gz",
+                post_hook=lambda path: install_sdnn_objects(path, cache.flagtree_dir))
+    cache.store(
+        files=("clang", "xpu-xxd", "xpu3-elfconv", "xpu3-elfconv-triton", "xpu-kernel.t", "ld.lld", "llvm-readelf",
+               "llvm-objdump", "llvm-objcopy"), condition=is_xpu,
+        copy_src_path=f"{os.environ.get('LLVM_SYSPATH','')}/bin", copy_dst_path="third_party/xpu/backend/xpu3/bin")
+    if is_xpu:
+        link_elfconv_triton(cache.flagtree_dir)
+    cache.store(
+        files=("libclang_rt.builtins-xpu3.a", "libclang_rt.builtins-xpu3s.a", "clang_rt.crtbegin-xpu3.o",
+               "clang_rt.crtend-xpu3.o", "libclang_rt.xpuprintf-xpu3.a", "libclang_rt.xpuprintfs-xpu3.a"),
+        condition=is_xpu, copy_src_path=f"{os.environ.get('LLVM_SYSPATH','')}/lib/linux",
+        copy_dst_path="third_party/xpu/backend/xpu3/lib/linux")
+    cache.store(files=("include", "so"), condition=is_xpu, copy_src_path=f"{cache.dir_path}/xpu/xre-Linux-x86_64",
+                copy_dst_path="third_party/xpu/backend/xpu3")
+    cache.store(
+        file="xpu-runtime-so",
+        condition=is_xpu,
+        url="https://klx-sdk-release-public.su.bcebos.com/XTriton/xpu-runtime-so_v0.3.6.2.0.tar.gz",
+        version="v0.3.6.2.0",
+    )
+    if is_xpu:
+        overlay_runtime_so(cache)
 
 
 def _wrap_setup(original_setup):
@@ -127,7 +381,8 @@ def _patch_setup_for_xpu_python_root():
         main_module.setup = _wrap_setup(main_module.setup)
         patched = True
 
-    if not patched:
+    main_file = getattr(main_module, "__file__", "") if main_module is not None else ""
+    if not patched and os.path.basename(main_file) == "setup.py":
         raise RuntimeError("xpu setup hook could not find setup() to patch")
 
 

--- a/setup.py
+++ b/setup.py
@@ -403,7 +403,26 @@ class CMakeBuildPy(build_py):
     def run(self) -> None:
         self.run_command('build_ext')
         helper.write_flagtree_backend_file()
-        return super().run()
+        # Re-apply the fixed xpu runtime .so overlay after cmake: device/CMakeLists.txt
+        # copies the stale liblaunch_shared.so/libxpujitc.so into backend/xpu3/so during
+        # build_ext, so we overwrite them again before build_py packages the wheel.
+        helper.overlay_backend_runtime_so()
+        ret = super().run()
+        # xpu-only: ensure triton/FLAGTREE_BACKEND lands in the wheel: build_py only
+        # copies .py by default, so this extension-less marker (read by
+        # triton._flagtree_backend to make XPUDriver.is_active() return True
+        # without any env var) was missing from the install, causing
+        # "0 active drivers". Write it into build_lib/triton so it is packaged.
+        if helper.flagtree_backend == "xpu":
+            try:
+                helper.write_flagtree_backend_file(os.path.join(self.build_lib, "triton"))
+            except Exception as _exc:  # noqa: BLE001
+                print(f"[flagtree] could not write build_lib FLAGTREE_BACKEND: {_exc}")
+        # xpu-only: drop a site .pth that preloads a GLIBCXX_3.4.30-capable libstdc++
+        # before torch, so kernel launch needs no manual LD_LIBRARY_PATH/LD_PRELOAD.
+        # Written into build_lib root so it lands at the site-packages root of the wheel.
+        helper.write_backend_site_pth(self.build_lib)
+        return ret
 
 
 class CMakeExtension(Extension):
@@ -428,6 +447,11 @@ class CMakeBuild(build_ext):
 
     def run(self):
         active_backend = os.environ.get("FLAGTREE_BACKEND", "")
+        # xpu: the prebuilt SDNN objects hard-encode a pybind11 ABI; verify the env
+        # pybind11 matches before cmake configures/compiles libtriton, and fail early
+        # with an actionable message otherwise. Done here (build_ext) rather than at
+        # import so non-build commands don't run the check.
+        helper.check_pybind11_abi()
         if active_backend not in ("xpu", ):
             download_and_copy_dependencies()
 
@@ -712,6 +736,34 @@ def get_packages():
         yield "triton.profiler"
 
 
+def get_package_data():
+    package_data = {}
+    if helper.flagtree_backend == "xpu":
+        # xpu-only: declare the FLAGTREE_BACKEND marker as package data so build_py
+        # copies it into build_lib/triton (and thus into the wheel + final install).
+        # Writing it to the source tree here guarantees the file physically exists
+        # when build_py globs package_data, instead of relying only on a post-run
+        # write into build_lib. Gated to xpu so other backends' wheels are unchanged.
+        helper.write_flagtree_backend_file()
+        package_data["triton"] = ["FLAGTREE_BACKEND"]
+        for backend in backends:
+            if backend.name != "xpu":
+                continue
+            files = []
+            driver_c = os.path.join(backend.backend_dir, "driver.c")
+            if os.path.exists(driver_c):
+                files.append("driver.c")
+            xpu3_dir = os.path.join(backend.backend_dir, "xpu3")
+            if os.path.isdir(xpu3_dir):
+                for root, _, filenames in os.walk(xpu3_dir):
+                    for filename in filenames:
+                        files.append(os.path.relpath(os.path.join(root, filename), backend.backend_dir))
+            if files:
+                package_data["triton.backends.xpu"] = files
+            break
+    return package_data
+
+
 def add_link_to_backends(external_only):
     for backend in backends:
         if external_only and not backend.is_external:
@@ -897,6 +949,7 @@ setup(
     ],
     packages=list(get_packages()),
     package_dir=dict(get_package_dirs()),
+    package_data=get_package_data(),
     entry_points=get_entry_points(),
     include_package_data=True,
     ext_modules=[CMakeExtension("triton", "triton/_C/")],

--- a/third_party/xpu/backend/driver.py
+++ b/third_party/xpu/backend/driver.py
@@ -22,7 +22,7 @@ def get_xpu_library_dirs(arch: int = -1):
     if arch == -1:
         include_dir = [os.path.join(dirname, "xpu3", "include")]
         libdevice_dir = os.path.join(dirname, "xpu3", "lib")
-        library_dir = os.path.join(dirname, f"xpu3", "so")
+        library_dir = os.path.join(dirname, "xpu3", "so")
         libraries = ["xpurt"]
         return include_dir, [libdevice_dir, library_dir], libraries
 
@@ -55,6 +55,9 @@ def get_xpu_spec(xpu_arch, is_sdnn=False):
 
 def compile_module_from_src(src, name, arch: int = -1):
     _print_startup_banner_once()
+    # Ensure a GLIBCXX_3.4.30-capable libstdc++ is loaded before the launcher .so
+    # is dlopened, so no manual LD_LIBRARY_PATH/LD_PRELOAD is needed at runtime.
+    _preload_libstdcxx()
     # Fold the backend install dir into the cache key. The launcher .so bakes
     # this dir into its RUNPATH (see _xpu_runtime_rpath_flags), so a cached
     # launcher built under a different install path would point at a stale/
@@ -146,10 +149,70 @@ def _flatten_library_dirs(library_dirs):
     return flat
 
 
+@functools.lru_cache(maxsize=1)
+def _compatible_libstdcxx():
+    """Locate a libstdc++.so.6 that exports GLIBCXX_3.4.30.
+
+    The prebuilt liblaunch_shared.so requires GLIBCXX_3.4.30, which the system
+    libstdc++ (e.g. Ubuntu 20.04 => 3.4.28) does not provide. The active Python
+    environment (conda/venv) ships a newer libstdc++, so resolve it from the
+    interpreter prefixes. Returns an absolute path or None.
+    """
+    import glob
+    candidates = []
+    for prefix in (sys.prefix, sys.base_prefix):
+        libdir = os.path.join(prefix, "lib")
+        candidates.append(os.path.join(libdir, "libstdc++.so.6"))
+        candidates.extend(sorted(glob.glob(os.path.join(libdir, "libstdc++.so.6.*"))))
+    seen = set()
+    for cand in candidates:
+        if cand in seen or not os.path.isfile(cand):
+            continue
+        seen.add(cand)
+        try:
+            with open(cand, "rb") as f:
+                blob = f.read()
+        except OSError:
+            continue
+        if b"GLIBCXX_3.4.30" in blob:
+            return cand
+    return None
+
+
+_libstdcxx_preloaded = False
+
+
+def _preload_libstdcxx():
+    """Preload a GLIBCXX_3.4.30-capable libstdc++ into the global namespace.
+
+    Must run before the launcher .so is dlopened so its (and liblaunch_shared.so's)
+    NEEDED libstdc++.so.6 binds to this newer library instead of the system one.
+    Idempotent and best-effort; failures are non-fatal.
+    """
+    global _libstdcxx_preloaded
+    if _libstdcxx_preloaded:
+        return
+    path = _compatible_libstdcxx()
+    if path is None:
+        return
+    try:
+        import ctypes
+        ctypes.CDLL(path, mode=ctypes.RTLD_GLOBAL)
+        _libstdcxx_preloaded = True
+    except OSError:
+        pass
+
+
 def _xpu_runtime_rpath_flags(library_dirs):
     flags = []
     seen = set()
-    for libdir in _flatten_library_dirs(library_dirs):
+    dirs = list(_flatten_library_dirs(library_dirs))
+    # Bake the env libstdc++ dir into the launcher RUNPATH so a cached launcher
+    # resolves GLIBCXX_3.4.30 without any manual LD_LIBRARY_PATH/LD_PRELOAD.
+    _libcxx = _compatible_libstdcxx()
+    if _libcxx is not None:
+        dirs.append(os.path.dirname(_libcxx))
+    for libdir in dirs:
         if not libdir or libdir in seen:
             continue
         seen.add(libdir)


### PR DESCRIPTION
[BUILD][XPU] Fix potential wheel build failure with setuptools package data
## Summary

Fix a potential XPU wheel build failure with newer setuptools by filtering non-regular files from `build_py` package data collection.

The reported failure happens during wheel build:

```text
error: can't copy 'third_party/xpu/python/triton/backends/xpu': doesn't exist or not a regular file