### PR TITLE
[TLE] Add tle.concat_dot_fragments to merge dot operands along K

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -965,25 +965,57 @@ public:
   }
 };
 
+// concat_dot_fragments op pattern
+class TleConcatDotFragmentsOpPattern
+    : public OpConversionPattern<tle::ConcatDotFragmentsOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(tle::ConcatDotFragmentsOp op,
+                  tle::ConcatDotFragmentsOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto tiles = adaptor.getTiles();
+    if (tiles.empty())
+      return op.emitError("concat_dot_fragments requires at least one tile");
+
+    auto tile0Type = dyn_cast<RankedTensorType>(tiles[0].getType());
+    if (!tile0Type)
+      return op.emitError("tiles must be ranked tensors");
+    auto tileEnc = tile0Type.getEncoding();
+    if (!tileEnc)
+      return op.emitError("tiles must have encoding attribute");
+
+    Type retType = op.getType().cloneWithEncoding(tileEnc);
+
+    auto newOp = rewriter.replaceOpWithNewOp<tle::ConcatDotFragmentsOp>(
+        op, retType, tiles, op.getDim());
+
+    addNamedAttrs(newOp, adaptor.getAttributes());
+
+    return success();
+  }
+};
+
 // flagtree tle raw
 void populateTleRawPatterns(TritonGPUTypeConverter &typeConverter,
                             RewritePatternSet &patterns) {
   MLIRContext *context = patterns.getContext();
-  patterns
-      .add<TleDSLRegionOpPattern, TleExtractTileOpPattern,
-           TleInsertTileOpPattern, GenericOpPattern<tle::LocalPointersOp>,
-           GenericOpPattern<tle::RemotePointersOp>,
-           GenericOpPattern<tle::ExclusiveCumsumOp>,
-           GenericOpPattern<tle::WGMMAOp>, GenericOpPattern<tle::WGMMAWaitOp>,
-           GenericOpPattern<tle::DistributedBarrierOp>,
-           GenericOpPattern<tle::YieldOp>,
-           GenericOpPattern<tle::ExtractAllocatedPtrOp>,
-           GenericOpPattern<tle::ExtractAlignedPtrOp>,
-           GenericOpPattern<tle::ExtractOffsetOp>,
-           GenericOpPattern<tle::ExtractSizesOp>,
-           GenericOpPattern<tle::ExtractStridesOp>,
-           GenericOpPattern<tle::ExtractPtrOp>, GenericOpPattern<tle::PackOp>>(
-          typeConverter, context);
+  patterns.add<
+      TleDSLRegionOpPattern, TleExtractTileOpPattern, TleInsertTileOpPattern,
+      TleConcatDotFragmentsOpPattern, GenericOpPattern<tle::LocalPointersOp>,
+      GenericOpPattern<tle::RemotePointersOp>,
+      GenericOpPattern<tle::ExclusiveCumsumOp>, GenericOpPattern<tle::WGMMAOp>,
+      GenericOpPattern<tle::WGMMAWaitOp>,
+      GenericOpPattern<tle::DistributedBarrierOp>,
+      GenericOpPattern<tle::YieldOp>,
+      GenericOpPattern<tle::ExtractAllocatedPtrOp>,
+      GenericOpPattern<tle::ExtractAlignedPtrOp>,
+      GenericOpPattern<tle::ExtractOffsetOp>,
+      GenericOpPattern<tle::ExtractSizesOp>,
+      GenericOpPattern<tle::ExtractStridesOp>,
+      GenericOpPattern<tle::ExtractPtrOp>, GenericOpPattern<tle::PackOp>>(
+      typeConverter, context);
 }
 #endif
 

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -51,6 +51,7 @@
 #endif // __FLAGTREE_RLC_ENHANCE__
 #include "triton/Analysis/Utility.h"
 #ifdef __TLE__
+#include "tle/dialect/include/IR/Dialect.h"
 #include "tle/dialect/include/Transforms/TransformAttrs.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #endif // __TLE__
@@ -4142,6 +4143,9 @@ void LayoutRematerialization::hoistConvertDotOperand(
     return (op->hasTrait<OpTrait::Elementwise>() && isMemoryEffectFree(op)) ||
            isa<BroadcastOp, Fp4ToFpOp, ConvertLayoutOp, UpcastFpOpInterface>(
                op) ||
+#ifdef __TLE__
+           isa<triton::tle::ConcatDotFragmentsOp>(op) ||
+#endif
            isView(op);
   };
   // Stop the slice as soon as we find an operation that cannot be done without

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -434,6 +434,18 @@ static Attribute inferSrcEncoding(GatherOp op, Attribute dstEnc) {
   return dstEnc;
 }
 
