### PR TITLE
[KMCompiler][TLERaw] Fix incorrect injection of NVSHMEM cumodule_hook

### DIFF
--- a/python/triton/experimental/tle/language/raw/core.py
+++ b/python/triton/experimental/tle/language/raw/core.py
@@ -60,15 +60,10 @@ def _normalize_hint(hint):
     return str(hint) if hint else ""
 
 
-def _tle_raw_call(func, args, *, output_indices, hint, smem, _semantic):
-    install_runtime_hook = getattr(
-        func,
-        "install_runtime_hook",
-        None,
-    )
-    if install_runtime_hook is not None:
-        install_runtime_hook()
-
+def _tle_raw_call(func, args, *, output_indices, hint, smem, _semantic, _generator):
+    mark_kernel_init_hook = getattr(func, "mark_kernel_init_hook", None)
+    if mark_kernel_init_hook is not None:
+        mark_kernel_init_hook(_semantic, _generator)
     hint = _normalize_hint(hint)
     handles = [arg.handle for arg in args]
     if getattr(func, "deferred", False):
@@ -88,10 +83,12 @@ def _tle_raw_call(func, args, *, output_indices, hint, smem, _semantic):
 
 
 @builtin
-def call(func, args, output_indices=None, hint="", _semantic=None):
-    return _tle_raw_call(func, args, output_indices=output_indices, hint=hint, smem=False, _semantic=_semantic)
+def call(func, args, output_indices=None, hint="", _semantic=None, _generator=None):
+    return _tle_raw_call(func, args, output_indices=output_indices, hint=hint, smem=False, _semantic=_semantic,
+                         _generator=_generator)
 
 
 @builtin
-def call_smem(func, args, output_indices=None, hint="", _semantic=None):
-    return _tle_raw_call(func, args, output_indices=output_indices, hint=hint, smem=True, _semantic=_semantic)
+def call_smem(func, args, output_indices=None, hint="", _semantic=None, _generator=None):
+    return _tle_raw_call(func, args, output_indices=output_indices, hint=hint, smem=True, _semantic=_semantic,
+                         _generator=_generator)

--- a/python/triton/experimental/tle/language/raw/core.py
+++ b/python/triton/experimental/tle/language/raw/core.py
@@ -61,6 +61,14 @@ def _normalize_hint(hint):
 
 
 def _tle_raw_call(func, args, *, output_indices, hint, smem, _semantic):
+    install_runtime_hook = getattr(
+        func,
+        "install_runtime_hook",
+        None,
+    )
+    if install_runtime_hook is not None:
+        install_runtime_hook()
+
     hint = _normalize_hint(hint)
     handles = [arg.handle for arg in args]
     if getattr(func, "deferred", False):

--- a/python/triton/experimental/tle/raw/cuda/runtime.py
+++ b/python/triton/experimental/tle/raw/cuda/runtime.py
@@ -37,6 +37,7 @@ from triton._C.libtriton import llvm  # pyright: ignore[reportMissingImports]
 from triton._C.libtriton.tle.llvm import parse_llvm_ir  # pyright: ignore[reportMissingImports]
 from triton.experimental.tle.raw.runtime import RawJITFunction
 from triton.experimental.tle.raw.source_store import register_source
+from triton.runtime.jit import register_kernel_init_hook
 
 # TODO: Temporarily shell out to clang; replace with LLVM Python bindings later.
 _MIN_CLANG_MAJOR = 20
@@ -175,8 +176,9 @@ def _sanitize_clang_ir(ir: str) -> str:
 # NVSHMEM: post-compile cumodule init hook
 # ---------------------------------------------------------------------------
 
-_cumodule_hook_installed = False
 _nvshmemx_cumodule_init = None
+_KERNEL_INIT_HOOK_ATTR = "tle.raw.kernel_init_hooks"
+_NVSHMEM_CUMODULE_INIT_HOOK = "nvshmem_cumodule_init"
 
 
 def _get_nvshmemx_cumodule_init():
@@ -196,24 +198,13 @@ def _get_nvshmemx_cumodule_init():
     return fn
 
 
-def _install_cumodule_hook():
-    global _cumodule_hook_installed
-    if _cumodule_hook_installed:
-        return
+def _initialize_nvshmem_cumodule(kernel):
+    kernel._init_handles()
+    result = _get_nvshmemx_cumodule_init()(ctypes.c_void_p(kernel.module))
+    assert result == 0, f"nvshmemx_cumodule_init failed: {result}"
 
-    def hook(*args, **kwargs):
-        key = kwargs["key"]
-        function = kwargs["fn"].jit_function
-        device = kwargs["compile"]["device"]
-        kernel = function.device_caches[device][0].get(key)
-        assert kernel is not None
-        kernel._init_handles()
-        result = _get_nvshmemx_cumodule_init()(ctypes.c_void_p(kernel.module))
-        assert result == 0, f"nvshmemx_cumodule_init failed: {result}"
 
