### PR TITLE
[CI] Add cleanup-flagtree-env action

### DIFF
--- a/.github/actions/cleanup-flagtree-env/action.yml
+++ b/.github/actions/cleanup-flagtree-env/action.yml
@@ -1,0 +1,77 @@
+# Copyright 2025-     FlagOS Contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: 'Cleanup FlagTree Environment'
+description: 'Purge previous FlagTree installations to ensure a fresh build'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Purge previous FlagTree installations
+      shell: bash
+      run: |
+        set -x
+        echo "Starting environment cleanup..."
+
+        SITE_PACKAGES=$(python3 -c "import sysconfig; print(sysconfig.get_path('purelib'))")
+
+        # 1. Normalize the path to resolve symlinks and eliminate '..'
+        SITE_PACKAGES=$(realpath -m "$SITE_PACKAGES" 2>/dev/null || readlink -f "$SITE_PACKAGES" 2>/dev/null || echo "$SITE_PACKAGES")
+
+        # 2. Reject if the path still contains '..' after normalization
+        if [[ "$SITE_PACKAGES" == *".."* ]]; then
+            echo "Error: Path contains '..' after normalization. Aborting."
+            exit 1
+        fi
+
+        # 3. Ensure it is a real, existing directory
+        if [[ ! -d "$SITE_PACKAGES" ]]; then
+            echo "Error: Directory '$SITE_PACKAGES' does not exist. Aborting."
+            exit 1
+        fi
+
+        # 4. Ensure it is an absolute path located in a standard Python directory
+        # Check if it contains 'site-packages' or 'dist-packages' as the directory name
+        if [[ ! "$SITE_PACKAGES" =~ ^/.*/python[^/]*/(site|dist)-packages/?$ ]]; then
+            echo "Error: '$SITE_PACKAGES' is not a recognized Python package directory. Aborting."
+            exit 1
+        fi
+
+        # 5. Reject overly broad or critical system directories
+        if [[ "$SITE_PACKAGES" == "/" ]] ||
+            [[ "$SITE_PACKAGES" == "/root" ]] ||
+            [[ "$SITE_PACKAGES" == "/home" ]] ||
+            [[ "$SITE_PACKAGES" == "/usr" ]] ||
+            [[ "$SITE_PACKAGES" == "/usr/lib" ]]; then
+            echo "Error: Path '$SITE_PACKAGES' is too broad. Aborting."
+            exit 1
+        fi
+
+        # 1. Attempt to gracefully uninstall via pip
+        python3 -m pip uninstall -y flagtree --break-system-packages || true
+
+        # 2. Remove temporary directories left by interrupted pip processes
+        rm -rf "$SITE_PACKAGES"/~* || true
+
+        # 3. Force remove any remaining metadata and code directories
+        rm -rf "$SITE_PACKAGES"/flagtree*dist-info || true
+        rm -rf "$SITE_PACKAGES"/triton || true
+
+        echo "Environment cleanup completed."


### PR DESCRIPTION
Create a new composite action `cleanup-flagtree-env` to thoroughly purge previous FlagTree installations.
This ensures a pristine environment before build step, primarily resolving build failures caused by residual files when a previous installation is unexpectedly interrupted.

<!-- PR Title Format:
[TLE][BUILD][TEST][CI/CD][DOC][PROTON][BACKEND][FLIR] Brief description
[LANGUAGE][AUTOTUNER][LAYOUT][PIPELINE][WarpSpecialization] Brief description
Do not set the following title tags: [FEATURE][BUG][FixBug][Refine] ...
-->
