### PR TITLE
[LICENSE] Remove license identifier from test_tle_distributed_d2d.py

### DIFF
--- a/python/test/tle/unit/test_tle_distributed_d2d.py
+++ b/python/test/tle/unit/test_tle_distributed_d2d.py
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-
 import os
 
 import torch


### PR DESCRIPTION
Remove SPDX license identifier from the test file.

<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->
