### PR TITLE
[HCU][TLE] Support tle.exclusive_cumsum

### DIFF
--- a/.github/workflows/hcu3.6-build-and-test.yml
+++ b/.github/workflows/hcu3.6-build-and-test.yml
@@ -50,5 +50,13 @@ jobs:
           python3 -m pytest -s python/test/tle/integration/test_tle_local_store.py
           python3 -m pytest -s python/test/tle/integration/test_tle_gemm.py
           python3 -m pytest -s python/test/tle/integration/test_tle_pipeline_e2e.py
+          python3 -m pytest -s python/test/tle/integration/test_tle_topk_smem_fallback.py
           python3 -m pytest -s python/test/tle/unit/test_tle_gpu_local_ptr.py
           python3 -m pytest -s python/test/tle/unit/test_tle_gpu_slot.py
+          python3 -m pytest -s python/test/tle/unit/test_tle_cumsum.py
+          python3 -m pytest -s python/test/tle/unit/test_extract_tile_dynamic_index.py
+          python3 -m pytest -s python/test/tle/unit/test_extract_tile_static_index.py
+          python3 -m pytest -s python/test/tle/unit/test_insert_tile_dynamic_index.py
+          python3 -m pytest -s python/test/tle/unit/test_insert_tile_static_index.py
+          python3 python/tutorials/tle/01-fft.py
+          python3 python/tutorials/tle/03-topk.py

--- a/python/test/tle/integration/test_tle_topk_smem_fallback.py
+++ b/python/test/tle/integration/test_tle_topk_smem_fallback.py
@@ -297,14 +297,14 @@ def test_tle_topk_smem_fallback_fullscan_recall_seq262144():
         TOPK=topk,
         BLOCK_SIZE=1024,
         ASSUME_ALIGNED=True,
-        num_warps=32,
+        num_warps=16,
         num_stages=1,
     )
     assert _recall(out, ref) == 1.0
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-@pytest.mark.parametrize("num_warps", [16, 32])
+@pytest.mark.parametrize("num_warps", [8, 16])
 def test_tle_topk_fallback_fullscan_stable_high_warps(num_warps):
     torch.manual_seed(1)
     seq_len = 262144

--- a/python/test/tle/unit/test_tle_cumsum.py
+++ b/python/test/tle/unit/test_tle_cumsum.py
@@ -17,6 +17,15 @@ def _is_enflame_backend():
     return target.backend == "gcu"
 
 
+def _is_hcu_backend():
+    target = triton.runtime.driver.active.get_current_target()
+    return target.backend == "hip"
+
+
+_nv_mma_shared_layout = tl.constexpr(False if _is_hcu_backend() else True)
+threads_per_warp = 64 if _is_hcu_backend() else 32
+
+
 def _require_cuda():
     try:
         if _is_enflame_backend():
@@ -63,7 +72,7 @@ def _tle_cumsum_callee_shared_kernel(hist_ptr, BLOCK: tl.constexpr):
 def _tle_cumsum_call_shared_kernel(exclusive_ptr, sentinel_ptr, BLOCK: tl.constexpr):
     sentinel_value = 123456789
     offs = tl.arange(0, BLOCK)
-    smem = tle.gpu.alloc([BLOCK * 2], dtype=tl.int32, scope=tle.gpu.smem)
+    smem = tle.gpu.alloc([BLOCK * 2], dtype=tl.int32, scope=tle.gpu.smem, nv_mma_shared_layout=_nv_mma_shared_layout)
     base = tle.gpu.local_ptr(smem, (0, ))
 
     tl.store(base + offs, offs + 1)
