### PR TITLE
[CI] Reorganize PR labeler configuration

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -84,126 +84,108 @@ DOC:
 # or .github/workflows/{backend}* are modified.
 # ==========================================
 
-# Aipu
 aipu:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/aipu/**'
           - '.github/workflows/aipu*'
 
-# AMD
 amd:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/amd/**'
           - '.github/workflows/amd*'
 
-# Ascend
 ascend:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/ascend/**'
           - '.github/workflows/ascend*'
 
-# Cambricon
 cambricon:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/cambricon/**'
           - '.github/workflows/cambricon*'
 
-# CPU
 cpu:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/cpu/**'
           - '.github/workflows/cpu*'
 
-# Enflame
 enflame:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/enflame/**'
           - '.github/workflows/enflame*'
 
-# HCU
 hcu:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/hcu/**'
           - '.github/workflows/hcu*'
 
-# Iluvatar
 iluvatar:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/iluvatar/**'
           - '.github/workflows/iluvatar*'
 
-# Metax
 metax:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/metax/**'
           - '.github/workflows/metax*'
 
-# Mthreads
 mthreads:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/mthreads/**'
           - '.github/workflows/mthreads*'
 
-# NVIDIA
 nvidia:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/nvidia/**'
           - '.github/workflows/nv*'
 
-# RPU
 rpu:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/rpu/**'
           - '.github/workflows/rpu*'
 
-# Sunrise
 sunrise:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/sunrise/**'
           - '.github/workflows/sunrise*'
 
-# Thrive
 thrive:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/thrive/**'
           - '.github/workflows/thrive*'
 
-# TileIR
 tileir:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/tileir/**'
           - '.github/workflows/tileir*'
 
-# TLE ARM64
 tle_arm64:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/tle_arm64/**'
           - '.github/workflows/tle_arm64*'
 
-# Tsingmicro
 tsingmicro:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/tsingmicro/**'
           - '.github/workflows/tsingmicro*'
 
-# XPU
 xpu:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -30,7 +30,6 @@ CORE:
           - 'cmake/**'
           - 'include/**'
           - 'lib/**'
-          - 'packaging/**'
           - 'python/**'
           - 'scripts/**'
           - 'test/**'
@@ -39,6 +38,11 @@ CORE:
           - 'third_party/proton/**'
           - 'third_party/tle/**'
           - 'third_party/f2reduce/**'
+          - 'CMakeLists.txt'
+          - 'Makefile'
+          - 'MANIFEST.in'
+          - 'pyproject.toml'
+          - 'setup.py'
 
 # ==========================================
 # 2. CI/CD Labels
@@ -48,8 +52,13 @@ CORE:
 CI/CD:
   - changed-files:
       - any-glob-to-any-file:
-          - '.github/workflows/**'
           - '.github/actions/**'
+          - '.github/workflows/**'
+          - '.github/CODEOWNERS'
+          - '.github/dependabot.yml'
+          - '.github/new-prs-labeler.yml'
+          - '.github/PULL_REQUEST_TEMPLATE.md'
+          - 'packaging/**'
 
 # ==========================================
 # 3. Documentation Labels (DOC)
@@ -67,7 +76,7 @@ DOC:
           - '**/*.jpeg'
           - '**/*.gif'
           - '**/*.ico'
-          - '**/CODEOWNERS'
+          - 'LICENSE'
 
 # ==========================================
 # 4. Backend Labels

--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -79,7 +79,22 @@ DOC:
           - 'LICENSE'
 
 # ==========================================
-# 4. Backend Labels
+# 4. Git Configuration Labels (GIT)
+# Applied if Git-related configuration files are modified.
+# ==========================================
+GIT:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.clang-format'
+          - '.dockerignore'
+          - '.editorconfig'
+          - '.gitattributes'
+          - '.git-blame-ignore-revs'
+          - '.gitignore'
+          - '.pre-commit-config.yaml'
+
+# ==========================================
+# 5. Backend Labels
 # Rule: Applied if files under third_party/{backend}
 # or .github/workflows/{backend}* are modified.
 # ==========================================

--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -18,126 +18,185 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# Labels applied to PRs based on the files changed.
-# Backend labels are set when any file under the backend's third_party/ directory changes.
-# The DOC label is set when every changed file is a documentation file
-# (matches the same "docs-only" definition used by check-docs-only action:
-#  *.md / *.yml / *.txt / CODEOWNERS, but NOT CMakeLists.txt).
+# ==========================================
+# 1. Core File Labels (CORE)
+# Includes core framework code and specific
+# third-party core libraries.
+# ==========================================
+CORE:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'bin/**'
+          - 'cmake/**'
+          - 'include/**'
+          - 'lib/**'
+          - 'packaging/**'
+          - 'python/**'
+          - 'scripts/**'
+          - 'test/**'
+          - 'unittest/**'
+          - 'utils/**'
+          - 'third_party/proton/**'
+          - 'third_party/tle/**'
+          - 'third_party/f2reduce/**'
 
