### PR TITLE
[BUILD] Fix packaging CI: ENOSPC, PR-trigger removal, tag matching, version sync

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -1,22 +1,17 @@
 name: Build Debian Packages
 
+# Packaging is a release artifact, not a PR gate: the full-source wheel
+# build costs ~45 min per run and its ENOSPC flakiness was blocking
+# unrelated PRs. Build on release tags or on demand (workflow_dispatch).
 on:
   push:
     tags:
       - 'v*'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'packaging/debian/**'
-      - 'python/**'
-      - 'include/**'
-      - 'lib/**'
-      - 'cmake/**'
-      - 'bin/**'
-      - 'CMakeLists.txt'
-      - 'pyproject.toml'
-      - '.github/workflows/build-deb.yml'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-deb:
@@ -28,6 +23,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
+      # The wheel build peaks close to the standard runner's ~14 GB of
+      # free disk (ENOSPC seen on the RPM twin of this workflow);
+      # dropping unused preinstalled toolchains reclaims ~25-30 GB.
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          df -h /
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -1,13 +1,7 @@
 name: Build Debian Packages
 
-# Packaging is a release artifact, not a PR gate: the full-source wheel
-# build costs ~45 min per run and its ENOSPC flakiness was blocking
-# unrelated PRs. Build on release tags or on demand (workflow_dispatch).
-#
-# FlagTree release tags are unprefixed (0.6.0, 0.6.0rc1); v-prefixed
-# tags stopped after v0.3.0. Backend-variant tags (0.6.0+mthreads3.6)
-# are filtered out at the job level — those releases are not the
-# nvidia package.
+# Release packaging only (no PR trigger). Release tags are unprefixed
+# since 0.3.0, e.g. 0.6.0 / 0.6.0rc1.
 on:
   push:
     tags:
@@ -31,11 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      # The wheel build peaks close to the standard runner's ~14 GB of
-      # free disk (ENOSPC seen on the RPM twin of this workflow);
-      # dropping unused preinstalled toolchains reclaims ~25-30 GB.
-      # Guarded to ephemeral GitHub-hosted VMs only, so a future move to
-      # a self-hosted runner can never wipe a real machine.
+      # The wheel build peaks near the runner's free-disk limit.
+      # Ephemeral GitHub-hosted VMs only — never a self-hosted machine.
       - name: Free runner disk space
         run: |
           if [ "${RUNNER_ENVIRONMENT}" != "github-hosted" ]; then

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -3,10 +3,16 @@ name: Build Debian Packages
 # Packaging is a release artifact, not a PR gate: the full-source wheel
 # build costs ~45 min per run and its ENOSPC flakiness was blocking
 # unrelated PRs. Build on release tags or on demand (workflow_dispatch).
+#
+# FlagTree release tags are unprefixed (0.6.0, 0.6.0rc1); v-prefixed
+# tags stopped after v0.3.0. Backend-variant tags (0.6.0+mthreads3.6)
+# are filtered out at the job level — those releases are not the
+# nvidia package.
 on:
   push:
     tags:
-      - 'v*'
+      - '[0-9]*'
+      - 'v[0-9]*'
   workflow_dispatch:
 
 concurrency:
@@ -15,6 +21,8 @@ concurrency:
 
 jobs:
   build-deb:
+    # Skip backend-variant tags like 0.6.0+mthreads3.6.
+    if: ${{ github.event_name != 'push' || !contains(github.ref_name, '+') }}
     # WARNING: this builds the full FlagTree LLVM/MLIR wheel from source
     # (~36 min on a 4-core builder) and peaks well above 4 GB RAM. The
     # public `ubuntu-latest` runner (4 vCPU / ~16 GB RAM) is on the edge

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -26,8 +26,14 @@ jobs:
       # The wheel build peaks close to the standard runner's ~14 GB of
       # free disk (ENOSPC seen on the RPM twin of this workflow);
       # dropping unused preinstalled toolchains reclaims ~25-30 GB.
+      # Guarded to ephemeral GitHub-hosted VMs only, so a future move to
+      # a self-hosted runner can never wipe a real machine.
       - name: Free runner disk space
         run: |
+          if [ "${RUNNER_ENVIRONMENT}" != "github-hosted" ]; then
+            echo "Not a GitHub-hosted runner; skipping disk cleanup."
+            exit 0
+          fi
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
           df -h /

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -1,12 +1,18 @@
 name: Build Debian Packages
 