@@ -81,7 +90,7 @@ def _tle_cumsum_call_shared_kernel(exclusive_ptr, sentinel_ptr, BLOCK: tl.conste
 def _tle_cumsum_scalar_base_addptr_kernel(exclusive_ptr, sentinel_ptr, BLOCK: tl.constexpr):
     sentinel_value = 123456789
     offs = tl.arange(0, BLOCK)
-    smem = tle.gpu.alloc([BLOCK * 2], dtype=tl.int32, scope=tle.gpu.smem)
+    smem = tle.gpu.alloc([BLOCK * 2], dtype=tl.int32, scope=tle.gpu.smem, nv_mma_shared_layout=_nv_mma_shared_layout)
     base = tle.gpu.local_ptr(smem, (0, ))
     data_ptrs = base + offs
     sentinel_ptrs = base + (BLOCK + offs)
@@ -190,6 +199,7 @@ def test_tle_cumsum_exclusive_and_total(dtype, n, block, reverse, num_warps):
 
 
 @pytest.mark.skipif(_is_enflame_backend(), reason="PTX-specific regression guard not applicable on Enflame GCU")
+@pytest.mark.skipif(_is_hcu_backend(), reason="PTX-specific regression guard not applicable on HCU")
 def test_tle_cumsum_ptx_fastpath_regression_guard():
     block = 512
     x = torch.randint(-1024, 1024, (block, ), device="cuda", dtype=torch.int32)
@@ -222,9 +232,46 @@ def test_tle_cumsum_ptx_fastpath_regression_guard():
     assert len(re.findall(r"\bselp\b", ptx)) == 0
 
 
+@pytest.mark.skipif(not _is_hcu_backend(),
+                    reason="HCU ISA-specific regression guard not applicable on non-HCU backends")
+def test_tle_cumsum_amdgcn_fastpath_regression_guard():
+    block = 1024
+    x = torch.randint(-1024, 1024, (block, ), device="cuda", dtype=torch.int32)
+    exclusive = torch.empty_like(x)
+    total = torch.empty((1, ), device="cuda", dtype=torch.int32)
+
+    compiled = _tle_cumsum_ptx_kernel.warmup(
+        x,
+        exclusive,
+        total,
+        BLOCK=block,
+        grid=(1, ),
+        num_warps=block // threads_per_warp,
+        num_stages=1,
+    )
+
+    ttgir = compiled.asm["ttgir"]
+    assert "tle.exclusive_cumsum" in ttgir
+    assert "\"tt.scan\"" not in ttgir
+    assert ttgir.count("ttg.convert_layout") == 0
+
+    isa = compiled.asm["amdgcn"]
+    assert len(re.findall(r"\bs_barrier\b", isa)) == 2, \
+        "Expected exactly 2 s_barrier (warp-total fence + block-prefix fence)"
+    assert len(re.findall(r"\bds_bpermute_b32\b", isa)) == 6, \
+        "Expected 6 ds_bpermute_b32 for 64-lane warp scan (offsets 1,2,4,8,16,32)"
+    total_cross_lane = (len(re.findall(r"\bds_bpermute_b32\b", isa)) + len(re.findall(r"\bv_readlane_b32\b", isa)))
+    assert total_cross_lane <= 7, \
+        f"Too many cross-lane ops ({total_cross_lane}), fast-path may have regressed"
+    assert not re.search(r"v_cndmask.*\n.*ds_read", isa), \
+        "Detected predicated ds_read: possible regression to generic path"
+    assert not re.search(r"v_cndmask.*\n.*ds_write", isa), \
+        "Detected predicated ds_write: possible regression to generic path"
+
+
 def test_tle_cumsum_call_shared_frame_regression():
     block = 512
-    num_warps = block // 32
+    num_warps = block // threads_per_warp
     exclusive = torch.empty((block, ), device="cuda", dtype=torch.int32)
     sentinel = torch.empty((block, ), device="cuda", dtype=torch.int32)
 
@@ -256,7 +303,7 @@ def test_tle_cumsum_call_shared_frame_regression():
 
 def test_tle_cumsum_scalar_base_addptr_alias_regression():
     block = 512
-    num_warps = block // 32
+    num_warps = block // threads_per_warp
     exclusive = torch.empty((block, ), device="cuda", dtype=torch.int32)
     sentinel = torch.empty((block, ), device="cuda", dtype=torch.int32)
 

--- a/third_party/hcu/backend/compiler_hcu.py
+++ b/third_party/hcu/backend/compiler_hcu.py
@@ -563,6 +563,7 @@ class HIPBackend(BaseBackend):
         ##    For now it is used as a controller for developers only.
         __HIP_FTZ = True
         hcu.passes.ttgpuir.add_to_llvmir(pm, options.arch, __HIP_FTZ)
+        hcu.passes.ttgpuir.set_func_inline_attrs(pm, options.arch)
         # TritonDistributed Extension: distributed -> llvm
         distributed.passes.ttgpuir.hcu.add_distributed_to_llvm(pm, options.arch, __HIP_FTZ)
         passes.common.add_canonicalizer(pm)

--- a/third_party/hcu/include/TritonHCUGPUToLLVM/Passes.h
+++ b/third_party/hcu/include/TritonHCUGPUToLLVM/Passes.h
@@ -34,6 +34,9 @@ createOptimizeLDSUsagePass(StringRef arch, int32_t customLDSLimit = 0);
 
 void runScalarizePackedFOpsPass(llvm::Function &F);
 
+std::unique_ptr<OperationPass<ModuleOp>>
+createTritonHCUGPUSetFuncInlineAttrsPass(StringRef arch = "");
+
 } // namespace mlir::triton::HCU
 
 namespace mlir::triton {

--- a/third_party/hcu/include/TritonHCUGPUToLLVM/Passes.td
+++ b/third_party/hcu/include/TritonHCUGPUToLLVM/Passes.td
@@ -118,4 +118,24 @@ def HCUGPUConvertWarpSpecializeToLLVM : Pass<"triton-hcugpu-convert-warp-special
     ];
 }
 
