### PR TITLE
[TLE] Reland scoped helper inlining for warp-specialized local pointers

### DIFF
--- a/third_party/tle/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tle/dialect/lib/IR/Dialect.cpp
@@ -23,8 +23,8 @@
 
 #include "tle/dialect/include/IR/Dialect.h"
 #include "mlir/Support/LLVM.h"
-#include "triton/Dialect/Triton/IR/Interfaces.h"
 #include "tle/dialect/include/IR/Dialect.cpp.inc"
+#include "triton/Dialect/Triton/IR/Interfaces.h"
 
 #define GET_ATTRDEF_CLASSES
 #include "tle/dialect/include/IR/TleAttrDefs.cpp.inc"

--- a/third_party/tle/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tle/dialect/lib/IR/Dialect.cpp
@@ -23,8 +23,8 @@
 
 #include "tle/dialect/include/IR/Dialect.h"
 #include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/InliningUtils.h"
 #include "tle/dialect/include/IR/Dialect.cpp.inc"
-#include "triton/Dialect/Triton/IR/Interfaces.h"
 
 #define GET_ATTRDEF_CLASSES
 #include "tle/dialect/include/IR/TleAttrDefs.cpp.inc"
@@ -38,6 +38,18 @@
 #endif
 
 namespace mlir::triton::tle {
+namespace {
+struct TleInlinerInterface final : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+
+  bool isLegalToInline(Operation *op, Region *, bool, IRMapping &) const final {
+    // TLE regions and terminators have their own semantics. Only allow
+    // ordinary operations to be cloned with a containing Triton function.
+    return op->getNumRegions() == 0 && !op->hasTrait<OpTrait::IsTerminator>();
+  }
+};
+} // namespace
+
 void TleDialect::initialize() {
   addAttributes<
 #define GET_ATTRDEF_LIST
@@ -55,8 +67,6 @@ void TleDialect::initialize() {
       >();
 #endif
 
-  // TLE ops can appear in ordinary @triton.jit helpers. Mark them as legal to
-  // clone so the module inliner can expose helper bodies to later passes.
-  addInterfaces<TritonInlinerInterface>();
+  addInterfaces<TleInlinerInterface>();
 }
 } // namespace mlir::triton::tle

--- a/third_party/tle/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tle/dialect/lib/IR/Dialect.cpp
@@ -23,6 +23,7 @@
 
 #include "tle/dialect/include/IR/Dialect.h"
 #include "mlir/Support/LLVM.h"
+#include "triton/Dialect/Triton/IR/Interfaces.h"
 #include "tle/dialect/include/IR/Dialect.cpp.inc"
 
 #define GET_ATTRDEF_CLASSES
@@ -53,5 +54,9 @@ void TleDialect::initialize() {
 #include "tle/dialect/include/IR/FlagCxOps.cpp.inc"
       >();
 #endif
+
+  // TLE ops can appear in ordinary @triton.jit helpers. Mark them as legal to
+  // clone so the module inliner can expose helper bodies to later passes.
+  addInterfaces<TritonInlinerInterface>();
 }
 } // namespace mlir::triton::tle

