### PR TITLE
[non-FlagCX] Fix/tle distributed nameerror guard

### DIFF
--- a/python/test/tle/unit/test_tle_d2d_barrier.py
+++ b/python/test/tle/unit/test_tle_d2d_barrier.py
@@ -1,4 +1,9 @@
 import triton.experimental.tle.language as tle
+import pytest
+from triton.experimental.tle.language.communication import enabled as _flagcx_enabled
+
+pytestmark = pytest.mark.skipif(
+    not _flagcx_enabled, reason="TLE distributed requires FlagCX (NVIDIA); unavailable here")
 import torch
 import triton
 import triton.language as tl

--- a/python/test/tle/unit/test_tle_get_local_pe.py
+++ b/python/test/tle/unit/test_tle_get_local_pe.py
@@ -1,4 +1,9 @@
+import pytest
 import triton.experimental.tle.language as tle
+from triton.experimental.tle.language.communication import enabled as _flagcx_enabled
+
+pytestmark = pytest.mark.skipif(
+    not _flagcx_enabled, reason="TLE distributed requires FlagCX (NVIDIA); unavailable here")
 import torch
 import triton
 import triton.language as tl
@@ -41,4 +46,5 @@ class TestLocalPeCount:
         tle.cleanup_communicator()
 
 
-TestLocalPeCount().test_tle_local_pe_kernel()
+if __name__ == "__main__":
+    TestLocalPeCount().test_tle_local_pe_kernel()

--- a/python/triton/experimental/tle/language/communication.py
+++ b/python/triton/experimental/tle/language/communication.py
@@ -24,6 +24,24 @@ try:
 except Exception:
     enabled = False
 
+# flagtree: module-level state + guard so the distributed entry points fail
+# with a clear error instead of a NameError on undefined globals when FlagCX
+# is unavailable (e.g. AMD/ROCm or any non-FlagCX environment).
+_allocator = None
+_allocator_wrapper = None
+_mem_pool = None
+_flagcx_allocator_failed_to_compile = False
+_init_communicator_ = False
+
+
+def _require_flagcx_distributed():
+    if not enabled:
+        raise RuntimeError(
+            "TLE distributed features require FlagCX "
+            "(triton.backends.nvidia.distributed.flagcx_rt_conf), which is "
+            "not available in this environment.")
+
+
 if enabled:
     from .flagcx_wrapper import (
         FLAGCXLibrary,
@@ -120,6 +138,7 @@ def compile_flagcx_allocator():
 
 
 def get_mem_pool():
+    _require_flagcx_distributed()
     init_communicator()
     """Return a cached PyTorch MemPool backed by flagcxMemAlloc."""
     global _mem_pool, _flagcx_allocator_failed_to_compile
@@ -141,6 +160,7 @@ def _cleanup_flagcx_allocator_wrapper():
 
 
 def cleanup_communicator():
+    _require_flagcx_distributed()
     global comm, rank, dev_mem, dev_comm, win
     dist.barrier()
     flagcx.flagcxDevMemFreeDevicePtr(dev_mem)
@@ -156,6 +176,7 @@ def cleanup_communicator():
 
 
 def init_communicator():
+    _require_flagcx_distributed()
     global comm, rank, _init_communicator_
     if _init_communicator_:
         return
@@ -189,6 +210,7 @@ def init_communicator():
 
 
 def create_dist_tensor(buf_tensor):
+    _require_flagcx_distributed()
     global comm, rank, dev_mem, dev_comm, win
     buf_ptr = buf_tensor.data_ptr()
     buf_size = buf_tensor.numel() * buf_tensor.element_size()


### PR DESCRIPTION
<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->
## What
On any non-FlagCX env (e.g. AMD/ROCm), the TLE distributed unit tests crash
pytest **collection** of the whole `unit/` dir.

## Why
`communication.py`'s distributed entry points (`get_mem_pool`, `init_communicator`,
`create_dist_tensor`, `cleanup_communicator`) are module-level, but the globals
they use (`_init_communicator_`, `dist`, `flagcx`, ...) are only defined inside
`if enabled:` (FlagCX present). When `enabled=False` → `NameError`. And
`test_tle_get_local_pe.py` ran a test at import time, so the NameError aborted
collection.

## Fix
- **lib**: add module-level state defaults + a `_require_flagcx_distributed()`
  guard → clear `RuntimeError` instead of `NameError`. FlagCX path unchanged.
- **tests**: `skipif(not FlagCX)` on the 2 distributed d2d tests + `if __name__`
  guard on the module-level call (matches the other d2d files).

## Verified (gfx1201 / no FlagCX)
| | before | after |
|---|---|---|
| `pytest unit/ --collect-only` | 109, **1 error (aborted)** | **110, 0 error** |
| distributed d2d tests | NameError | **2 skipped** |
| `test_tle.py` | 40 passed | **40 passed** |

3 files changed, no compiler/kernel logic touched.