+def TritonHCUGPUSetFuncInlineAttrs : Pass<"tritonhcugpu-set-func-inline-attrs", "mlir::ModuleOp"> {
+  let summary = "Rewrite noinline/alwaysinline passthrough attrs on lowered LLVM funcs";
+  let description = [{
+    This pass runs after ConvertTritonHCUGPUToLLVM. It inspects LLVM::LLVMFuncOp
+    ops with internal linkage (i.e. non-kernel helper functions) and rewrites
+    their `passthrough` attribute:
+      - If the func carries a `noinline` bool attr with value `false`, it is
+        marked `alwaysinline` instead of the default `noinline`.
+      - Otherwise it keeps the default `noinline` behavior so the LLVM
+        backend inliner does not inline large helper functions by default.
+  }];
+  let constructor = "mlir::triton::HCU::createTritonHCUGPUSetFuncInlineAttrsPass(\"\")";
+  let dependentDialects = ["mlir::LLVM::LLVMDialect"];
+
+  let options = [
+      Option<"arch", "arch", "std::string", /*default*/"\"\"",
+             "gfx target device architecture, e.g., gfx942">,
+  ];
+}
+
 #endif

--- a/third_party/hcu/lib/Analysis/HCUGPUAllocation.cpp
+++ b/third_party/hcu/lib/Analysis/HCUGPUAllocation.cpp
@@ -184,6 +184,26 @@ unsigned HCUAllocationAnalysisScratchSizeFn(Operation *op) {
     return static_cast<unsigned>(tileTy.getNumElements() *
                                  (getBitwidth(tileTy) / 8));
   }