-# ---- Backend labels ----
+# ==========================================
+# 2. CI/CD Labels
+# Applied if any file under .github/workflows
+# or .github/actions is modified.
+# ==========================================
+CI/CD:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+          - '.github/actions/**'
 
+# ==========================================
+# 3. Documentation Labels (DOC)
+# Applied if the PR contains modifications to
+# any of the following file types.
+# ==========================================
+DOC:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - '**/*.txt'
+          - '**/*.rst'
+          - '**/*.png'
+          - '**/*.jpg'
+          - '**/*.jpeg'
+          - '**/*.gif'
+          - '**/*.ico'
+          - '**/CODEOWNERS'
+
+# ==========================================
+# 4. Backend Labels
+# Rule: Applied if files under third_party/{backend}
+# or .github/workflows/{backend}* are modified.
+# ==========================================
+
+# Aipu
 aipu:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/aipu/**'
+          - '.github/workflows/aipu*'
 
+# AMD
 amd:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/amd/**'
+          - '.github/workflows/amd*'
 
+# Ascend
 ascend:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/ascend/**'
+          - '.github/workflows/ascend*'
 
+# Cambricon
 cambricon:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/cambricon/**'
+          - '.github/workflows/cambricon*'
 
+# CPU
+cpu:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'third_party/cpu/**'
+          - '.github/workflows/cpu*'
+
+# Enflame
 enflame:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/enflame/**'
+          - '.github/workflows/enflame*'
 
-f2reduce:
-  - changed-files:
-      - any-glob-to-any-file:
-          - 'third_party/f2reduce/**'
-
+# HCU
 hcu:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/hcu/**'
+          - '.github/workflows/hcu*'
 
+# Iluvatar
 iluvatar:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/iluvatar/**'
+          - '.github/workflows/iluvatar*'
 
+# Metax
 metax:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/metax/**'
+          - '.github/workflows/metax*'
 
+# Mthreads
 mthreads:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/mthreads/**'
+          - '.github/workflows/mthreads*'
 
+# NVIDIA
 nvidia:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/nvidia/**'
+          - '.github/workflows/nv*'
 
-proton:
-  - changed-files:
-      - any-glob-to-any-file:
-          - 'third_party/proton/**'
-
+# RPU
 rpu:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/rpu/**'
+          - '.github/workflows/rpu*'
 
+# Sunrise
 sunrise:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/sunrise/**'
+          - '.github/workflows/sunrise*'
 
+# Thrive
 thrive:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/thrive/**'
+          - '.github/workflows/thrive*'
 
-tle:
-  - changed-files:
-      - any-glob-to-any-file:
-          - 'third_party/tle/**'
-
+# TileIR
 tileir:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/tileir/**'
+          - '.github/workflows/tileir*'
 
+# TLE ARM64
+tle_arm64:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'third_party/tle_arm64/**'
+          - '.github/workflows/tle_arm64*'
+
+# Tsingmicro
 tsingmicro:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/tsingmicro/**'
+          - '.github/workflows/tsingmicro*'
 
+# XPU
 xpu:
   - changed-files:
       - any-glob-to-any-file:
           - 'third_party/xpu/**'
-
-
-# ---- DOC label ----
-# This label is applied ONLY when the PR consists exclusively of documentation.
-# It uses a strict inclusion list combined with an explicit exclusion of build files
-# to ensure no functional code changes are mislabeled as "DOC".
-
-DOC:
-  - all:
-      # Condition A: All must be document file extensions
-      - changed-files:
-          - any-glob-to-all-files:
-              - '**/*.md'
-              - '**/*.yml'
-              - '**/*.txt'
-              - '**/CODEOWNERS'
-
-      # Condition B: Must not contain CMakeLists.txt
-      - changed-files:
-          - all-globs-to-all-files:
-              - '!**/CMakeLists.txt'
+          - '.github/workflows/xpu*'


### PR DESCRIPTION
- Group labels into logical categories: CORE, CI/CD, DOC, Backend
- Add CI/CD workflow file patterns for all backend labels
- Remove proton, tle, f2reduce from backend labels (they are core libraries)
- Sort backend labels alphabetically for better maintainability
- Update DOC label to use simpler file extension matching

<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->