--- a/third_party/tle/test/GPU/test_tle_inline.mlir
+++ b/third_party/tle/test/GPU/test_tle_inline.mlir
@@ -19,7 +19,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// RUN: triton-opt %s -split-input-file -inline | FileCheck %s
+// RUN: triton-opt %s -split-input-file -inline -verify-each | FileCheck %s
 
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
@@ -121,24 +121,53 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 module {
   llvm.func @_sink(!llvm.ptr)
 
-  // CHECK-LABEL: tt.func public @inline_dsl_region
-  tt.func public @inline_dsl_region(%arg0: !tt.ptr<i32>) {
-    // CHECK-NOT: tt.call
-    // CHECK: %[[DSL_RESULT:.*]] = "tle.dsl_region"
-    // CHECK: tle.yield
-    // CHECK: llvm.call @_sink(%[[DSL_RESULT]])
+  // Region-bearing TLE ops remain opaque to the module inliner.
+  // CHECK-LABEL: tt.func public @preserve_dsl_region_helper
+  tt.func public @preserve_dsl_region_helper(%arg0: !tt.ptr<i32>) {
+    // CHECK: tt.call @dsl_region_worker
     tt.call @dsl_region_worker(%arg0) : (!tt.ptr<i32>) -> ()
-    // CHECK-NEXT: tt.return
     tt.return
   }
 
-  // CHECK-NOT: @dsl_region_worker
+  // CHECK: tt.func private @dsl_region_worker
+  // CHECK: "tle.dsl_region"
+  // CHECK: tle.yield
+  // CHECK: llvm.call @_sink
   tt.func private @dsl_region_worker(%arg0: !tt.ptr<i32>)
       attributes {noinline = false} {
     %ptr = "tle.dsl_region"(%arg0) ({
     ^bb0(%input: !tt.ptr<i32>):
       %raw = "tle.extract_ptr"(%input) : (!tt.ptr<i32>) -> !llvm.ptr
       "tle.yield"(%raw) : (!llvm.ptr) -> ()
+    }) {arg_dialect = "llvm", output_operand_indices = array<i32: 0>,
+        region_dialect = "llvm", tle_raw.source_id = "inline-test"}
+        : (!tt.ptr<i32>) -> !llvm.ptr
+    llvm.call @_sink(%ptr) : (!llvm.ptr) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+module {
+  // TLE does not opt calls nested in its isolated region into generic
+  // inlining.
+  // CHECK: llvm.func internal @dsl_identity
+  llvm.func internal @dsl_identity(%arg0: !llvm.ptr) -> !llvm.ptr {
+    llvm.return %arg0 : !llvm.ptr
+  }
+
+  llvm.func @_sink(!llvm.ptr)
+
+  // CHECK-LABEL: tt.func public @preserve_call_inside_dsl_region
+  tt.func public @preserve_call_inside_dsl_region(%arg0: !tt.ptr<i32>) {
+    %ptr = "tle.dsl_region"(%arg0) ({
+    ^bb0(%input: !tt.ptr<i32>):
+      %raw = "tle.extract_ptr"(%input) : (!tt.ptr<i32>) -> !llvm.ptr
+      // CHECK: %[[DSL_CALLED:.*]] = llvm.call @dsl_identity
+      %called = llvm.call @dsl_identity(%raw) : (!llvm.ptr) -> !llvm.ptr
+      // CHECK-NEXT: tle.yield %[[DSL_CALLED]]
+      "tle.yield"(%called) : (!llvm.ptr) -> ()
     }) {arg_dialect = "llvm", output_operand_indices = array<i32: 0>,
         region_dialect = "llvm", tle_raw.source_id = "inline-test"}
         : (!tt.ptr<i32>) -> !llvm.ptr

--- a/third_party/tle/test/GPU/test_tle_inline.mlir
+++ b/third_party/tle/test/GPU/test_tle_inline.mlir
@@ -1,0 +1,198 @@
+// Copyright 2025-     FlagOS Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files
+// (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software,
+// and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// RUN: triton-opt %s -split-input-file -inline | FileCheck %s
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: tt.func public @inline_local_pointers
+  tt.func public @inline_local_pointers(
+      %smem: !ttg.memdesc<16xi32, #shared, #smem, mutable>) {
+    // CHECK-NOT: tt.call
+    // CHECK: %[[PLAIN_PTR:.*]] = "tle.local_pointers"
+    // CHECK: tt.atomic_rmw add, relaxed, cta, %[[PLAIN_PTR]]
+    tt.call @plain_local_pointer_worker(%smem) : (!ttg.memdesc<16xi32, #shared, #smem, mutable>) -> ()
+    // CHECK-NEXT: tt.return
+    tt.return
+  }
+
+  // CHECK-NOT: @plain_local_pointer_worker
+  tt.func private @plain_local_pointer_worker(
+      %smem: !ttg.memdesc<16xi32, #shared, #smem, mutable>)
+      attributes {noinline = false} {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    %ptr = "tle.local_pointers"(%smem, %c0) : (!ttg.memdesc<16xi32, #shared, #smem, mutable>, i32) -> !tt.ptr<i32, 3>
+    %old = tt.atomic_rmw add, relaxed, cta, %ptr, %c1, %true : (!tt.ptr<i32, 3>, i32, i1) -> i32
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: tt.func public @inline_local_pointers_in_warp_specialize
+  tt.func public @inline_local_pointers_in_warp_specialize(
+      %smem: !ttg.memdesc<16xi32, #shared, #smem, mutable>) {
+    ttg.warp_specialize(%smem)
+    default {
+      ttg.warp_yield
+    }
+    // CHECK: partition0
+    partition0(%arg0: !ttg.memdesc<16xi32, #shared, #smem, mutable>) num_warps(4) {
+      // CHECK-NOT: tt.call
+      // CHECK: %[[PTR:.*]] = "tle.local_pointers"
+      // CHECK: tt.atomic_rmw add, relaxed, cta, %[[PTR]]
+      tt.call @ws_local_pointer_worker(%arg0) : (!ttg.memdesc<16xi32, #shared, #smem, mutable>) -> ()
+      // CHECK-NEXT: ttg.warp_return
+      ttg.warp_return
+    } : (!ttg.memdesc<16xi32, #shared, #smem, mutable>) -> ()
+    tt.return
+  }
+
+  // CHECK-NOT: @ws_local_pointer_worker
+  tt.func private @ws_local_pointer_worker(
+      %smem: !ttg.memdesc<16xi32, #shared, #smem, mutable>)
+      attributes {noinline = false, "ttg.num-warps" = 4 : i32} {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    %ptr = "tle.local_pointers"(%smem, %c0) : (!ttg.memdesc<16xi32, #shared, #smem, mutable>, i32) -> !tt.ptr<i32, 3>
+    %old = tt.atomic_rmw add, relaxed, cta, %ptr, %c1, %true : (!tt.ptr<i32, 3>, i32, i1) -> i32
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: tt.func public @preserve_noinline_local_pointers
+  tt.func public @preserve_noinline_local_pointers(
+      %smem: !ttg.memdesc<16xi32, #shared, #smem, mutable>) {
+    // CHECK: tt.call @noinline_local_pointer_worker
+    tt.call @noinline_local_pointer_worker(%smem) : (!ttg.memdesc<16xi32, #shared, #smem, mutable>) -> ()
+    tt.return
+  }
+
+  // CHECK: tt.func private @noinline_local_pointer_worker
+  // CHECK: "tle.local_pointers"
+  // CHECK: tt.atomic_rmw add, relaxed, cta
+  tt.func private @noinline_local_pointer_worker(
+      %smem: !ttg.memdesc<16xi32, #shared, #smem, mutable>)
+      attributes {noinline = true} {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    %ptr = "tle.local_pointers"(%smem, %c0) : (!ttg.memdesc<16xi32, #shared, #smem, mutable>, i32) -> !tt.ptr<i32, 3>
+    %old = tt.atomic_rmw add, relaxed, cta, %ptr, %c1, %true : (!tt.ptr<i32, 3>, i32, i1) -> i32
+    tt.return
+  }
+}
+
+// -----
+
+module {
+  llvm.func @_sink(!llvm.ptr)
+
+  // CHECK-LABEL: tt.func public @inline_dsl_region
+  tt.func public @inline_dsl_region(%arg0: !tt.ptr<i32>) {
+    // CHECK-NOT: tt.call
+    // CHECK: %[[DSL_RESULT:.*]] = "tle.dsl_region"
+    // CHECK: tle.yield
+    // CHECK: llvm.call @_sink(%[[DSL_RESULT]])
+    tt.call @dsl_region_worker(%arg0) : (!tt.ptr<i32>) -> ()
+    // CHECK-NEXT: tt.return
+    tt.return
+  }
+
+  // CHECK-NOT: @dsl_region_worker
+  tt.func private @dsl_region_worker(%arg0: !tt.ptr<i32>)
+      attributes {noinline = false} {
+    %ptr = "tle.dsl_region"(%arg0) ({
+    ^bb0(%input: !tt.ptr<i32>):
+      %raw = "tle.extract_ptr"(%input) : (!tt.ptr<i32>) -> !llvm.ptr
+      "tle.yield"(%raw) : (!llvm.ptr) -> ()
+    }) {arg_dialect = "llvm", output_operand_indices = array<i32: 0>,
+        region_dialect = "llvm", tle_raw.source_id = "inline-test"}
+        : (!tt.ptr<i32>) -> !llvm.ptr
+    llvm.call @_sink(%ptr) : (!llvm.ptr) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: tt.func public @inline_pipe_lifecycle_ops
+  tt.func public @inline_pipe_lifecycle_ops(
+      %field: !ttg.memdesc<4x16xf16, #shared, #smem, mutable>) {
+    // CHECK-NOT: tt.call
+    // CHECK: tle.pipe.create
+    // CHECK: tle.pipe.writer_acquire
+    // CHECK: tle.pipe.writer_commit
+    tt.call @pipe_lifecycle_worker(%field) : (!ttg.memdesc<4x16xf16, #shared, #smem, mutable>) -> ()
+    // CHECK-NEXT: tt.return
+    tt.return
+  }
+
+  // CHECK-NOT: @pipe_lifecycle_worker
+  tt.func private @pipe_lifecycle_worker(
+      %field: !ttg.memdesc<4x16xf16, #shared, #smem, mutable>)
+      attributes {noinline = false} {
+    %c0 = arith.constant 0 : i32
+    %false = arith.constant false
+    tle.pipe.create %field {capacity = 4 : i32, pipe_name = "field", field_names = ["field"], scope = "cta"} : !ttg.memdesc<4x16xf16, #shared, #smem, mutable>
+    tle.pipe.writer_acquire %field[%c0, %false] {capacity = 4 : i32, pipe_name = "field", field_names = ["field"], scope = "cta"} : !ttg.memdesc<4x16xf16, #shared, #smem, mutable>
+    tle.pipe.writer_commit %field[%c0] {capacity = 4 : i32, pipe_name = "field", field_names = ["field"], scope = "cta"} : !ttg.memdesc<4x16xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+module {
+  // CHECK-LABEL: tt.func public @inline_other_tle_ops
+  tt.func public @inline_other_tle_ops() {
+    // CHECK-NOT: tt.call
+    // CHECK: tle.tma_store.commit_group
+    tt.call @tma_store_commit() : () -> ()
+    // CHECK-NEXT: tt.return
+    tt.return
+  }
+
+  // CHECK-NOT: @tma_store_commit
+  tt.func private @tma_store_commit() attributes {noinline = false} {
+    tle.tma_store.commit_group
+    tt.return
+  }
+}


### PR DESCRIPTION
## Summary

Relands #837, reverted by #845, with narrower TLE-specific inlining legality.

Helpers containing `tle.local_pointers` were rejected by the module inliner. In the warp-specialized case from #828, leaving the worker helper out of line allowed barrier insertion to produce a CTA-wide barrier that only worker threads entered, causing a deadlock.

This version:

- registers a dedicated `TleInlinerInterface` instead of reusing `TritonInlinerInterface`;
- allows only regionless, non-terminator TLE operations to be cloned with an enclosing Triton function;
- keeps `tle.dsl_region` / `tle.yield` and calls inside isolated TLE regions opaque to generic inlining;
- continues to respect `noinline = true`.

This avoids inheriting Triton's `tt.return`-specific terminator handling and unconditional region legality while restoring the fix for #828.

## Root cause and impact

The common inliner runs before TLE local pointers are lowered, and every operation in the callee must be legal to inline. TLE previously had no dialect inliner interface, so a helper containing TLE operations remained as a `tt.call`.

For a warp-specialized worker, shared-memory atomic analysis could then insert a CTA-wide barrier inside that out-of-line helper. Only the worker's 128 threads entered the helper in a 256-thread CTA, so the generated bare `bar.sync 0` could wait forever. Inlining the helper early lets the warp-specialization passes see and scope those barriers correctly.

## Validation

- TLE inliner MLIR regression with `-split-input-file -inline -verify-each` and FileCheck;
- 5 adjacent TritonGPU, TritonNvidiaGPU, Gluon, membar, and warp-specialization MLIR regressions;
- TLE cumsum, local-pointer, and WGMMA routing unit tests: 30 passed, 1 skipped;
- #828 H800 reproducer: plain and warp-specialized kernels completed with the expected output;
- generated PTX contains no helper call or bare `bar.sync 0`, and contains two worker-scoped `bar.sync 2, 128` instructions.

Fixes #828.