+
+  if (auto cumsumOp = dyn_cast<mlir::triton::tle::ExclusiveCumsumOp>(op)) {
+    auto srcTy = dyn_cast<RankedTensorType>(cumsumOp.getSrc().getType());
+    if (!srcTy || srcTy.getRank() != 1)
+      return 0;
+    int64_t axisExtent = srcTy.getShape()[0];
+    if (ShapedType::isDynamic(axisExtent) || axisExtent <= 0)
+      return 0;
+    unsigned elemBytes =
+        static_cast<unsigned>(std::max<int>(1, getBitwidth(srcTy) / 8));
+    // Scratch layout for cumsum lowering:
+    // [axisExtent data][numWarps warp-prefix slots][1 total slot]
+    int64_t numWarps = std::max<int64_t>(1, triton::gpu::lookupNumWarps(op));
+    uint64_t totalBytes = (static_cast<uint64_t>(axisExtent) +
+                           static_cast<uint64_t>(numWarps) + 1ull) *
+                          elemBytes;
+    if (totalBytes > std::numeric_limits<unsigned>::max())
+      return 0;
+    return static_cast<unsigned>(totalBytes);
+  }
 #endif
 
   return defaultAllocationAnalysisScratchSizeFn(op);

--- a/third_party/hcu/lib/TritonHCUGPUToLLVM/CMakeLists.txt
+++ b/third_party/hcu/lib/TritonHCUGPUToLLVM/CMakeLists.txt
@@ -46,6 +46,7 @@ add_triton_library(TritonHCUGPUToLLVM
     ElementwiseOpHCUToLLVM.cpp
     MlsOpToLLVM.cpp
     ConvertWarpSpecializeToLLVM.cpp
+    SetFuncInlineAttrs.cpp
 
     DEPENDS
     TritonHCUGPUConversionPassIncGen

--- a/third_party/hcu/lib/TritonHCUGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/hcu/lib/TritonHCUGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1959,9 +1959,14 @@ struct AtomicRMWOpConversion
       numElems = tensorTy.getNumElements();
 
       auto threadOrder = getThreadOrder(tensorTy);
-      unsigned contigWithinLanes =
-          axisAnalysisPass.getAxisInfo(ptr)->getContiguity(threadOrder.front());
-      enableIntraWaveReduce &= contigWithinLanes == 1;
+      auto *axisInfo = axisAnalysisPass.getAxisInfo(ptr);
+      if (axisInfo) {
+        unsigned contigWithinLanes =
+            axisInfo->getContiguity(threadOrder.front());
+        enableIntraWaveReduce &= contigWithinLanes == 1;
+      } else {
+        enableIntraWaveReduce = false;
+      }
     }
 
     auto vecTy = vec_ty(valueElemTy, vec);

--- a/third_party/hcu/lib/TritonHCUGPUToLLVM/SetFuncInlineAttrs.cpp
+++ b/third_party/hcu/lib/TritonHCUGPUToLLVM/SetFuncInlineAttrs.cpp
@@ -1,0 +1,58 @@
+#include "TritonHCUGPUToLLVM/Passes.h"
+#include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
+#include "mlir/IR/BuiltinAttributes.h"
+
+namespace mlir::triton {
+#define GEN_PASS_DEF_TRITONHCUGPUSETFUNCINLINEATTRS
+#include "TritonHCUGPUToLLVM/Passes.h.inc"
+} // namespace mlir::triton
+
+using namespace mlir;
+
+//===----------------------------------------------------------------------===//
+// Pass Definition
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct TritonHCUGPUSetFuncInlineAttrs
+    : public mlir::triton::impl::TritonHCUGPUSetFuncInlineAttrsBase<
+          TritonHCUGPUSetFuncInlineAttrs> {
+public:
+  TritonHCUGPUSetFuncInlineAttrs(StringRef arch)
+      : TritonHCUGPUSetFuncInlineAttrsBase<TritonHCUGPUSetFuncInlineAttrs>() {
+    this->arch = arch.str();
+  }
+
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    MLIRContext *ctx = mod->getContext();
+
+    mod.walk([&](LLVM::LLVMFuncOp funcOp) {
+      // Only touch non-kernel (internal linkage) helper functions.
+      // Kernel entry points are handled separately in FuncOpToLLVM and
+      // should not be affected here.
+      if (funcOp.getLinkage() != LLVM::Linkage::Internal)
+        return;
+
+      if (auto noinlineAttr = funcOp->getAttrOfType<BoolAttr>("noinline")) {
+        if (!noinlineAttr.getValue()) {
+          funcOp.setPassthroughAttr(
+              ArrayAttr::get(ctx, {StringAttr::get(ctx, "alwaysinline")}));
+        }
+      }
+    });
+  }
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Factory Function
+//===----------------------------------------------------------------------===//
+namespace mlir::triton::HCU {
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createTritonHCUGPUSetFuncInlineAttrsPass(StringRef targetArch) {
+  return std::make_unique<TritonHCUGPUSetFuncInlineAttrs>(targetArch);
+}
+
+} // namespace mlir::triton::HCU

