### PR TITLE
[BUILD] Check cache version instead of destination

### DIFF
--- a/.github/workflows/code-format-check.yml
+++ b/.github/workflows/code-format-check.yml
@@ -4,9 +4,9 @@ on:
   schedule:
     - cron: '0 21 * * *'
   push:
-    branches: [ "main", "triton_v3.2.x", "triton_v3.3.x", "triton_v3.4.x", "triton_v3.5.x"]
+    branches: [ "triton_v3.1.x", "triton_v3.2.x", "triton_v3.3.x", "triton_v3.4.x", "triton_v3.5.x"]
   pull_request:
-    branches: [ "main", "triton_v3.2.x", "triton_v3.3.x", "triton_v3.4.x", "triton_v3.5.x"]
+    branches: [ "triton_v3.1.x", "triton_v3.2.x", "triton_v3.3.x", "triton_v3.4.x", "triton_v3.5.x"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/nv3.3-build-and-test.yml
+++ b/.github/workflows/nv3.3-build-and-test.yml
@@ -4,9 +4,9 @@ on:
   schedule:
     - cron: '0 21 * * *'
   push:
-    branches: [ "main", "triton_v3.2.x", "triton_v3.3.x" ]
+    branches: [ "triton_v3.1.x", "triton_v3.2.x", "triton_v3.3.x" ]
   pull_request:
-    branches: [ "main", "triton_v3.2.x", "triton_v3.3.x" ]
+    branches: [ "triton_v3.1.x", "triton_v3.2.x", "triton_v3.3.x" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -46,8 +46,8 @@ jobs:
           echo "TARGET_BRANCH=$TARGET_BRANCH" >> $GITHUB_ENV
           echo "TARGET_BRANCH=$TARGET_BRANCH"
 
-      - name: FlagTree Build on NVidia (main branch)
-        if: ${{ steps.check_backend.outputs.should_skip != 'true' && env.TARGET_BRANCH == 'main' }}
+      - name: FlagTree Build on NVidia (triton_v3.1.x branch)
+        if: ${{ steps.check_backend.outputs.should_skip != 'true' && env.TARGET_BRANCH == 'triton_v3.1.x' }}
         shell: bash
         run: |
           set -x

--- a/python/setup.py
+++ b/python/setup.py
@@ -275,10 +275,14 @@ def download_and_copy(name, src_path, variable, version, url_func):
     dst_path = os.path.join(base_dir, os.pardir, "third_party", "nvidia", "backend", src_path)  # final binary path
     src_path = os.path.join(tmp_path, src_path)
     download = not os.path.exists(src_path)
-    if os.path.exists(dst_path) and system == "Linux" and shutil.which(dst_path) is not None:
-        curr_version = subprocess.check_output([dst_path, "--version"]).decode("utf-8").strip()
-        curr_version = re.search(r"V([.|\d]+)", curr_version).group(1)
-        download = download or curr_version != version
+    # flagtree: check the cached binary version in ~/.triton, skip download if it matches
+    if os.path.exists(src_path) and system == "Linux" and shutil.which(src_path) is not None:
+        try:
+            cache_version = subprocess.check_output([src_path, "--version"]).decode("utf-8").strip()
+            cache_version = re.search(r"V([.|\d]+)", cache_version).group(1)
+            download = download or cache_version != version
+        except Exception:
+            download = True
     if download and not helper.utils.OfflineBuildManager.is_offline_build():
         print(f'{YELLOW}downloading and extracting {url} ... {NC}', file=sys.stderr, flush=True)
         file = tarfile.open(fileobj=open_url(url), mode="r|*")


### PR DESCRIPTION
Check the cached binary version in ~/.triton rather than the already-installed binary in third_party/nvidia/backend/. This avoids unnecessary re-downloads when the cache is valid but the destination differs.

<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->