-    knobs.runtime.jit_post_compile_hook = hook
-    _cumodule_hook_installed = True
-
+register_kernel_init_hook(_NVSHMEM_CUMODULE_INIT_HOOK, _initialize_nvshmem_cumodule)
 
 # ---------------------------------------------------------------------------
 # Dialect runtime
@@ -234,9 +225,16 @@ class CUDAJITFunction(RawJITFunction):
             from triton.experimental.tle.raw.nvshmem.utils import enable_nvshmem_device_bc
             enable_nvshmem_device_bc(True)
 
-    def install_runtime_hook(self) -> None:
+    def mark_kernel_init_hook(self, semantic, generator) -> None:
         if self.library == "nvshmem" and "nvshmem" in self.code:
-            _install_cumodule_hook()
+            operation = generator.module.get_operation()
+            hooks = operation.get_str_attr(_KERNEL_INIT_HOOK_ATTR)
+            hook_names = set(hooks.split(",")) if hooks else set()
+            hook_names.add(_NVSHMEM_CUMODULE_INIT_HOOK)
+            generator.module.set_attr(
+                _KERNEL_INIT_HOOK_ATTR,
+                semantic.builder.get_string_attr(",".join(sorted(hook_names))),
+            )
 
     def register_pending_source(self, *, hint: str = "") -> str:
         if not self.extern_func_name:

--- a/python/triton/experimental/tle/raw/cuda/runtime.py
+++ b/python/triton/experimental/tle/raw/cuda/runtime.py
@@ -29,7 +29,7 @@ import shutil
 import struct
 import subprocess
 from pathlib import Path
-from typing import Any, Final
+from typing import Any, Final, Callable
 
 import torch
 from triton import knobs
@@ -37,7 +37,6 @@ from triton._C.libtriton import llvm  # pyright: ignore[reportMissingImports]
 from triton._C.libtriton.tle.llvm import parse_llvm_ir  # pyright: ignore[reportMissingImports]
 from triton.experimental.tle.raw.runtime import RawJITFunction
 from triton.experimental.tle.raw.source_store import register_source
-from triton.runtime.jit import register_kernel_init_hook
 
 # TODO: Temporarily shell out to clang; replace with LLVM Python bindings later.
 _MIN_CLANG_MAJOR = 20
@@ -177,6 +176,7 @@ def _sanitize_clang_ir(ir: str) -> str:
 # ---------------------------------------------------------------------------
 
 _nvshmemx_cumodule_init = None
+_KERNEL_INIT_HOOKS: dict[str, Callable] = {}
 _KERNEL_INIT_HOOK_ATTR = "tle.raw.kernel_init_hooks"
 _NVSHMEM_CUMODULE_INIT_HOOK = "nvshmem_cumodule_init"
 
@@ -204,6 +204,20 @@ def _initialize_nvshmem_cumodule(kernel):
     assert result == 0, f"nvshmemx_cumodule_init failed: {result}"
 
 
+def register_kernel_init_hook(name: str, hook: Callable) -> None:
+    if name in _KERNEL_INIT_HOOKS:
+        raise RuntimeError(f"kernel init hook {name!r} is already registered")
+    _KERNEL_INIT_HOOKS[name] = hook
+
+
+def run_kernel_init_hooks(kernel) -> None:
+    for name in getattr(kernel.metadata, "kernel_init_hooks", ()):
+        hook = _KERNEL_INIT_HOOKS.get(name)
+        if hook is None:
+            raise RuntimeError(f"kernel init hook {name!r} is not registered")
+        hook(kernel)
+
+
 register_kernel_init_hook(_NVSHMEM_CUMODULE_INIT_HOOK, _initialize_nvshmem_cumodule)
 
 # ---------------------------------------------------------------------------
@@ -226,7 +240,7 @@ class CUDAJITFunction(RawJITFunction):
             enable_nvshmem_device_bc(True)
 
     def mark_kernel_init_hook(self, semantic, generator) -> None:
-        if self.library == "nvshmem" and "nvshmem" in self.code:
+        if self.library == "nvshmem":
             operation = generator.module.get_operation()
             hooks = operation.get_str_attr(_KERNEL_INIT_HOOK_ATTR)
             hook_names = set(hooks.split(",")) if hooks else set()

--- a/python/triton/experimental/tle/raw/cuda/runtime.py
+++ b/python/triton/experimental/tle/raw/cuda/runtime.py
@@ -233,7 +233,9 @@ class CUDAJITFunction(RawJITFunction):
         if self.library == "nvshmem":
             from triton.experimental.tle.raw.nvshmem.utils import enable_nvshmem_device_bc
             enable_nvshmem_device_bc(True)
-        if self.library == "nvshmem" or "nvshmem" in self.code:
+
+    def install_runtime_hook(self) -> None:
+        if self.library == "nvshmem" and "nvshmem" in self.code:
             _install_cumodule_hook()
 
     def register_pending_source(self, *, hint: str = "") -> str:

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -601,6 +601,23 @@ class JitFunctionInfo:
     jit_function: JITFunction
 
 