--- a/third_party/hcu/lib/TritonHCUGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/hcu/lib/TritonHCUGPUToLLVM/TritonGPUToLLVM.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Pass/Pass.h"
 #ifdef __TLE__
+#include "tle/dialect/include/Conversion/TleToLLVM/ExclusiveCumsumOpToLLVM.h"
 #include "tle/dialect/include/Conversion/TleToLLVM/LocalPointersOpToLLVM.h"
 #include "tle/dialect/include/IR/Dialect.h"
 #include "tle/dialect/include/Transforms/PatternTleToLLVM.h"
@@ -214,6 +215,9 @@ struct ConvertTritonHCUGPUToLLVM
           typeConverter, tlePatterns, targetInfo,
           patternBenefitPrioritizeOverLLVMConversions);
       mlir::triton::tle::populateLocalPointersOpToLLVMPatterns(
+          typeConverter, targetInfo, tlePatterns,
+          patternBenefitPrioritizeOverLLVMConversions);
+      mlir::triton::tle::populateExclusiveCumsumOpToLLVMPatterns(
           typeConverter, targetInfo, tlePatterns,
           patternBenefitPrioritizeOverLLVMConversions);
       if (failed(

--- a/third_party/hcu/lib/TritonHCUGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/hcu/lib/TritonHCUGPUTransforms/ConvertToBufferOps.cpp
@@ -234,6 +234,15 @@ bool canUseBufferOps(Value ptr,
   // pointer(splatted) and non-uniform offset addition
 
   LDBG("Buffer op checks for: " << ptr);
+  // flagtree tle:
+  // tt.load(smem_ptr + offsets) matches the buffer op rewrite pattern,
+  // check the ptr's address space to avoid incorrectly matching a
+  // shared-memory write as a buffer store.
+  if (auto tensorTy = dyn_cast<RankedTensorType>(ptr.getType()))
+    if (auto ptrTy = dyn_cast<triton::PointerType>(tensorTy.getElementType()))
+      if (ptrTy.getAddressSpace() == 3) // 3 = shared/LDS
+        return false;
+
   auto addPtrOp = ptr.getDefiningOp<triton::AddPtrOp>();
   if (!addPtrOp)
     return false;

--- a/third_party/hcu/lib/TritonHCUGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/hcu/lib/TritonHCUGPUTransforms/ConvertToBufferOps.cpp
@@ -235,7 +235,7 @@ bool canUseBufferOps(Value ptr,
 
   LDBG("Buffer op checks for: " << ptr);
   // flagtree tle:
-  // tt.load(smem_ptr + offsets) matches the buffer op rewrite pattern,
+  // tt.store(smem_ptr + offsets) matches the buffer op rewrite pattern,
   // check the ptr's address space to avoid incorrectly matching a
   // shared-memory write as a buffer store.
   if (auto tensorTy = dyn_cast<RankedTensorType>(ptr.getType()))

--- a/third_party/hcu/python/triton_hcu.cc
+++ b/third_party/hcu/python/triton_hcu.cc
@@ -121,6 +121,10 @@ void init_triton_hcu_passes_ttgpuir(py::module &&m) {
               arch, waspNumLoadWarps, waspNumMmaWarps, wdraEnabled,
               wdraNumLoadRegs, wdraNumMmaRegsMain, wdraNumMmaRegsTail));
         });
+  ADD_PASS_WRAPPER_1(
+      "set_func_inline_attrs",
+      mlir::triton::HCU::createTritonHCUGPUSetFuncInlineAttrsPass,
+      const std::string &);
 }
 
 void addControlConstant(llvm::Module *module, const char *name,

--- a/third_party/hcu/triton/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
+++ b/third_party/hcu/triton/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
@@ -165,11 +165,18 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
                          rewriter.getIntegerAttr(type::u1Ty(ctx), 1));
       newFuncOp.setLinkage(LLVM::Linkage::External);
     } else {
+#if __TLE__
+      auto noinlineAttr = newFuncOp->getAttrOfType<BoolAttr>("noinline");
+      if (noinlineAttr && !noinlineAttr.getValue())
+        newFuncOp.setPassthroughAttr(
+            ArrayAttr::get(ctx, rewriter.getStringAttr("alwaysinline")));
+#else
       // The noinline attribute will be used by the LLVM codegen to prevent
       // inlining.
       // https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/LLVMIR/IR/LLVMInlining.cpp#L267
       newFuncOp.setPassthroughAttr(
           ArrayAttr::get(ctx, rewriter.getStringAttr("noinline")));
+#endif
       newFuncOp.setLinkage(LLVM::Linkage::Internal);
     }
 

