### PR TITLE
[TLE] Fix compilation with gcc7/gcc8

### DIFF
--- a/third_party/tle/dialect/lib/Conversion/TleToLLVM/DSLRegionOpToLLVM.cpp
+++ b/third_party/tle/dialect/lib/Conversion/TleToLLVM/DSLRegionOpToLLVM.cpp
@@ -33,7 +33,7 @@
 
 namespace {
 using namespace mlir;
-namespace tle = mlir::triton::tle;
+using namespace mlir::triton;
 
 struct DSLRegionOpConversion : public ConvertOpToLLVMPattern<tle::DSLRegionOp> {
   DSLRegionOpConversion(LLVMTypeConverter &typeConverter,

--- a/third_party/tle/dialect/lib/Conversion/TleToLLVM/DistributedBarrierOpToLLVM.cpp
+++ b/third_party/tle/dialect/lib/Conversion/TleToLLVM/DistributedBarrierOpToLLVM.cpp
@@ -40,7 +40,7 @@
 namespace {
 
 using namespace mlir;
-namespace tle = mlir::triton::tle;
+using namespace mlir::triton;
 
 constexpr llvm::StringLiteral kSpaceAttr = "space";
 constexpr llvm::StringLiteral kOrderAttr = "order";

--- a/third_party/tle/dialect/lib/Conversion/TleToLLVM/ExclusiveCumsumOpToLLVM.cpp
+++ b/third_party/tle/dialect/lib/Conversion/TleToLLVM/ExclusiveCumsumOpToLLVM.cpp
@@ -39,7 +39,7 @@
 namespace {
 
 using namespace mlir;
-namespace tle = mlir::triton::tle;
+using namespace mlir::triton;
 
 static Value createZeroConstant(Location loc,
                                 ConversionPatternRewriter &rewriter, Type ty) {

--- a/third_party/tle/dialect/lib/Conversion/TleToLLVM/ExtractOpToLLVM.cpp
+++ b/third_party/tle/dialect/lib/Conversion/TleToLLVM/ExtractOpToLLVM.cpp
@@ -38,7 +38,7 @@ namespace {
 
 using namespace mlir;
 namespace ttg = mlir::triton::gpu;
-namespace tle = mlir::triton::tle;
+using namespace mlir::triton;
 
 struct ExtractAllocatedPtrOpConversion
     : public ConvertOpToLLVMPattern<tle::ExtractAllocatedPtrOp> {

--- a/third_party/tle/dialect/lib/Conversion/TleToLLVM/FlagCxOpToLLVM/DeviceIntraBarrierOpToLLVM.cpp
+++ b/third_party/tle/dialect/lib/Conversion/TleToLLVM/FlagCxOpToLLVM/DeviceIntraBarrierOpToLLVM.cpp
@@ -41,7 +41,7 @@
 namespace {
 using namespace mlir;
 namespace ttg = mlir::triton::gpu;
-namespace tle = mlir::triton::tle;
+using namespace mlir::triton;
 
 struct DeviceIntraBarrierOpConversion
     : public ConvertOpToLLVMPattern<tle::DeviceIntraBarrierOp> {

--- a/third_party/tle/dialect/lib/Conversion/TleToLLVM/FlagCxOpToLLVM/GetLocalRankOpToLLVM.cpp
+++ b/third_party/tle/dialect/lib/Conversion/TleToLLVM/FlagCxOpToLLVM/GetLocalRankOpToLLVM.cpp
@@ -41,7 +41,7 @@
 namespace {
 using namespace mlir;
 namespace ttg = mlir::triton::gpu;
-namespace tle = mlir::triton::tle;
+using namespace mlir::triton;
 
 struct GetNumPesOpConversion : public ConvertOpToLLVMPattern<tle::GetNumPesOp> {
   GetNumPesOpConversion(LLVMTypeConverter &typeConverter,

--- a/third_party/tle/dialect/lib/Conversion/TleToLLVM/GetDeviceIdToFlagCX.cpp
+++ b/third_party/tle/dialect/lib/Conversion/TleToLLVM/GetDeviceIdToFlagCX.cpp
@@ -41,7 +41,7 @@
 namespace {
 using namespace mlir;
 namespace ttg = mlir::triton::gpu;
-namespace tle = mlir::triton::tle;
+using namespace mlir::triton;
 
 Value getDistDevicePtr(tle::GetDeviceIdOp op, SmallVector<Value> &srcElems) {
   if (!srcElems.empty())

--- a/third_party/tle/dialect/lib/Conversion/TleToLLVM/LocalPointersOpToLLVM.cpp
+++ b/third_party/tle/dialect/lib/Conversion/TleToLLVM/LocalPointersOpToLLVM.cpp
@@ -43,7 +43,7 @@ namespace {
 
 using namespace mlir;
 namespace ttg = mlir::triton::gpu;
-namespace tle = mlir::triton::tle;
+using namespace mlir::triton;
 
 // Extract pointee type from tle.remote_pointers result type.
 static Type getRemotePointeeType(Type resultTy) {

--- a/third_party/tle/dialect/lib/Conversion/TleToLLVM/PackOpToLLVM.cpp
+++ b/third_party/tle/dialect/lib/Conversion/TleToLLVM/PackOpToLLVM.cpp
@@ -33,7 +33,7 @@ namespace {
 
 using namespace mlir;
 namespace ttg = mlir::triton::gpu;
-namespace tle = mlir::triton::tle;
+using namespace mlir::triton;
 
 struct PackOpConversion : public ConvertOpToLLVMPattern<tle::PackOp> {
   PackOpConversion(LLVMTypeConverter &typeConverter, PatternBenefit benefit);

--- a/third_party/tle/dialect/lib/Conversion/TleToLLVM/TMAStoreCommitGroupOpToLLVM.cpp
+++ b/third_party/tle/dialect/lib/Conversion/TleToLLVM/TMAStoreCommitGroupOpToLLVM.cpp
@@ -27,7 +27,7 @@
 #include "tle/dialect/include/Transforms/PatternTleToLLVM.h"
 
 using namespace mlir;
-namespace tle = mlir::triton::tle;
+using namespace mlir::triton;
 
 namespace {
 

--- a/third_party/tle/dialect/lib/Transforms/TleMaterializeTileStylePipeline.cpp
+++ b/third_party/tle/dialect/lib/Transforms/TleMaterializeTileStylePipeline.cpp
@@ -414,9 +414,11 @@ static TileStyleLoopAnalysis analyzeTileStyleLoop(scf::ForOp forOp) {
       llvm::SmallDenseSet<Operation *, 8> visited;
       if (!hasDotLikeConsumer(allocOp.getResult(), body, visited))
         continue;
-      analysis.asyncTileProducers.push_back({.baseMemDesc = allocOp.getResult(),
-                                             .loadOp = loadOp,
-                                             .allocOp = allocOp});
+      AsyncTileProducerGroup group;
+      group.baseMemDesc = allocOp.getResult();
+      group.loadOp = loadOp;
+      group.allocOp = allocOp;
+      analysis.asyncTileProducers.push_back(std::move(group));
       continue;
     }
 
@@ -437,8 +439,10 @@ static TileStyleLoopAnalysis analyzeTileStyleLoop(scf::ForOp forOp) {
   }
 
   for (auto &it : directAsyncFamilies) {
-    analysis.asyncTileProducers.push_back(
-        {.baseMemDesc = it.first, .asyncCopyOps = it.second});
+    AsyncTileProducerGroup group;
+    group.baseMemDesc = it.first;
+    group.asyncCopyOps = it.second;
+    analysis.asyncTileProducers.push_back(group);
   }
   return analysis;
 }


### PR DESCRIPTION
[TLE] Fix compilation with gcc7/gcc8

- Replace `namespace tle = mlir::triton::tle;` with
  `using namespace mlir::triton;` in anonymous namespaces.
  gcc7 cannot correctly resolve types via namespace alias
  within anonymous namespaces for template/pattern matching.

- Replace C99 designated initializers with explicit struct
  member assignment in TleMaterializeTileStylePipeline.cpp.
  Designated initializers are not supported in C++ by gcc7/gcc8.