-# Release packaging only (no PR trigger). Release tags are unprefixed
-# since 0.3.0, e.g. 0.6.0 / 0.6.0rc1.
+# PRs trigger this only for packaging-file changes; source changes do
+# not (the full wheel build is too heavy for a general PR gate).
+# Release tags are unprefixed since 0.3.0, e.g. 0.6.0 / 0.6.0rc1.
 on:
   push:
     tags:
       - '[0-9]*'
       - 'v[0-9]*'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packaging/debian/**'
+      - '.github/workflows/build-deb.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -3,10 +3,16 @@ name: Build RPM Packages
 # Packaging is a release artifact, not a PR gate: the full-source wheel
 # build costs ~45 min x 2 runners and its ENOSPC flakiness was blocking
 # unrelated PRs. Build on release tags or on demand (workflow_dispatch).
+#
+# FlagTree release tags are unprefixed (0.6.0, 0.6.0rc1); v-prefixed
+# tags stopped after v0.3.0. Backend-variant tags (0.6.0+mthreads3.6)
+# are filtered out at the job level — '+' cannot appear in an RPM
+# Version and those releases are not the nvidia package.
 on:
   push:
     tags:
-      - 'v*'
+      - '[0-9]*'
+      - 'v[0-9]*'
   workflow_dispatch:
 
 concurrency:
@@ -15,6 +21,8 @@ concurrency:
 
 jobs:
   build-rpm:
+    # Skip backend-variant tags like 0.6.0+mthreads3.6.
+    if: ${{ github.event_name != 'push' || !contains(github.ref_name, '+') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -1,22 +1,17 @@
 name: Build RPM Packages
 
+# Packaging is a release artifact, not a PR gate: the full-source wheel
+# build costs ~45 min x 2 runners and its ENOSPC flakiness was blocking
+# unrelated PRs. Build on release tags or on demand (workflow_dispatch).
 on:
   push:
     tags:
       - 'v*'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'packaging/rpm/**'
-      - 'python/**'
-      - 'include/**'
-      - 'lib/**'
-      - 'cmake/**'
-      - 'bin/**'
-      - 'CMakeLists.txt'
-      - 'pyproject.toml'
-      - '.github/workflows/build-rpm.yml'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-rpm:
@@ -34,6 +29,15 @@ jobs:
             base_image: openeuler/openeuler:24.03-lts
             artifact: flagtree-nvidia-oe2403-rpm-packages
     steps:
+      # The wheel build peaks close to the standard runner's ~14 GB of
+      # free disk (ENOSPC seen in both matrix targets); dropping unused
+      # preinstalled toolchains reclaims ~25-30 GB.
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          df -h /
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -1,12 +1,18 @@
 name: Build RPM Packages
 
-# Release packaging only (no PR trigger). Release tags are unprefixed
-# since 0.3.0, e.g. 0.6.0 / 0.6.0rc1.
+# PRs trigger this only for packaging-file changes; source changes do
+# not (the full wheel build is too heavy for a general PR gate).
+# Release tags are unprefixed since 0.3.0, e.g. 0.6.0 / 0.6.0rc1.
 on:
   push:
     tags:
       - '[0-9]*'
       - 'v[0-9]*'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packaging/rpm/**'
+      - '.github/workflows/build-rpm.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -31,9 +31,15 @@ jobs:
     steps:
       # The wheel build peaks close to the standard runner's ~14 GB of
       # free disk (ENOSPC seen in both matrix targets); dropping unused
-      # preinstalled toolchains reclaims ~25-30 GB.
+      # preinstalled toolchains reclaims ~25-30 GB. Guarded to ephemeral
+      # GitHub-hosted VMs only, so a future move to a self-hosted runner
+      # can never wipe a real machine.
       - name: Free runner disk space
         run: |
+          if [ "${RUNNER_ENVIRONMENT}" != "github-hosted" ]; then
+            echo "Not a GitHub-hosted runner; skipping disk cleanup."
+            exit 0
+          fi
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
           df -h /

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -1,13 +1,7 @@
 name: Build RPM Packages
 
-# Packaging is a release artifact, not a PR gate: the full-source wheel
-# build costs ~45 min x 2 runners and its ENOSPC flakiness was blocking
-# unrelated PRs. Build on release tags or on demand (workflow_dispatch).
-#
-# FlagTree release tags are unprefixed (0.6.0, 0.6.0rc1); v-prefixed
-# tags stopped after v0.3.0. Backend-variant tags (0.6.0+mthreads3.6)
-# are filtered out at the job level — '+' cannot appear in an RPM
-# Version and those releases are not the nvidia package.
+# Release packaging only (no PR trigger). Release tags are unprefixed
+# since 0.3.0, e.g. 0.6.0 / 0.6.0rc1.
 on:
   push:
     tags:
@@ -37,11 +31,8 @@ jobs:
             base_image: openeuler/openeuler:24.03-lts
             artifact: flagtree-nvidia-oe2403-rpm-packages
     steps:
-      # The wheel build peaks close to the standard runner's ~14 GB of
-      # free disk (ENOSPC seen in both matrix targets); dropping unused
-      # preinstalled toolchains reclaims ~25-30 GB. Guarded to ephemeral
-      # GitHub-hosted VMs only, so a future move to a self-hosted runner
-      # can never wipe a real machine.
+      # The wheel build peaks near the runner's free-disk limit.
+      # Ephemeral GitHub-hosted VMs only — never a self-hosted machine.
       - name: Free runner disk space
         run: |
           if [ "${RUNNER_ENVIRONMENT}" != "github-hosted" ]; then

--- a/packaging/debian/build-helpers/Dockerfile.deb
+++ b/packaging/debian/build-helpers/Dockerfile.deb
@@ -110,6 +110,14 @@ RUN dpkg-buildpackage -us -uc -b && \
 # in the build log without failing the build.
 RUN lintian --info --display-info /python3-flagtree-*.deb || true
 
+# Smoke test: install the freshly built deb and import the package.
+# Catches the "installs fine, fails at import" class (missing libs,
+# bad rpath, glibc mismatch) that dpkg-buildpackage alone cannot see.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends /python3-flagtree-*.deb && \
+    python3 -c "import triton; print(getattr(triton, '__version__', 'import ok'))" && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # ---------- Stage 3: just the .deb output ----------
 FROM scratch AS deb-output
 COPY --from=deb-assembler /python3-flagtree-*.deb /output/

--- a/packaging/debian/build-helpers/Dockerfile.deb
+++ b/packaging/debian/build-helpers/Dockerfile.deb
@@ -72,11 +72,15 @@ COPY CMakeLists.txt pyproject.toml setup.py MANIFEST.in LICENSE README.md /src/
 # FLAGTREE_DEFAULT_BACKENDS=nvidia,amd matches the historical package
 # contents and keeps the tileir backend (GCC >= 13 + cuda-tile
 # submodule) out of the distro build.
+# The trailing rm keeps only /wheels in this layer: the CMake build
+# tree and the LLVM tarball cache (~/.triton) would otherwise add
+# several GB and push CI runners into ENOSPC.
 RUN unset FLAGTREE_BACKEND && \
     FLAGTREE_DEFAULT_BACKENDS=nvidia,amd \
     MAX_JOBS=4 python -m pip wheel . --no-build-isolation --no-deps -w /wheels -v && \
     ls -lh /wheels/ && \
-    test -n "$(ls /wheels/flagtree-*.whl 2>/dev/null)"
+    test -n "$(ls /wheels/flagtree-*.whl 2>/dev/null)" && \
+    rm -rf /src/build /root/.triton
 
 # ---------- Stage 2: assemble the .deb ----------
 FROM ${DEB_BASE_IMAGE} AS deb-assembler

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,9 @@
+flagtree (0.6.0-1) unstable; urgency=medium
+
+  * Sync package version with the flagtree wheel (0.6.0).
+
+ -- FlagOS Contributors <contact@flagos.io>  Wed, 15 Jul 2026 08:00:00 +0000
+
 flagtree (0.5.0-1) unstable; urgency=medium
 
   * Initial Debian packaging.

--- a/packaging/rpm/helpers/Dockerfile.rpm
+++ b/packaging/rpm/helpers/Dockerfile.rpm
@@ -86,6 +86,12 @@ RUN rpmbuild -ba /root/rpmbuild/SPECS/flagtree.spec \
         --define "wheel_dir /wheels" && \
     ls -lh /root/rpmbuild/RPMS/x86_64/
 
+# Smoke test: install the freshly built rpm and import the package.
+# Catches the "installs fine, fails at import" class (missing libs,
+# bad rpath, glibc mismatch) that rpmbuild alone cannot see.
+RUN dnf install -y /root/rpmbuild/RPMS/x86_64/python3-flagtree-*.x86_64.rpm && \
+    python3 -c "import triton; print(getattr(triton, '__version__', 'import ok'))"
+
 # ---------- Stage 3: extract just the rpms ----------
 FROM scratch AS rpm-output
 COPY --from=rpm-assembler /root/rpmbuild/RPMS/x86_64/python3-flagtree-*.rpm /output/

--- a/packaging/rpm/helpers/Dockerfile.rpm
+++ b/packaging/rpm/helpers/Dockerfile.rpm
@@ -44,11 +44,15 @@ COPY CMakeLists.txt pyproject.toml setup.py MANIFEST.in LICENSE README.md /src/
 # FLAGTREE_DEFAULT_BACKENDS=nvidia,amd matches the historical package
 # contents and keeps the tileir backend (GCC >= 13 + cuda-tile
 # submodule) out of the distro build.
+# The trailing rm keeps only /wheels in this layer: the CMake build
+# tree and the LLVM tarball cache (~/.triton) would otherwise add
+# several GB and push CI runners into ENOSPC.
 RUN unset FLAGTREE_BACKEND && \
     FLAGTREE_DEFAULT_BACKENDS=nvidia,amd \
     MAX_JOBS=4 python3 -m pip wheel . --no-build-isolation --no-deps -w /wheels -v && \
     ls -lh /wheels/ && \
-    test -n "$(ls /wheels/flagtree-*.whl 2>/dev/null)"
+    test -n "$(ls /wheels/flagtree-*.whl 2>/dev/null)" && \
+    rm -rf /src/build /root/.triton
 
 # ---------- Stage 2: assemble the .rpm ----------
 FROM ${RPM_BASE_IMAGE} AS rpm-assembler

--- a/packaging/rpm/specs/flagtree.spec
+++ b/packaging/rpm/specs/flagtree.spec
@@ -29,7 +29,7 @@
 %define __requires_exclude libcuda\\.so|libnvidia.*
 
 Name:           python3-flagtree-%{flagtree_backend}
-Version:        0.5.0
+Version:        0.6.0
 Release:        1%{?dist}
 Summary:        FlagTree compiler with %{flagtree_backend} backend
 License:        MIT AND Apache-2.0 WITH LLVM-exception AND BSD-3-Clause AND LicenseRef-NVIDIA-CUDA-EULA
@@ -102,6 +102,14 @@ if [ -z "$WHEEL" ]; then
     exit 1
 fi
 
+# Guard against Version drifting from the wheel again (0.5.0 rpms used
+# to ship a 0.6.0 wheel).
+WHEEL_VER=$(basename "$WHEEL" | cut -d- -f2)
+if [ "$WHEEL_VER" != "%{version}" ]; then
+    echo "ERROR: wheel version $WHEEL_VER != spec Version %{version}" >&2
+    exit 1
+fi
+
 PYDIR=%{buildroot}%{python3_sitearch}
 mkdir -p "$PYDIR" %{buildroot}%{_bindir}
 
@@ -134,6 +142,10 @@ install -D -m 0644 %{SOURCE0} %{buildroot}%{_licensedir}/%{name}/LICENSE
 %{_bindir}/proton*
 
 %changelog
+* Wed Jul 15 2026 FlagOS Contributors <contact@flagos.io> - 0.6.0-1
+- Sync package version with the flagtree wheel (0.6.0).
+- Fail the install step when the wheel version does not match the spec.
+
 * Mon Apr 27 2026 FlagOS Contributors <contact@flagos.io> - 0.5.0-1
 - Initial RPM packaging.
 - Package the %{flagtree_backend} backend variant.


### PR DESCRIPTION
Follow-up to #794. Fixes the packaging CI issues seen this week (two Build-RPM runs hit ENOSPC on 2026-07-15 and blocked unrelated PRs).

- **Narrow the PR trigger to packaging files** — the old `python/**`-wide filter ran the ~45-min build on unrelated PRs (e.g. an mthreads change building the nvidia package). PRs now trigger only on `packaging/**` / workflow-file changes; source-code coverage moves to release tags + `workflow_dispatch`.
- **Fix ENOSPC** — free ~25-30 GB of unused preinstalled toolchains before building (guarded to GitHub-hosted runners only), and drop the CMake build tree + LLVM cache from the wheel Docker layer.
- **Fix tag trigger** — `v*` never matched: release tags are unprefixed since 0.3.0 (`0.6.0`, `0.6.0rc1`). Match numeric tags and skip backend-variant tags (`0.6.0+mthreads3.6`) at the job level.
- **Sync package version** — spec/changelog said 0.5.0 while the wheel is 0.6.0; bump both and fail the rpm install step on future drift.

## Why ENOSPC: disk breakdown of one packaging job

`ubuntu-latest` runners have ~14-20 GB free (varies per machine — hence the flakiness). Peak usage per job:

| Segment | Size |
|---|---|
| Checkout + buildx context + base/toolchain/pip layers | ~2.5-3 GB |
| **Wheel-build layer (peak)**: LLVM download + extract (~3 GB), CMake tree with `libtriton.so` (~4-8 GB), setuptools' two full staging copies (~2-3 GB), wheel zip ×2 (365 MB each) | **~8-13 GB** |
| RPM assembly (buildroot unpacks the wheel) + output | ~2.5-3.5 GB |

Total peak ~13-18 GB rides exactly on the free-space line; both observed failures happened inside the wheel-build peak (fedora43 while zipping the wheel, openeuler2403 at final link). The cleanup step raises headroom past the peak; the in-layer `rm` stops the dead build tree from being carried through the assembly stage.