--- a/third_party/hcu/triton/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
+++ b/third_party/hcu/triton/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
@@ -165,18 +165,11 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
                          rewriter.getIntegerAttr(type::u1Ty(ctx), 1));
       newFuncOp.setLinkage(LLVM::Linkage::External);
     } else {
-#if __TLE__
-      auto noinlineAttr = newFuncOp->getAttrOfType<BoolAttr>("noinline");
-      if (noinlineAttr && !noinlineAttr.getValue())
-        newFuncOp.setPassthroughAttr(
-            ArrayAttr::get(ctx, rewriter.getStringAttr("alwaysinline")));
-#else
       // The noinline attribute will be used by the LLVM codegen to prevent
       // inlining.
       // https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/LLVMIR/IR/LLVMInlining.cpp#L267
       newFuncOp.setPassthroughAttr(
           ArrayAttr::get(ctx, rewriter.getStringAttr("noinline")));
-#endif
       newFuncOp.setLinkage(LLVM::Linkage::Internal);
     }
 

--- a/third_party/tle/dialect/lib/Conversion/TleToLLVM/ExclusiveCumsumOpToLLVM.cpp
+++ b/third_party/tle/dialect/lib/Conversion/TleToLLVM/ExclusiveCumsumOpToLLVM.cpp
@@ -106,6 +106,10 @@ static Value createWarpScanStepI32(Location loc,
     Value added = createAdd(loc, rewriter, shuffled, val, elemTy);
     return b.select(pred, added, val);
   } else {
+    auto intTy = dyn_cast<IntegerType>(val.getType());
+    if (!intTy || intTy.getWidth() != 32)
+      return Value();
+
     mlir::triton::PTXBuilder ptxBuilder;
     auto *out = ptxBuilder.newOperand("=r", /*init=*/false);
     auto *in = ptxBuilder.newOperand(val, "r");

--- a/third_party/tle/dialect/lib/Conversion/TleToLLVM/ExclusiveCumsumOpToLLVM.cpp
+++ b/third_party/tle/dialect/lib/Conversion/TleToLLVM/ExclusiveCumsumOpToLLVM.cpp
@@ -97,39 +97,44 @@ static Value branchSelect(ConversionPatternRewriter &rewriter, Location loc,
 
 static Value createWarpScanStepI32(Location loc,
                                    ConversionPatternRewriter &rewriter,
-                                   Value val, int offset) {
-  auto intTy = dyn_cast<IntegerType>(val.getType());
-  if (!intTy || intTy.getWidth() != 32)
-    return Value();
-
-  mlir::triton::PTXBuilder ptxBuilder;
-  auto *out = ptxBuilder.newOperand("=r", /*init=*/false);
-  auto *in = ptxBuilder.newOperand(val, "r");
-  auto i32Ty = rewriter.getI32Type();
-  auto *offsetOpr = ptxBuilder.newOperand(
-      LLVM::ConstantOp::create(rewriter, loc, i32Ty,
-                               rewriter.getI32IntegerAttr(offset)),
-      "r");
-  auto *clampOpr = ptxBuilder.newOperand(
-      LLVM::ConstantOp::create(rewriter, loc, i32Ty,
-                               rewriter.getI32IntegerAttr(0)),
-      "r");
-  auto *maskOpr = ptxBuilder.newOperand(
-      LLVM::ConstantOp::create(rewriter, loc, i32Ty,
-                               rewriter.getI32IntegerAttr(-1)),
-      "r");
-  std::string ptx = "{\n"
-                    "  .reg .s32 r0;\n"
-                    "  .reg .pred p;\n"
-                    "  shfl.sync.up.b32 r0|p, $1, $2, $3, $4;\n"
-                    "  @p add.s32 r0, r0, $1;\n"
-                    "  mov.s32 $0, r0;\n"
-                    "}\n";
-  auto &shflScan = *ptxBuilder.create(ptx);
-  shflScan({out, in, offsetOpr, clampOpr, maskOpr},
-           /*onlyAttachMLIRArgs=*/true);
-  return ptxBuilder.launch(rewriter, loc, val.getType(),
-                           /*hasSideEffects=*/false);
+                                   const TargetInfoBase &targetInfo, Value val,
+                                   int offset, Value laneId, Type elemTy) {
+  if (targetInfo.isHCU()) {
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    Value shuffled = targetInfo.shuffleUp(rewriter, loc, val, offset);
+    Value pred = b.icmp_sge(laneId, b.i32_val(offset));
+    Value added = createAdd(loc, rewriter, shuffled, val, elemTy);
+    return b.select(pred, added, val);
+  } else {
+    mlir::triton::PTXBuilder ptxBuilder;
+    auto *out = ptxBuilder.newOperand("=r", /*init=*/false);
+    auto *in = ptxBuilder.newOperand(val, "r");
+    auto i32Ty = rewriter.getI32Type();
+    auto *offsetOpr = ptxBuilder.newOperand(
+        LLVM::ConstantOp::create(rewriter, loc, i32Ty,
+                                 rewriter.getI32IntegerAttr(offset)),
+        "r");
+    auto *clampOpr = ptxBuilder.newOperand(
+        LLVM::ConstantOp::create(rewriter, loc, i32Ty,
+                                 rewriter.getI32IntegerAttr(0)),
+        "r");
+    auto *maskOpr = ptxBuilder.newOperand(
+        LLVM::ConstantOp::create(rewriter, loc, i32Ty,
+                                 rewriter.getI32IntegerAttr(-1)),
+        "r");
+    std::string ptx = "{\n"
+                      "  .reg .s32 r0;\n"
+                      "  .reg .pred p;\n"
+                      "  shfl.sync.up.b32 r0|p, $1, $2, $3, $4;\n"
+                      "  @p add.s32 r0, r0, $1;\n"
+                      "  mov.s32 $0, r0;\n"
+                      "}\n";
+    auto &shflScan = *ptxBuilder.create(ptx);
+    shflScan({out, in, offsetOpr, clampOpr, maskOpr},
+             /*onlyAttachMLIRArgs=*/true);
+    return ptxBuilder.launch(rewriter, loc, val.getType(),
+                             /*hasSideEffects=*/false);
+  }
 }
 
 struct ExclusiveCumsumOpConversion
@@ -187,6 +192,8 @@ struct ExclusiveCumsumOpConversion
       return getSharedElemPtr(loc, b, baseSharedMem, llvmElemTy, logicalIndex);
     };
 
+    const int warpShift = llvm::Log2_32(threadsPerWarp);
+
     // TRT/CUB-aligned fastpath for topk histogram rounds:
     // - rank-1, one element per thread
     // - no reverse remapping
@@ -195,14 +202,15 @@ struct ExclusiveCumsumOpConversion
     // generic logical-index path.
     if (!op.getReverse() && inputVals.size() == 1 &&
         axisExtent == static_cast<int64_t>(numThreadsPerCTA) &&
-        threadsPerWarp == 32 && numWarps > 0 && numWarps <= 32) {
+        !(threadsPerWarp % 32) && numWarps > 0 && numWarps <= 32) {
       Value laneId = b.and_(threadId, b.i32_val(threadsPerWarp - 1));
-      Value warpId = b.lshr(threadId, b.i32_val(5));
+      Value warpId = b.lshr(threadId, b.i32_val(warpShift));
       Value orderedVal = inputVals.front();
       Value scanVal = orderedVal;
       for (int offset = 1; offset < threadsPerWarp; offset <<= 1) {
         if (Value scanStep =
-                createWarpScanStepI32(loc, rewriter, scanVal, offset)) {
+                createWarpScanStepI32(loc, rewriter, targetInfo, scanVal,
+                                      offset, laneId, llvmElemTy)) {
           scanVal = scanStep;
         } else {
           Value shfl = targetInfo.shuffleUp(rewriter, loc, scanVal, offset);
@@ -297,10 +305,10 @@ struct ExclusiveCumsumOpConversion
     // warp-scan + shared-memory cross-warp prefix scan.
     // This is the dominant configuration for topk histogram threshold search.
     if (inputVals.size() == 1 && axisExtent <= numThreadsPerCTA &&
-        threadsPerWarp == 32 && numWarps > 0 && numWarps <= 32) {
+        !(threadsPerWarp % 32) && numWarps > 0 && numWarps <= 32) {
       Value axisExtentVal = b.i32_val(static_cast<int32_t>(axisExtent));
       Value laneId = b.and_(threadId, b.i32_val(threadsPerWarp - 1));
-      Value warpId = b.lshr(threadId, b.i32_val(5));
+      Value warpId = b.lshr(threadId, b.i32_val(warpShift));
       Value activeOrdered = b.icmp_ult(threadId, axisExtentVal);
 
       Value orderedPtr = getElemPtr(threadId);
@@ -311,7 +319,8 @@ struct ExclusiveCumsumOpConversion
       Value scanVal = orderedVal;
       for (int offset = 1; offset < threadsPerWarp; offset <<= 1) {
         if (Value scanStep =
-                createWarpScanStepI32(loc, rewriter, scanVal, offset)) {
+                createWarpScanStepI32(loc, rewriter, targetInfo, scanVal,
+                                      offset, laneId, llvmElemTy)) {
           scanVal = scanStep;
         } else {
           Value shfl = targetInfo.shuffleUp(rewriter, loc, scanVal, offset);


### PR DESCRIPTION
## HCU backend support for `tle.exclusive_cumsum` primitive and TLE topk tutorial.


## Lowering path

  - Avoid incorrectly rewriting the LDS write operation `tt.store(smem_ptr + offsets)` into a buffer store op.
  - Add the Passthrough="alwaysinline" attribute to inline the `noinline=false` non-kernel functions to avoid generating dynamic LDS instructions.

## Unit Test

  Reduce num_warps to avoid triton.runtime.errors.OutOfResources: out of resource: threads, Required: 2048, Hardware limit: 1024.

## Performance Data
  Benchmark source: 
  - `python/tutorials/tle/03-topk.py`.

  Environment:
  - Docker: harbor.baai.ac.cn/flagtree/flagtree-hcu3.6-py310-torch2.4.1-ubuntu22.04:202604-base

  Performance:
  - TLE vs Triton: 1.25x speedup in large size