+#ifdef __TLE__
+static Attribute inferSrcEncoding(triton::tle::ConcatDotFragmentsOp op,
+                                  Attribute dstEnc) {
+  // Only DotOperandEncodingAttr carries no K extent, so it is the only encoding
+  // a concat can share unchanged with its tiles; shape-coupled ones like
+  // blocked take the generic conversion path.
+  if (isa<ttg::DotOperandEncodingAttr>(dstEnc))
+    return dstEnc;
+  return {};
+}
+#endif
+
 static Attribute inferTransOpDstEncoding(Attribute srcEnc,
                                          ArrayRef<int64_t> shape,
                                          ArrayRef<int32_t> order) {
@@ -526,6 +538,16 @@ static Attribute inferDstEncoding(GatherOp op, Attribute encoding) {
   return encoding;
 }
 
+#ifdef __TLE__
+static Attribute inferDstEncoding(triton::tle::ConcatDotFragmentsOp op,
+                                  Attribute srcEnc) {
+  // Symmetric to inferSrcEncoding(ConcatDotFragmentsOp).
+  if (isa<ttg::DotOperandEncodingAttr>(srcEnc))
+    return srcEnc;
+  return {};
+}
+#endif
+
 static Attribute inferSrcEncoding(triton::ReshapeOp op, Attribute encoding) {
   // The encoding of x given the encoding of y in `reshape(x) -> y` is the same
   // as the encoding of x given the encoding of y in `reshape(y) -> x`.  It's an
@@ -583,6 +605,10 @@ Attribute inferSrcEncoding(Operation *op, Attribute encoding) {
     return inferSrcEncoding(gather, encoding);
   if (auto fp4ToFp = dyn_cast<triton::gpu::Fp4ToFpOp>(op))
     return inferSrcEncoding(fp4ToFp, encoding);
+#ifdef __TLE__
+  if (auto concatDotFragments = dyn_cast<triton::tle::ConcatDotFragmentsOp>(op))
+    return inferSrcEncoding(concatDotFragments, encoding);
+#endif
 
   return {};
 }
@@ -617,6 +643,10 @@ Attribute inferDstEncoding(Operation *op, Attribute encoding) {
     return inferDstEncoding(gather, encoding);
   if (auto fp4ToFp = dyn_cast<triton::gpu::Fp4ToFpOp>(op))
     return inferDstEncoding(fp4ToFp, encoding);
+#ifdef __TLE__
+  if (auto concatDotFragments = dyn_cast<triton::tle::ConcatDotFragmentsOp>(op))
+    return inferDstEncoding(concatDotFragments, encoding);
+#endif
 
   return {};
 }

--- a/python/test/tle/unit/test_concat_dot_fragments.py
+++ b/python/test/tle/unit/test_concat_dot_fragments.py
@@ -7,6 +7,19 @@ import triton.experimental.tle.language as tle
 import pytest
 
 
+def _is_cuda_backend():
+    try:
+        return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    except Exception:
+        return False
+
+
+# The merge is expressed in terms of the NVIDIA mma fragment layout, so these
+# checks only apply on the cuda backend.
+requires_cuda_backend = pytest.mark.skipif(not torch.cuda.is_available() or not _is_cuda_backend(),
+                                           reason="requires an NVIDIA GPU backend")
+
+
 @triton.jit
 def segmented_dot_kernel(a_ptr, b_ptr, out_ptr, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr, K_SEG: tl.constexpr,
                          NUM_SEG: tl.constexpr):
@@ -47,7 +60,7 @@ def _shapes():
     return M, N, K, K // num_seg, num_seg
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for this test")
+@requires_cuda_backend
 def test_concat_dot_fragments_matches_segmented_dot():
     M, N, K, k_seg, num_seg = _shapes()
 
@@ -64,7 +77,7 @@ def test_concat_dot_fragments_matches_segmented_dot():
         "concat_dot_fragments must be bit-exact with accumulating one dot per K segment"
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for this test")
+@requires_cuda_backend
 def test_concat_dot_fragments_keeps_dot_operand_encoding():
     # The op is only zero-cost while the dot_op encoding propagates through it:
     # a #blocked operand means it did not, and the merged fragment would then
@@ -92,7 +105,7 @@ def test_concat_dot_fragments_keeps_dot_operand_encoding():
     # staging, which is the same with or without the concat.
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for this test")
+@requires_cuda_backend
 def test_concat_dot_fragments_rejects_non_dot_operands(capfd):
     # Without a dot consuming the result the operands stay #blocked, which the
     # lowering rejects: the per-thread relabel is only valid for dot_op layouts.

--- a/python/test/tle/unit/test_concat_dot_fragments.py
+++ b/python/test/tle/unit/test_concat_dot_fragments.py
@@ -1,0 +1,116 @@
+import re
+
+import torch
+import triton
+import triton.language as tl
+import triton.experimental.tle.language as tle
+import pytest
+
+
+@triton.jit
+def segmented_dot_kernel(a_ptr, b_ptr, out_ptr, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr, K_SEG: tl.constexpr,
+                         NUM_SEG: tl.constexpr):
+    # Accumulate one dot per K segment, the pattern concat_dot_fragments replaces.
+    offs_m = tl.arange(0, M)
+    offs_n = tl.arange(0, N)
+    acc = tl.zeros((M, N), dtype=tl.float32)
+    for s in tl.static_range(NUM_SEG):
+        offs_k = s * K_SEG + tl.arange(0, K_SEG)
+        a = tl.load(a_ptr + offs_m[:, None] * K + offs_k[None, :])
+        b = tl.load(b_ptr + offs_k[:, None] * N + offs_n[None, :])
+        acc = tl.dot(a, b, acc=acc)
+    tl.store(out_ptr + offs_m[:, None] * N + offs_n[None, :], acc)
+
+
+@triton.jit
+def merged_dot_kernel(a_ptr, b_ptr, out_ptr, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr, K_SEG: tl.constexpr,
+                      NUM_SEG: tl.constexpr):
+    # Merge the same segments into one fragment and issue a single dot. The
+    # operand encoding comes from layout propagation off that dot, so the concat
+    # sees dot_op tiles.
+    offs_m = tl.arange(0, M)
+    offs_n = tl.arange(0, N)
+    offs_k = tl.arange(0, K)
+
+    a0 = tl.load(a_ptr + offs_m[:, None] * K + (0 * K_SEG + tl.arange(0, K_SEG))[None, :])
+    a1 = tl.load(a_ptr + offs_m[:, None] * K + (1 * K_SEG + tl.arange(0, K_SEG))[None, :])
+    a_full = tle.concat_dot_fragments([a0, a1], dim=1)
+
+    b = tl.load(b_ptr + offs_k[:, None] * N + offs_n[None, :])
+    acc = tl.dot(a_full, b)
+    tl.store(out_ptr + offs_m[:, None] * N + offs_n[None, :], acc)
+
+
+def _shapes():
+    M, N, K = 64, 64, 64
+    num_seg = 2
+    return M, N, K, K // num_seg, num_seg
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for this test")
+def test_concat_dot_fragments_matches_segmented_dot():
+    M, N, K, k_seg, num_seg = _shapes()
+
+    torch.manual_seed(0)
+    a = torch.randn((M, K), device='cuda', dtype=torch.float16)
+    b = torch.randn((K, N), device='cuda', dtype=torch.float16)
+    seg_out = torch.zeros((M, N), device='cuda', dtype=torch.float32)
+    merged_out = torch.zeros((M, N), device='cuda', dtype=torch.float32)
+
+    segmented_dot_kernel[(1, )](a, b, seg_out, M, N, K, k_seg, num_seg)
+    merged_dot_kernel[(1, )](a, b, merged_out, M, N, K, k_seg, num_seg)
+
+    assert torch.equal(merged_out, seg_out), \
+        "concat_dot_fragments must be bit-exact with accumulating one dot per K segment"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for this test")
+def test_concat_dot_fragments_keeps_dot_operand_encoding():
+    # The op is only zero-cost while the dot_op encoding propagates through it:
+    # a #blocked operand means it did not, and the merged fragment would then
+    # round-trip through shared memory before reaching the mma.
+    M, N, K, k_seg, num_seg = _shapes()
+    a = torch.randn((M, K), device='cuda', dtype=torch.float16)
+    b = torch.randn((K, N), device='cuda', dtype=torch.float16)
+    out = torch.zeros((M, N), device='cuda', dtype=torch.float32)
+
+    compiled = merged_dot_kernel.warmup(a, b, out, M, N, K, k_seg, num_seg, grid=(1, ))
+    ttgir = compiled.asm["ttgir"]
+
+    concat = [ln for ln in ttgir.splitlines() if "tle.concat_dot_fragments" in ln]
+    assert len(concat) == 1, f"expected exactly one concat, got {len(concat)}"
+    assert "ttg.dot_op" in concat[0] and "#blocked" not in concat[0], \
+        f"concat operands lost their dot_op encoding: {concat[0]}"
+
+    # One mma for the whole K tile instead of one per segment. Match on the
+    # result assignment so `warp_group_dot_wait` does not count as a dot.
+    mma = re.findall(r"=\s+(ttng\.warp_group_dot|tt\.dot)\b", ttgir)
+    assert len(mma) == 1, f"expected a single mma, got {mma}"
+
+    # That the relabel emits no data movement is pinned at the IR level by
+    # test_tle_concat_dot_fragments.mlir; PTX here is dominated by the B operand
+    # staging, which is the same with or without the concat.
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for this test")
+def test_concat_dot_fragments_rejects_non_dot_operands(capfd):
+    # Without a dot consuming the result the operands stay #blocked, which the
+    # lowering rejects: the per-thread relabel is only valid for dot_op layouts.
+    @triton.jit
+    def blocked_kernel(x_ptr, out_ptr, M: tl.constexpr, N: tl.constexpr, TILE_N: tl.constexpr):
+        offs_m = tl.arange(0, M)
+        t0 = tle.extract_tile(
+            tl.load(x_ptr + offs_m[:, None] * N + tl.arange(0, N)[None, :]),
+            index=[0, 0],
+            tile_shape=[M, TILE_N],
+        )
+        merged = tle.concat_dot_fragments([t0, t0], dim=1)
+        tl.store(out_ptr + offs_m[:, None] * N + tl.arange(0, N)[None, :], merged)
+
+    x = torch.zeros((32, 64), device='cuda', dtype=torch.float32)
+    out = torch.zeros((32, 64), device='cuda', dtype=torch.float32)
+    with pytest.raises(Exception):
+        blocked_kernel[(1, )](x, out, 32, 64, 32)
+    # Pin the reason: the raised error only says the pass manager failed, so
+    # check the diagnostic itself, which MLIR writes to stderr.
+    assert "expects dot_op encoded operands" in capfd.readouterr().err

--- a/python/triton/experimental/tle/language/__init__.py
+++ b/python/triton/experimental/tle/language/__init__.py
@@ -25,6 +25,7 @@ from .core import (
     cumsum,
     extract_tile,
     insert_tile,
+    concat_dot_fragments,
     load,
 )
 from .pipe import (
@@ -88,6 +89,7 @@ __all__ = [
     "cumsum",
     "extract_tile",
     "insert_tile",
+    "concat_dot_fragments",
     "MeshConfig",
     "pipe",
     "pipe_reader",

--- a/python/triton/experimental/tle/language/core.py
+++ b/python/triton/experimental/tle/language/core.py
@@ -534,3 +534,55 @@ def insert_tile(
         return tl.tensor(output, x.type)
     except Exception as e:
         raise RuntimeError(f"Failed to create insert_tile operation: {str(e)}") from e
+
+
+@tl.builtin
+def concat_dot_fragments(
+    tiles,
+    dim,
+    _semantic=None,
+) -> tl.tensor:
+    """
+    Concatenate two or more same-shape, same-dtype, same-layout tiles along a
+    given axis, producing a single tensor whose extent along that axis is the
+    sum of the inputs.
+
+    Intended for dot-operand fragments sliced along the contraction (K) axis:
+    when the tiles share one fragment layout and the concat axis is a multiple
+    of the CTA tile size, this lowers to a pure per-thread register relabel
+    (no cross-lane communication, no extra load), replacing a tl.join/reshape
+    chain that would round-trip through shared memory.
+    """
+    tiles = list(tiles)
+    if len(tiles) < 2:
+        raise ValueError(f"concat_dot_fragments requires at least two tiles, got {len(tiles)}")
+    for i, t in builtins.enumerate(tiles):
+        if not isinstance(t, tl.tensor):
+            raise ValueError(f"tiles[{i}] must be tl.tensor, but got {type(t)}")
+
+    dim_value = tl._unwrap_if_constexpr(dim)
+    if not isinstance(dim_value, int):
+        raise ValueError("dim must be a compile-time int or constexpr")
+
+    tile0_shape = [tl._unwrap_if_constexpr(d) for d in tiles[0].type.shape]
+    rank = len(tile0_shape)
+    if dim_value < 0 or dim_value >= rank:
+        raise ValueError(f"dim {dim_value} out of range for rank {rank}")
+
+    for i, t in builtins.enumerate(tiles):
+        shape = [tl._unwrap_if_constexpr(d) for d in t.type.shape]
+        if shape != tile0_shape:
+            raise ValueError(f"tiles[{i}] shape {shape} must match tiles[0] shape {tile0_shape}")
+        if t.type.element_ty != tiles[0].type.element_ty:
+            raise ValueError(f"tiles[{i}] element type {t.type.element_ty} must match "
+                             f"tiles[0] element type {tiles[0].type.element_ty}")
+
+    try:
+        handles = [t.handle for t in tiles]
+        output = _semantic.builder.create_concat_dot_fragments(handles, dim_value)
+        result_shape = list(tile0_shape)
+        result_shape[dim_value] = tile0_shape[dim_value] * len(tiles)
+        block_type = tl.block_type(tiles[0].type.element_ty, result_shape)
+        return tl.tensor(output, block_type)
+    except Exception as e:
+        raise RuntimeError(f"Failed to create concat_dot_fragments operation: {str(e)}") from e

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -182,6 +182,8 @@ struct ConvertTritonGPUToLLVM
           typeConverter, patterns, targetInfo, benefit);
       mlir::triton::tle::populateInsertTileOpToLLVMPatterns(
           typeConverter, patterns, targetInfo, benefit);
+      mlir::triton::tle::populateConcatDotFragmentsOpToLLVMPatterns(
+          typeConverter, patterns, targetInfo, benefit);
       mlir::triton::tle::populateMemDescWGMMAViewOpToLLVMPatterns(
           typeConverter, patterns, benefit);
       mlir::triton::tle::populateExclusiveCumsumOpToLLVMPatterns(

--- a/third_party/tle/dialect/include/IR/TleOps.td
+++ b/third_party/tle/dialect/include/IR/TleOps.td
@@ -79,6 +79,37 @@ def Tle_InsertTileOp
   let hasVerifier = 1;
 }
 
+def Tle_ConcatDotFragmentsOp
+    : Tle_Op<"concat_dot_fragments", [Pure,
+                                     DeclareOpInterfaceMethods<InferTypeOpInterface>,
+                                     SameTypeOperands]> {
+  let summary = "Concatenate dot-operand fragments along the contraction axis";
+
+  let description = [{
+    Concatenate N dot-operand fragments along the contraction (K) axis into a
+    single fragment of N times the K extent, letting one mma cover the whole K
+    tile instead of one mma per segment. The wider `dot_op` layout only adds
+    register bases along K and leaves the lane and warp bases untouched, so
+    every result element already lives on the thread holding its source and
+    this lowers to a per-thread register relabel - unlike a tl.join / reshape
+    chain, which round-trips the operand through shared memory.
+
+    Requirements, checked when lowering since the operand encoding is only
+    settled after layout propagation: operands carry a `dot_op` encoding; `dim`
+    is the contraction axis for their `opIdx`; the tile spans at least
+    `8 * kWidth` along `dim`, below which the layout no longer scales with K;
+    tile and result agree on their lane, warp and block bases, and neither
+    broadcasts along a dim the relabel indexes by.
+  }];
+
+  let arguments = (ins Variadic<TT_Tensor>:$tiles, I32Attr:$dim);
+  let results = (outs TT_Tensor:$result);
+  let assemblyFormat = [{
+    $tiles attr-dict `:` qualified(type($tiles)) `->` qualified(type($result))
+  }];
+  let hasVerifier = 1;
+}
+
 // End TLE-Lite
 
 // Begin TLE-Raw

--- a/third_party/tle/dialect/include/Transforms/PatternTleToLLVM.h
+++ b/third_party/tle/dialect/include/Transforms/PatternTleToLLVM.h
@@ -40,6 +40,12 @@ void populateInsertTileOpToLLVMPatterns(
     mlir::LLVMTypeConverter &typeConverter, mlir::RewritePatternSet &patterns,
     const mlir::triton::TargetInfoBase &targetInfo, unsigned benefit = 1);
 
+/// Populate patterns to convert tle.concat_dot_fragments to LLVM
+/// (register-level relabel)
+void populateConcatDotFragmentsOpToLLVMPatterns(
+    mlir::LLVMTypeConverter &typeConverter, mlir::RewritePatternSet &patterns,
+    const mlir::triton::TargetInfoBase &targetInfo, unsigned benefit = 1);
+
 void populateMemDescWGMMAViewOpToLLVMPatterns(
     mlir::LLVMTypeConverter &typeConverter, mlir::RewritePatternSet &patterns,
     unsigned benefit = 1);

--- a/third_party/tle/dialect/lib/IR/Ops.cpp
+++ b/third_party/tle/dialect/lib/IR/Ops.cpp
@@ -635,6 +635,84 @@ LogicalResult InsertTileOp::verify() {
   return success();
 }
 
+// ============================================================================
+// ConcatDotFragmentsOp Type Inference + Verification
+// ============================================================================
+LogicalResult ConcatDotFragmentsOp::inferReturnTypes(
+    [[maybe_unused]] MLIRContext *context,
+    [[maybe_unused]] std::optional<Location> location, ValueRange operands,
+    [[maybe_unused]] DictionaryAttr attributes, OpaqueProperties properties,
+    [[maybe_unused]] RegionRange regions,
+    SmallVectorImpl<Type> &inferredReturnTypes) {
+
+  if (operands.empty())
+    return failure();
+  auto tileTy = dyn_cast<RankedTensorType>(operands[0].getType());
+  if (!tileTy)
+    return failure();
+
+  // `dim` is an inherent attribute stored in the op's Properties struct (not
+  // the discardable-attribute dictionary), same pattern as ReduceOp::axis.
+  auto *prop = properties.as<ConcatDotFragmentsOp::Properties *>();
+  if (!prop || !prop->dim)
+    return failure();
+  int64_t dim = prop->dim.getValue().getSExtValue();
+  if (dim < 0 || dim >= tileTy.getRank())
+    return failure();
+
+  SmallVector<int64_t> resultShape(tileTy.getShape());
+  resultShape[dim] *= static_cast<int64_t>(operands.size());
+
+  inferredReturnTypes.clear();
+  inferredReturnTypes.push_back(RankedTensorType::get(
+      resultShape, tileTy.getElementType(), tileTy.getEncoding()));
+  return success();
+}
+
+LogicalResult ConcatDotFragmentsOp::verify() {
+  auto tiles = getTiles();
+  if (tiles.size() < 2)
+    return emitOpError(
+        "concat_dot_fragments requires at least two input tiles");
+
+  auto tile0Ty = cast<RankedTensorType>(tiles[0].getType());
+  auto dstTy = cast<RankedTensorType>(getResult().getType());
+  int64_t rank = tile0Ty.getRank();
+
+  // getDim() is unsigned, so sign-extend the stored i32 to keep a negative
+  // `dim` readable in the diagnostic instead of wrapping to a huge value.
+  int64_t dim = getDimAttr().getValue().getSExtValue();
+  if (dim < 0 || dim >= rank)
+    return emitOpError("dim ") << dim << " out of range for rank " << rank;
+
+  // Tiles sharing shape, element type and encoding is enforced by
+  // SameTypeOperands, which reports before this verifier runs.
+
+  // Result must match the tile in every dim except `dim`, which grows by N.
+  auto tileShape = tile0Ty.getShape();
+  auto dstShape = dstTy.getShape();
+  if (dstTy.getRank() != rank)
+    return emitOpError("result rank must equal tile rank");
+  if (dstTy.getElementType() != tile0Ty.getElementType())
+    return emitOpError("result element type must match tile element type");
+  if (dstTy.getEncoding() != tile0Ty.getEncoding())
+    return emitOpError("result encoding must match tile encoding");
+  for (int64_t i = 0; i < rank; ++i) {
+    int64_t expect = (i == dim)
+                         ? tileShape[i] * static_cast<int64_t>(tiles.size())
+                         : tileShape[i];
+    if (dstShape[i] != expect)
+      return emitOpError("result shape mismatch at dimension ")
+             << i << " (expected " << expect << ", got " << dstShape[i] << ")";
+  }
+
+  // The dot_op specific checks (encoding kind, contraction axis, kWidth) live
+  // in the lowering rather than here: the operands only pick up their dot_op
+  // encoding once layout propagation has run, so until then a #blocked tile is
+  // a legal intermediate state and must not be rejected.
+  return success();
+}
+
 void DSLRegionOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {

--- a/third_party/tle/dialect/lib/Transforms/CMakeLists.txt
+++ b/third_party/tle/dialect/lib/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ add_triton_library(TritonTLETransforms
   TleTileToLLVMUtils.cpp
   ExtractTileToLLVM.cpp
   InsertTileToLLVM.cpp
+  ConcatDotFragmentsToLLVM.cpp
   TleLowerExtractTile.cpp
   TleLowerInsertTile.cpp
   TleLowerTmaCopy.cpp

--- a/third_party/tle/dialect/lib/Transforms/ConcatDotFragmentsToLLVM.cpp
+++ b/third_party/tle/dialect/lib/Transforms/ConcatDotFragmentsToLLVM.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2025-     FlagOS Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "TleTileToLLVMUtils.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "tle/dialect/include/IR/Dialect.h"
+#include "tle/dialect/include/Transforms/PatternTleToLLVM.h"
+#include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
+#include "triton/Tools/LinearLayout.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace {
+namespace ttg = mlir::triton::gpu;
+using namespace mlir::triton::tle;
+
+// concat_dot_fragments lowering: pure per-thread register gather. For each
+// result register slot the authoritative LinearLayout of result and tile tells
+// which (tile, tile-register-slot) feeds it, and that register is copied over.
+static LogicalResult
+lowerConcatDotFragmentsRegister(ConcatDotFragmentsOp op,
+                                ConcatDotFragmentsOp::Adaptor adaptor,
+                                ConversionPatternRewriter &rewriter,
+                                const LLVMTypeConverter *typeConverter) {
+  Location loc = op->getLoc();
+  auto dstTy = cast<RankedTensorType>(op.getType());
+  auto tileTy = cast<RankedTensorType>(op.getTiles()[0].getType());
+  int64_t dim = op.getDim();
+  int64_t numTiles = op.getTiles().size();
+
+  MLIRContext *ctx = op.getContext();
+  StringAttr kReg = StringAttr::get(ctx, "register");
+
+  // Layouts other than dot_op place lanes differently as `dim` grows, so the
+  // per-thread relabel below would silently move the wrong registers.
+  auto dotEnc = dyn_cast<ttg::DotOperandEncodingAttr>(tileTy.getEncoding());
+  if (!dotEnc)
+    return op.emitError("concat_dot_fragments: expects dot_op encoded "
+                        "operands, but got ")
+           << tileTy.getEncoding()
+           << "; the result must be consumed only by a dot";
+
+  // Only the contraction axis can be extended in place: growing M or N would
+  // change which lane owns an element. opIdx 0 contracts along the last dim,
+  // opIdx 1 along the one before it.
+  int64_t rank = tileTy.getRank();
+  int64_t kDim = dotEnc.getOpIdx() == 0 ? rank - 1 : rank - 2;
+  if (dim != kDim)
+    return op.emitError("concat_dot_fragments: dim ")
+           << dim << " is not the contraction axis (expected " << kDim
+           << " for opIdx " << dotEnc.getOpIdx() << ")";
+
+  // Below 8 * kWidth the layout stops scaling with K - the per-thread element
+  // count stays flat - so the tile is not a K-slice of the wider fragment and
+  // cannot be relabeled into it. kWidth is 0 for layouts that do not use it.
+  unsigned kWidth = dotEnc.getKWidth();
+  int64_t minK = 8 * static_cast<int64_t>(kWidth);
+  if (kWidth != 0 && tileTy.getShape()[dim] < minK)
+    return op.emitError("concat_dot_fragments: tile K extent ")
+           << tileTy.getShape()[dim] << " is below the minimum " << minK
+           << " (8 * kWidth) required for this dot_op layout";
+
+  // Authoritative layouts.
+  LinearLayout dstLL = ttg::toLinearLayout(dstTy);
+  LinearLayout tileLL = ttg::toLinearLayout(tileTy);
+
+  unsigned dstRegs = ttg::getTotalElemsPerThread(dstTy);
+  unsigned tileRegs = ttg::getTotalElemsPerThread(tileTy);
+  if (dstRegs != tileRegs * numTiles)
+    return op.emitError("concat_dot_fragments: result per-thread elems must "
+                        "equal N * tile elems");
+
+  // The register mapping below is derived on lane 0 and applied to every
+  // thread, which only holds if both layouts distribute elements over lanes,
+  // warps and blocks identically - a valid concat adds register bases and
+  // nothing else.
+  for (StringAttr inDim :
+       {StringAttr::get(ctx, "lane"), StringAttr::get(ctx, "warp"),
+        StringAttr::get(ctx, "block")}) {
+    if (dstLL.hasInDim(inDim) != tileLL.hasInDim(inDim) ||
+        (dstLL.hasInDim(inDim) &&
+         dstLL.getBases().lookup(inDim) != tileLL.getBases().lookup(inDim)))
+      return op.emitError("concat_dot_fragments: ")
+             << inDim.getValue()
+             << " basis differs between tile and result layout; the "
+                "concatenation would move elements across threads";
+  }
+
+  // Output dim names in a stable order (dim0, dim1, ...).
+  SmallVector<StringAttr> outDims(llvm::to_vector(dstLL.getOutDimNames()));
+
+  // Enumerate tile register slots once, recording in-tile coord -> slot, so we
+  // can invert result coords back to the feeding tile register.
+  auto dimIndexOf = [&](StringAttr d) -> int {
+    for (int i = 0; i < (int)outDims.size(); ++i)
+      if (outDims[i] == d)
+        return i;
+    return -1;
+  };
+  auto coordKey = [&](ArrayRef<int64_t> c) {
+    int64_t key = 0;
+    for (int i = 0; i < rank; ++i)
+      key = key * tileTy.getShape()[i] + c[i];
+    return key;
+  };
+
+  llvm::DenseMap<int64_t, unsigned> tileCoordToSlot;
+  for (unsigned r = 0; r < tileRegs; ++r) {
+    auto outs = tileLL.apply({{kReg, r},
+                              {StringAttr::get(ctx, "lane"), 0},
+                              {StringAttr::get(ctx, "warp"), 0},
+                              {StringAttr::get(ctx, "block"), 0}});
+    SmallVector<int64_t> c(rank, 0);
+    for (auto &kv : outs) {
+      int idx = dimIndexOf(kv.first);
+      if (idx >= 0)
+        c[idx] = kv.second;
+    }
+    // Two registers mapping to the same coordinate means the layout broadcasts
+    // along a dim we index by, so the reverse lookup below would drop one of
+    // them and duplicate the other. Bail out instead of relabeling silently.
+    if (!tileCoordToSlot.try_emplace(coordKey(c), r).second)
+      return op.emitError("concat_dot_fragments: tile layout maps several "
+                          "registers to the same element; it cannot be "
+                          "relabeled by index");
+  }
+
+  SmallVector<SmallVector<Value>> allTileVals;
+  allTileVals.reserve(numTiles);
+  for (int64_t t = 0; t < numTiles; ++t)
+    allTileVals.push_back(
+        unpackLLElements(loc, adaptor.getTiles()[t], rewriter));
+
+  SmallVector<Value> resultVals;
+  resultVals.reserve(dstRegs);
+  for (unsigned r = 0; r < dstRegs; ++r) {
+    auto outs = dstLL.apply({{kReg, r},
+                             {StringAttr::get(ctx, "lane"), 0},
+                             {StringAttr::get(ctx, "warp"), 0},
+                             {StringAttr::get(ctx, "block"), 0}});
+    SmallVector<int64_t> c(rank, 0);
+    for (auto &kv : outs) {
+      int idx = dimIndexOf(kv.first);
+      if (idx >= 0)
+        c[idx] = kv.second;
+    }
+    // Split the concat-axis coord into (tile index, in-tile coord).
+    int64_t tileExtent = tileTy.getShape()[dim];
+    int64_t tileIdx = c[dim] / tileExtent;
+    c[dim] = c[dim] % tileExtent;
+    if (tileIdx < 0 || tileIdx >= numTiles)
+      return op.emitError(
+          "concat_dot_fragments: concat-axis coord out of range");
+    auto it = tileCoordToSlot.find(coordKey(c));
+    if (it == tileCoordToSlot.end())
+      return op.emitError(
+          "concat_dot_fragments: no matching tile register slot; "
+          "layouts are not a clean K-superset");
+    resultVals.push_back(allTileVals[tileIdx][it->second]);
+  }
+
+  Value ret = packLLElements(loc, typeConverter, resultVals, rewriter, dstTy);
+  rewriter.replaceOp(op, ret);
+  return success();
+}
+
+struct ConcatDotFragmentsOpConversion
+    : public ConvertOpToLLVMPattern<ConcatDotFragmentsOp> {
+  // The relabel is expressed entirely through LinearLayout, so unlike the other
+  // tile ops this one needs no target-specific information.
+  ConcatDotFragmentsOpConversion(LLVMTypeConverter &typeConverter,
+                                 PatternBenefit benefit)
+      : ConvertOpToLLVMPattern<ConcatDotFragmentsOp>(typeConverter, benefit) {}
+
+  LogicalResult
+  matchAndRewrite(ConcatDotFragmentsOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto dstTy = dyn_cast<RankedTensorType>(op.getType());
+    auto tileTy = dyn_cast<RankedTensorType>(op.getTiles()[0].getType());
+    if (!dstTy || !tileTy)
+      return op.emitError(
+          "concat_dot_fragments operands must be ranked tensors");
+    if (!dstTy.getEncoding() || !tileTy.getEncoding())
+      return op.emitError(
+          "concat_dot_fragments requires tensors with encoding");
+    return lowerConcatDotFragmentsRegister(op, adaptor, rewriter,
+                                           this->getTypeConverter());
+  }
+};
+
+} // anonymous namespace
+
+namespace mlir::triton::tle {
+void populateConcatDotFragmentsOpToLLVMPatterns(
+    LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    [[maybe_unused]] const TargetInfoBase &targetInfo, unsigned benefit) {
+  patterns.add<ConcatDotFragmentsOpConversion>(typeConverter, benefit);
+}
+} // namespace mlir::triton::tle

--- a/third_party/tle/test/GPU/test_tle_concat_dot_fragments.mlir
+++ b/third_party/tle/test/GPU/test_tle_concat_dot_fragments.mlir
@@ -1,0 +1,77 @@
+// Copyright 2025-     FlagOS Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files
+// (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software,
+// and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// RUN: triton-opt %s -split-input-file -pass-pipeline='builtin.module(convert-triton-gpu-to-llvm{compute-capability=90})' | FileCheck %s --check-prefix=NOMOVE
+// RUN: triton-opt %s -split-input-file -pass-pipeline='builtin.module(convert-triton-gpu-to-llvm{compute-capability=90})' | FileCheck %s --check-prefix=REGS
+
+// A pure register relabel: concatenating two K=64 dot-operand fragments into one
+// K=128 fragment must move registers and nothing else. The two run lines are
+// separate because CHECK-NOT only holds until the next positive match, so the
+// forbidden ops and the register counts cannot share a prefix.
+
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 16, 16]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // No shared memory, barrier or mma anywhere in the function.
+  // NOMOVE-LABEL: llvm.func @concat_dot_fragments_dot_operand
+  // NOMOVE-NOT: llvm.load
+  // NOMOVE-NOT: llvm.store
+  // NOMOVE-NOT: nvvm.barrier0
+  // NOMOVE-NOT: nvg.wgmma
+  // NOMOVE-NOT: llvm.inline_asm
+  // NOMOVE: llvm.return
+
+  // Every result register is filled from a source register: 128 slots in, 128 out.
+  // REGS-LABEL: llvm.func @concat_dot_fragments_dot_operand
+  // REGS-COUNT-128: llvm.extractvalue
+  // REGS-COUNT-128: llvm.insertvalue
+  // REGS: llvm.return
+  tt.func @concat_dot_fragments_dot_operand(%a0: tensor<128x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>,
+                                %a1: tensor<128x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>) {
+    %merged = tle.concat_dot_fragments %a0, %a1 {dim = 1 : i32} : tensor<128x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>, tensor<128x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> -> tensor<128x128xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+    tt.return
+  }
+}
+
+// -----
+
+// The contraction axis is derived from the rank, so a batched fragment merges
+// along its last dim just the same.
+
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [1, 4, 1], instrShape = [1, 16, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // NOMOVE-LABEL: llvm.func @concat_dot_fragments_batched
+  // NOMOVE-NOT: llvm.load
+  // NOMOVE-NOT: llvm.store
+  // NOMOVE-NOT: nvvm.barrier0
+  // NOMOVE: llvm.return
+
+  // REGS-LABEL: llvm.func @concat_dot_fragments_batched
+  // REGS-COUNT-64: llvm.extractvalue
+  // REGS-COUNT-64: llvm.insertvalue
+  // REGS: llvm.return
+  tt.func @concat_dot_fragments_batched(%a0: tensor<1x128x32xbf16, #dot0>, %a1: tensor<1x128x32xbf16, #dot0>) {
+    %merged = tle.concat_dot_fragments %a0, %a1 {dim = 2 : i32} : tensor<1x128x32xbf16, #dot0>, tensor<1x128x32xbf16, #dot0> -> tensor<1x128x64xbf16, #dot0>
+    tt.return
+  }
+}

--- a/third_party/tle/test/GPU/test_tle_concat_dot_fragments_errors.mlir
+++ b/third_party/tle/test/GPU/test_tle_concat_dot_fragments_errors.mlir
@@ -1,0 +1,120 @@
+// Copyright 2025-     FlagOS Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files
+// (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software,
+// and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// RUN: triton-opt %s -split-input-file -convert-triton-gpu-to-llvm -verify-diagnostics
+
+// Arity and shape are rejected by the verifier; the dot_op specific constraints
+// are rejected when lowering, since operands only pick up their dot_op encoding
+// after layout propagation and a #blocked tile is a legal intermediate state.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @reject_too_few_tiles(%a0: tensor<64x64xf32, #blocked>) {
+    // expected-error @+1 {{concat_dot_fragments requires at least two input tiles}}
+    %m = tle.concat_dot_fragments %a0 {dim = 0 : i32} : tensor<64x64xf32, #blocked> -> tensor<64x64xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @reject_wrong_result_shape(%a0: tensor<64x64xf32, #blocked>, %a1: tensor<64x64xf32, #blocked>) {
+    // Concatenating two 64x64 tiles along dim 1 must produce 64x128; claiming
+    // 64x64 is a shape mismatch.
+    // expected-error @+1 {{result shape mismatch at dimension 1 (expected 128, got 64)}}
+    %m = tle.concat_dot_fragments %a0, %a1 {dim = 1 : i32} : tensor<64x64xf32, #blocked>, tensor<64x64xf32, #blocked> -> tensor<64x64xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @reject_out_of_range_dim(%a0: tensor<64x64xf32, #blocked>, %a1: tensor<64x64xf32, #blocked>) {
+    // expected-error @+1 {{dim 2 out of range for rank 2}}
+    %m = tle.concat_dot_fragments %a0, %a1 {dim = 2 : i32} : tensor<64x64xf32, #blocked>, tensor<64x64xf32, #blocked> -> tensor<64x128xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @reject_non_dot_encoding(%a0: tensor<64x32xf32, #blocked>, %a1: tensor<64x32xf32, #blocked>) {
+    // expected-error @+2 {{expects dot_op encoded operands}}
+    // expected-error @+1 {{failed to legalize operation 'tle.concat_dot_fragments'}}
+    %m = tle.concat_dot_fragments %a0, %a1 {dim = 1 : i32} : tensor<64x32xf32, #blocked>, tensor<64x32xf32, #blocked> -> tensor<64x64xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 16, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @reject_non_contraction_axis(%a0: tensor<128x16xbf16, #dot0>, %a1: tensor<128x16xbf16, #dot0>) {
+    // dim 0 is M for opIdx 0; extending it would change which lane owns an element.
+    // expected-error @+2 {{dim 0 is not the contraction axis (expected 1 for opIdx 0)}}
+    // expected-error @+1 {{failed to legalize operation 'tle.concat_dot_fragments'}}
+    %m = tle.concat_dot_fragments %a0, %a1 {dim = 0 : i32} : tensor<128x16xbf16, #dot0>, tensor<128x16xbf16, #dot0> -> tensor<256x16xbf16, #dot0>
+    tt.return
+  }
+}
+
+// -----
+
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 16, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @reject_tile_below_min_k(%a0: tensor<128x1xbf16, #dot0>, %a1: tensor<128x1xbf16, #dot0>) {
+    // expected-error @+2 {{tile K extent 1 is below the minimum 16 (8 * kWidth)}}
+    // expected-error @+1 {{failed to legalize operation 'tle.concat_dot_fragments'}}
+    %m = tle.concat_dot_fragments %a0, %a1 {dim = 1 : i32} : tensor<128x1xbf16, #dot0>, tensor<128x1xbf16, #dot0> -> tensor<128x2xbf16, #dot0>
+    tt.return
+  }
+}
+
+// -----
+
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 16, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @reject_broadcast_along_indexed_dim(%a0: tensor<8x16xf16, #dot0>, %a1: tensor<8x16xf16, #dot0>) {
+    // With M below the mma M extent the layout broadcasts, so several registers
+    // hold the same element and the index-based relabel would drop some of them.
+    // expected-error @+2 {{maps several registers to the same element}}
+    // expected-error @+1 {{failed to legalize operation 'tle.concat_dot_fragments'}}
+    %m = tle.concat_dot_fragments %a0, %a1 {dim = 1 : i32} : tensor<8x16xf16, #dot0>, tensor<8x16xf16, #dot0> -> tensor<8x32xf16, #dot0>
+    tt.return
+  }
+}

