### PR TITLE
[CI] Update runner label from aipu to aipu3.3

### DIFF
--- a/.github/workflows/aipu3.3-build-and-test.yml
+++ b/.github/workflows/aipu3.3-build-and-test.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   aipu-build-and-test:
-    runs-on: aipu
+    runs-on: aipu3.3
     if: ${{ github.repository == 'FlagTree/flagtree' || github.repository == 'flagos-ai/flagtree' }}
     steps:
       - name: Setup environment


### PR DESCRIPTION
Update runs-on from 'aipu' to 'aipu3.3' to match the actual label configured on the self-hosted runner machine.

<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->
