### PR TITLE
[CI] Refine CI test trigger conditions

### DIFF
--- a/.github/actions/check-backend-changed/action.yml
+++ b/.github/actions/check-backend-changed/action.yml
@@ -61,46 +61,86 @@ runs:
           fi
         fi
 
+        NEED_CI_TEST=(
+          "bin"
+          "cmake"
+          "include"
+          "lib"
+          "python"
+          "scripts"
+          "test"
+          "unittest"
+          "utils"
+          "third_party/proton"
+          "third_party/tle"
+          "third_party/f2reduce"
+          "CMakeLists.txt"
+          "Makefile"
+          "MANIFEST.in"
+          "pyproject.toml"
+          "setup.py"
+          ".github/actions"
+          ".github/workflows/code-format-check.yml"
+        )
+
+        # ============================================================
+        # Function: Check if file should trigger CI test
+        # ============================================================
+        need_ci_test() {
+          local file="$1"
+          for item in "${NEED_CI_TEST[@]}"; do
+            # Check if it's a directory (ends with / or no extension)
+            # or check if file matches exactly or is under the directory
+            if [[ "$file" == "$item" ]] || [[ "$file" == "$item/"* ]]; then
+              return 0
+            fi
+          done
+          return 1
+        }
+
+
+        # ================================================================
+        # MAIN LOGIC: Determine whether to run CI
+        # ================================================================
+        # CI will run if ANY changed file matches one of these three rules:
+        #   1. The current workflow file itself
+        #   2. The NEED_CI_TEST white list above
+        #   3. third_party/${BACKEND}/ directory
+        #
+        # Otherwise, CI will be skipped.
+        # ================================================================
         SHOULD_SKIP=true
-        # If no changes were made, we need to run the CI process to avoid any misjudgments.
-        if [ -z "$FILES" ]; then
-          echo "No files changed, running CI by default"
-          SHOULD_SKIP=false
-        else
-          while IFS= read -r file; do
-            # Skip empty lines
-            if [ -z "$file" ]; then
-              continue
-            fi
-            # Current workflow file changed → always run
-            if [[ "$file" == "$CURRENT_WORKFLOW" ]]; then
-              echo "'$file' -> This workflow file changed, need to run"
+
+        while IFS= read -r file; do
+          # Skip empty lines
+          if [ -z "$file" ]; then
+            continue
+          fi
+
+          # Current workflow file changed → always run
+          if [[ "$file" == "$CURRENT_WORKFLOW" ]]; then
+            echo "'$file' -> This workflow file changed, need to run"
+            SHOULD_SKIP=false
+            break
+          fi
+
+          # Files/directories in NEED_CI_TEST → run CI
+          if need_ci_test "$file"; then
+            echo "'$file' -> In NEED_CI_TEST list, need to run"
+            SHOULD_SKIP=false
+            break
+          fi
+
+          # It is a code file. Check whether it lives inside third_party/
+          if [[ "$file" == third_party/* ]]; then
+            if [[ "$file" == third_party/${BACKEND}/* ]]; then
+              echo "'$file' -> Backend '$BACKEND' file changed, need to run"
               SHOULD_SKIP=false
               break
             fi
-            # Check if the file is a documentation file (same logic as check-docs-only)
-            if [[ ! "$file" =~ CMakeLists\.txt$ ]] && [[ "$file" =~ (\.(md|yml|txt|png|jpg|jpeg|gif|svg|ico|webp)$|CODEOWNERS$) ]]; then
-              echo "'$file' -> Doc file, not relevant to CI decision"
-              continue
-            fi
-            # It is a code file. Check whether it lives inside third_party/
-            if [[ "$file" == third_party/* ]]; then
-              if [[ "$file" == third_party/${BACKEND}/* ]]; then
-                echo "'$file' -> Backend '$BACKEND' file changed, need to run"
-                SHOULD_SKIP=false
-                break
-              else
-                echo "'$file' -> Other backend file, not relevant to '$BACKEND'"
-                continue
-              fi
-            else
-              # Core code file (outside third_party/) — affects all backends
-              echo "'$file' -> Core code file changed, need to run"
-              SHOULD_SKIP=false
-              break
-            fi
-          done <<< "$FILES"
-        fi
+          fi
+        done <<< "$FILES"
+
         echo "should_skip=$SHOULD_SKIP" >> $GITHUB_OUTPUT
         if [ "$SHOULD_SKIP" == "true" ]; then
           echo "✅ No relevant files changed for backend '$BACKEND'. Will skip CI."

--- a/.github/actions/check-backend-changed/action.yml
+++ b/.github/actions/check-backend-changed/action.yml
@@ -108,12 +108,21 @@ runs:
         #   3. third_party/${BACKEND}/ directory
         #
         # Otherwise, CI will be skipped.
+        #
+        # Documentation files (markdown, images, text files, etc.) are automatically
+        # skipped and do NOT trigger CI, unless they are CMakeLists.txt.
         # ================================================================
         SHOULD_SKIP=true
 
         while IFS= read -r file; do
           # Skip empty lines
           if [ -z "$file" ]; then
+            continue
+          fi
+
+          # Skip documentation files
+          if [[ ! "$file" =~ CMakeLists\.txt$ ]] && [[ "$file" =~ (\.(md|txt|png|jpg|jpeg|gif|svg|ico|webp)$|CODEOWNERS$) ]]; then
+            echo "'$file' -> Doc file, not relevant to CI decision"
             continue
           fi
 

--- a/.github/actions/check-backend-changed/action.yml
+++ b/.github/actions/check-backend-changed/action.yml
@@ -46,7 +46,9 @@ runs:
 
         # Check if the workflow is triggered by a Pull Request event
         if [ "${{ github.event_name }}" == "pull_request" ]; then
-          FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }})
+          # Use three-dot syntax to compare the merge base (common ancestor) with the HEAD commit
+          # This ensures we only detect files changed in this PR, excluding changes already merged to base branch
+          FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.sha }})
         else
           # Handle 'push' events (or other events where 'base_ref' isn't applicable)
           # Check if the 'before' SHA is all zeros, which indicates a newly created/pushed branch


### PR DESCRIPTION
Replace file filtering with explicit NEED_CI_TEST white list CI triggers only for: workflow itself, white-listed files/dirs, or backend-specific changes.

<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->