--- a/third_party/tle/triton_tle.cc
+++ b/third_party/tle/triton_tle.cc
@@ -105,6 +105,29 @@ void init_triton_tle_ir(py::module &&m) {
           },
           py::arg("input"), py::arg("tile"), py::arg("index"),
           "Create insert_tile operation")
+      .def(
+          "create_concat_dot_fragments",
+          [](TritonOpBuilder &self, std::vector<Value> &tiles,
+             int32_t dim) -> Value {
+            // Result type inference aborts the process on failure, so reject
+            // the cases it cannot infer here and raise instead.
+            if (tiles.size() < 2)
+              throw std::invalid_argument(
+                  "concat_dot_fragments requires at least two tiles");
+            auto tileTy = dyn_cast<RankedTensorType>(tiles[0].getType());
+            if (!tileTy)
+              throw std::invalid_argument(
+                  "concat_dot_fragments tiles must be ranked tensors");
+            if (dim < 0 || dim >= tileTy.getRank())
+              throw std::invalid_argument(
+                  "concat_dot_fragments dim is out of range for the tile rank");
+            auto &builder = self.getBuilder();
+            auto op = self.create<tle::ConcatDotFragmentsOp>(
+                tiles, builder.getI32IntegerAttr(dim));
+            return op.getResult();
+          },
+          py::arg("tiles"), py::arg("dim"),
+          "Create concat_dot_fragments operation")
       // TLE-Struct
       .def("make_swizzled_shared_encoding_attr",
            [](TritonOpBuilder &self, unsigned vectorSize, unsigned perPhase,


### PR DESCRIPTION
## Background

A quantized MoE kernel dequantizes its weight operand inside the main loop. One `tl.inline_asm_elementwise` unpacks an int32 of packed 4-bit weights into eight bf16 outputs, and because `tl.dot` hides the fragment layout it picks for the mma, the host has no way to learn the lane→element mapping and must pack with a strided permutation to accommodate it. The dequant therefore yields eight K-slices that are contiguous in K but are eight independent tensors, and `tl.dot` accepts a single tensor per operand — so the loop issues one mma per slice and repeats the address computation, the token load and the fence/wait every time.

Assembling the slices in the kernel does not help. `tl.join` + `reshape` produces a blocked layout, which has to be converted back to `dot_op` before it can feed the mma — materializing as a `local_alloc` / `local_load` pair, i.e. a shared-memory round trip of the dequantized weight on every K iteration.

The merge should be free. In the LinearLayout algebra a `dot_op` layout of K=128 is exactly eight K=16 layouts concatenated along K: it adds three register bases (`[0,16]`, `[0,32]`, `[0,64]`) and leaves the lane and warp bases bit-identical, so every element of the wider fragment already lives on the thread that holds it in the slice. What is missing is an op expressing that relabel: `tl.cat` is unordered, and the join/reshape chain changes the layout.

**Motivation**: add a TLE primitive for the K-wise concatenation of dot-operand fragments, so one mma covers the whole K tile — without touching host packing or the dequant asm.

## Design

### `tle.concat_dot_fragments(tiles, dim)`

Takes N same-encoding dot-operand fragments and returns their concatenation along `dim`, lowering to a per-thread register gather: for each result register slot the authoritative `LinearLayout` of result and tile tells which `(tile, tile-register-slot)` feeds it, and that register is copied over. No shared memory, no cross-lane traffic, no extra instruction. The hardware still issues the same number of mma instructions; what goes away is the per-segment overhead.

The op is wired through all three layers a user-visible TLE op needs: ODS definition and verifier, a TT→TTG legalization pattern (Triton-level tensors carry no layout encoding, so the result inherits `tiles[0]`'s once TTG assigns one), and the TTG→LLVM lowering. Unlike `extract_tile`, the lowering does not use CTA-tile index arithmetic — that only handles `BlockedEncoding` — but goes through `LinearLayout`, which covers dot-operand encodings.

### Reaching through the op during layout propagation

For the relabel to pay off, the `dot_op` encoding has to reach the dequant through the op; otherwise the operand stays `#blocked` and the round trip returns. The gate is the `noDataMovement` allowlist in `hoistConvertDotOperand`, which treats any op outside it as a leaf of the backward slice — before `inferSrcEncoding` is ever consulted — so the new op is added there.

The accompanying `inferSrcEncoding` / `inferDstEncoding` overloads propagate `DotOperandEncodingAttr` **only**: it carries no K extent and can be shared unchanged between a slice and the merged result, whereas shape-coupled encodings like blocked would yield the wrong per-thread element count. Those return empty and take the generic shared-memory conversion path.

### Constraints, split by what breaks when violated

The relabel derives its register mapping on lane 0 and applies it to every thread. Violating that premise produces silently wrong registers rather than an error, so each premise is checked explicitly.

The **verifier** checks what the types alone determine: at least two tiles, tiles agreeing in shape/dtype/encoding, `dim` in range, and the result matching the tiles in every dim except `dim`, which grows by N.

The **lowering** checks the dot_op specific premises, which cannot live in the verifier: operands only pick up their `dot_op` encoding after layout propagation, so until then a `#blocked` tile is a legal intermediate state.

| Checked when lowering | Why |
|---|---|
| encoding is `dot_op` | other layouts place lanes differently as `dim` grows |
| `dim` is the contraction axis for the operand's `opIdx` | extending M or N changes which lane owns an element |
| tile spans at least `8 * kWidth` along `dim` | below that the layout stops scaling with K, so the tile is not a K-slice of the wider fragment |
| tile and result agree on lane/warp/block bases | otherwise the lane-0 mapping cannot be applied to other threads |
| neither broadcasts along an indexed dim | a broadcast maps several registers to one element, and the reverse lookup would drop some and duplicate others |

Two further conditions need no code: non-power-of-2 tile counts are already rejected by the upstream TTG layout verifier with an accurate diagnostic, and a bijective mapping cannot be required because `dot_op` layouts are inherently broadcast — `broadcastedDotOperandLayout` uses `zeros1D` for lane and warp along K so the A operand can be shared across warps.

Whether the merge is also *profitable* is left to the caller. Canonical register-base order, `local_alloc` count, surviving `convert_layout` and whether the merged mma was split back along K are all per-(shape, config) properties that the op cannot judge, and none of them breaks correctness — the compiler has a legal fallback. Asserting on them would turn "runs but slower" into "does not run".

## Test

- `test_tle_concat_dot_fragments.mlir` — the lowering emits `extractvalue`/`insertvalue` only: 128 in, 128 out for a 2×K=64 merge, and no load, store, barrier or mma anywhere in the function. Covers a batched (rank-3) fragment too.
- `test_tle_concat_dot_fragments_errors.mlir` — seven negative cases, covering the verifier's arity/shape/dim checks and the lowering's encoding, contraction-axis, minimum-K and broadcast checks.
- `test_concat_dot_fragments.py` — on GPU, a merged dot is compared against accumulating one dot per K segment and is bit-identical; a second test reads the emitted TTGIR to confirm the concat kept its `dot_op` encoding and that exactly one mma was issued.

## Performance

Hardware **H20-3e**, bf16, CUDA Graph ON, `return_mode=median`, `USE_FLAGTUNE=0`. Consumer is the FlagGems MXFP4 fused-Marlin-MoE kernel (`fused_marlin_moe.py`, gated by `FLAGGEMS_MXFP4_USE_CONCAT_TILE`); baseline is the same kernel issuing one mma per K segment. `speedup = T_vLLM(Marlin) / T_Gems`.

Shapes: 53 deduped shapes from a real DeepSeek-V4-Flash inference trace, geometry `(M, E=256, H=4096, I=256, top_k=6)`, `M ∈ [1, 16384]`. Both sides autotune independently with the persistent config DB cleared beforehand.

| | segmented | merged |
|---|---|---|
| Average speedup | 1.062 | **1.168** |
| Call-weighted speedup | 1.110 | **1.208** |

Latency improves on **53/53 shapes**, +2.53% to +15.72% (mean +9.33%), no regression. By regime: decode (`M ≤ 128`, 19 shapes) +10.17%, mid (`128 < M ≤ 512`, 32 shapes) +9.00%, prefill (`M > 512`) +6.75%.

The weight GEMM merges 8 segments into one mma and the SiLU-fused gate/up GEMM merges 16 into two. TTGIR at M=256 confirms where the time goes: the per-segment 16-wide activation buffers collapse into one 128-wide buffer (`local_alloc` 8→1, 13→6 in total), and the address computation and async copies that were duplicated per segment drop by roughly half (`async_copy_global_to_local` 65→30, `tt.addptr` 78→41). The dequant inline asm is byte-identical on both sides — the merge does not touch it.

The primitive sits between the dequant output and the mma and is independent of the mma variant, so both autotuner winners benefit — MMAv2 (`tt.dot`) and wgmma (`ttng.warp_group_dot`) alike.