+_KERNEL_INIT_HOOKS: Dict[str, Callable] = {}
+
+
+def register_kernel_init_hook(name: str, hook: Callable) -> None:
+    if name in _KERNEL_INIT_HOOKS:
+        raise RuntimeError(f"kernel init hook {name!r} is already registered")
+    _KERNEL_INIT_HOOKS[name] = hook
+
+
+def _run_kernel_init_hooks(kernel) -> None:
+    for name in getattr(kernel.metadata, "kernel_init_hooks", ()):
+        hook = _KERNEL_INIT_HOOKS.get(name)
+        if hook is None:
+            raise RuntimeError(f"kernel init hook {name!r} is not registered")
+        hook(kernel)
+
+
 def compute_cache_key(kernel_key_cache, specialization, options):
     key = (tuple(specialization), str(options))
     cache_key = kernel_key_cache.get(key, None)
@@ -891,6 +908,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
 
             def finalize_compile(kernel):
                 kernel_cache[key] = kernel
+                _run_kernel_init_hooks(kernel)
                 self._call_hook(knobs.runtime.jit_post_compile_hook, key, signature, device, constexprs, options,
                                 [attrs], warmup)
 
@@ -898,6 +916,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
         else:
             kernel = self.compile(src, target=target, options=options.__dict__)
             kernel_cache[key] = kernel
+            _run_kernel_init_hooks(kernel)
             self._call_hook(knobs.runtime.jit_post_compile_hook, key, signature, device, constexprs, options, [attrs],
                             warmup)
         return kernel

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -601,23 +601,6 @@ class JitFunctionInfo:
     jit_function: JITFunction
 
 
-_KERNEL_INIT_HOOKS: Dict[str, Callable] = {}
-
-
-def register_kernel_init_hook(name: str, hook: Callable) -> None:
-    if name in _KERNEL_INIT_HOOKS:
-        raise RuntimeError(f"kernel init hook {name!r} is already registered")
-    _KERNEL_INIT_HOOKS[name] = hook
-
-
-def _run_kernel_init_hooks(kernel) -> None:
-    for name in getattr(kernel.metadata, "kernel_init_hooks", ()):
-        hook = _KERNEL_INIT_HOOKS.get(name)
-        if hook is None:
-            raise RuntimeError(f"kernel init hook {name!r} is not registered")
-        hook(kernel)
-
-
 def compute_cache_key(kernel_key_cache, specialization, options):
     key = (tuple(specialization), str(options))
     cache_key = kernel_key_cache.get(key, None)
@@ -908,7 +891,13 @@ class JITFunction(JITCallable, KernelInterface[T]):
 
             def finalize_compile(kernel):
                 kernel_cache[key] = kernel
-                _run_kernel_init_hooks(kernel)
+                # flagtree tle raw
+                try:
+                    from triton.experimental.tle.raw.cuda.runtime import run_kernel_init_hooks
+                except ImportError:
+                    pass
+                else:
+                    run_kernel_init_hooks(kernel)
                 self._call_hook(knobs.runtime.jit_post_compile_hook, key, signature, device, constexprs, options,
                                 [attrs], warmup)
 
@@ -916,7 +905,13 @@ class JITFunction(JITCallable, KernelInterface[T]):
         else:
             kernel = self.compile(src, target=target, options=options.__dict__)
             kernel_cache[key] = kernel
-            _run_kernel_init_hooks(kernel)
+            # flagtree tle raw
+            try:
+                from triton.experimental.tle.raw.cuda.runtime import run_kernel_init_hooks
+            except ImportError:
+                pass
+            else:
+                run_kernel_init_hooks(kernel)
             self._call_hook(knobs.runtime.jit_post_compile_hook, key, signature, device, constexprs, options, [attrs],
                             warmup)
         return kernel

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -269,6 +269,7 @@ class CUDABackend(BaseBackend):
 
     @staticmethod
     def make_ttir(mod, metadata, opt, capability):
+        # flagtree tle raw
         kernel_init_hooks = mod.get_operation().get_str_attr("tle.raw.kernel_init_hooks")
         metadata["kernel_init_hooks"] = kernel_init_hooks.split(",") if kernel_init_hooks else []
 

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -269,6 +269,9 @@ class CUDABackend(BaseBackend):
 
     @staticmethod
     def make_ttir(mod, metadata, opt, capability):
+        kernel_init_hooks = mod.get_operation().get_str_attr("tle.raw.kernel_init_hooks")
+        metadata["kernel_init_hooks"] = kernel_init_hooks.split(",") if kernel_init_hooks else []
+
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         passes.common.add_inliner(pm)


### PR DESCRIPTION
This PR fixes incorrect hook injection in the following cases:
1. A single Python file launches multiple kernels, but only one of them uses NVSHMEM;
2. A CUDA device function is registered in Python, but it is never invoked by the Triton kernel through `tle_raw.call`, https://github.com/flagos-ai/FlagTree/issues/846;

Our solutions: 
- For case1, bind the hook to the kernel and write it into the kernel metadata; 
- For case2, defer the hook registration until inside `tle_raw.call`;
