### PR TITLE
[CI] Update runner label from hopper to nvidia3.5

### DIFF
--- a/.github/workflows/nv3.5-build-and-test.yml
+++ b/.github/workflows/nv3.5-build-and-test.yml
@@ -1,4 +1,4 @@
-name: Hopper3.5-Build-And-Test
+name: NV3.5-Build-And-Test
 
 on:
   schedule:
@@ -13,8 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  hopper-build-and-test:
-    runs-on: hopper
+  nv-build-and-test:
+    runs-on: nvidia3.5
     if: ${{ github.repository == 'FlagTree/flagtree' || github.repository == 'flagos-ai/flagtree' }}
     steps:
       - name: Setup environment


### PR DESCRIPTION
Update runs-on from 'hopper' to 'nvidia3.5' to match the actual label configured on the self-hosted runner machine.

<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->
