### PR TITLE
[CI] Mark global CI/CD infrastructure as CORE

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -43,6 +43,8 @@ CORE:
           - 'MANIFEST.in'
           - 'pyproject.toml'
           - 'setup.py'
+          - '.github/actions/**'
+          - '.github/workflows/code-format-check.yml'
 
 # ==========================================
 # 2. CI/CD Labels


### PR DESCRIPTION
Add .github/actions/** and .github/workflows/code-format-check.yml to CORE label as they have global impact on the project. These files will now receive both CORE and CI/CD labels.

<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->
