### PR TITLE
[CI] Optimize workflow with env cleanup and build timeout

### DIFF
--- a/.github/workflows/enflame3.6-gcu300-build-and-test.yml
+++ b/.github/workflows/enflame3.6-gcu300-build-and-test.yml
@@ -56,6 +56,10 @@ jobs:
         with:
           backend: enflame
 
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
+
       - name: Detect Target Branch
         shell: bash
         run: |
@@ -70,6 +74,7 @@ jobs:
 
       - name: Build FlagTree
         if: ${{ steps.check_backend.outputs.should_skip != 'true' }}
+        timeout-minutes: 60
         shell: bash
         run: |
           set -x

--- a/.github/workflows/enflame3.6-gcu400-build-and-test.yml
+++ b/.github/workflows/enflame3.6-gcu400-build-and-test.yml
@@ -56,6 +56,10 @@ jobs:
         with:
           backend: enflame
 
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
+
       - name: Detect Target Branch
         shell: bash
         run: |
@@ -70,6 +74,7 @@ jobs:
 
       - name: Build FlagTree
         if: ${{ steps.check_backend.outputs.should_skip != 'true' }}
+        timeout-minutes: 60
         shell: bash
         run: |
           set -x

--- a/.github/workflows/flagcicd-nv3.6-build-and-test.yml
+++ b/.github/workflows/flagcicd-nv3.6-build-and-test.yml
@@ -66,6 +66,10 @@ jobs:
         with:
           backend: nvidia
 
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
+
       - name: Detect Target Branch
         shell: bash
         run: |
@@ -81,6 +85,7 @@ jobs:
 
       - name: Build FlagTree
         if: ${{ steps.check_backend.outputs.should_skip != 'true' }}
+        timeout-minutes: 20
         shell: bash
         run: |
           set -x

--- a/.github/workflows/hcu3.6-build-and-test.yml
+++ b/.github/workflows/hcu3.6-build-and-test.yml
@@ -56,8 +56,13 @@ jobs:
         with:
           backend: hcu
 
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
+
       - name: Build FlagTree
         if: steps.check_backend.outputs.should_skip != 'true'
+        timeout-minutes: 20
         shell: bash
         run: |
           set -x

--- a/.github/workflows/iluvatar3.6-build-and-test.yml
+++ b/.github/workflows/iluvatar3.6-build-and-test.yml
@@ -56,8 +56,13 @@ jobs:
         with:
           backend: iluvatar
 
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
+
       - name: Build FlagTree
         if: steps.check_backend.outputs.should_skip != 'true'
+        timeout-minutes: 20
         shell: bash
         run: |
           set -x

--- a/.github/workflows/metax3.6-build-and-test.yml
+++ b/.github/workflows/metax3.6-build-and-test.yml
@@ -56,8 +56,13 @@ jobs:
         with:
           backend: metax
 
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
+
       - name: Build FlagTree
         if: steps.check_backend.outputs.should_skip != 'true'
+        timeout-minutes: 20
         shell: bash
         run: |
           set -x

--- a/.github/workflows/mthreads3.6-build-and-test.yml
+++ b/.github/workflows/mthreads3.6-build-and-test.yml
@@ -56,8 +56,13 @@ jobs:
         with:
           backend: mthreads
 
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
+
       - name: Build FlagTree
         if: steps.check_backend.outputs.should_skip != 'true'
+        timeout-minutes: 20
         shell: bash
         run: |
           set -x

--- a/.github/workflows/nv3.6-build-and-test.yml
+++ b/.github/workflows/nv3.6-build-and-test.yml
@@ -58,6 +58,10 @@ jobs:
         with:
           backend: nvidia
 
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
+
       - name: Detect Target Branch
         shell: bash
         run: |
@@ -72,6 +76,7 @@ jobs:
 
       - name: Build FlagTree
         if: ${{ steps.check_backend.outputs.should_skip != 'true' }}
+        timeout-minutes: 20
         shell: bash
         run: |
           set -x

--- a/.github/workflows/nv3.6-qwen-benchmark.yaml
+++ b/.github/workflows/nv3.6-qwen-benchmark.yaml
@@ -56,8 +56,13 @@ jobs:
         with:
           backend: nvidia
 
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
+
       - name: Build FlagTree
         if: ${{ steps.check_backend.outputs.should_skip != 'true' }}
+        timeout-minutes: 20
         shell: bash
         run: |
           set -x

--- a/.github/workflows/rpu3.6-build-and-test.yml
+++ b/.github/workflows/rpu3.6-build-and-test.yml
@@ -123,6 +123,7 @@ jobs:
 
       - name: Clear cache if ClearCache label present
         if: steps.check_backend.outputs.should_skip != 'true'
+        timeout-minutes: 20
         id: clear_cache
         uses: flagos-ai/FlagTree/.github/actions/clear-cache-if-labeled@main
         with:

--- a/.github/workflows/sunrise-build-and-test.yml
+++ b/.github/workflows/sunrise-build-and-test.yml
@@ -56,8 +56,13 @@ jobs:
         with:
           backend: sunrise
 
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
+
       - name: Build FlagTree
         if: steps.check_backend.outputs.should_skip != 'true'
+        timeout-minutes: 20
         shell: bash
         run: |
           set -x

--- a/.github/workflows/thrive3.6-build-and-test.yml
+++ b/.github/workflows/thrive3.6-build-and-test.yml
@@ -50,8 +50,13 @@ jobs:
         with:
           backend: thrive
 
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
+
       - name: Build FlagTree
         if: steps.check_backend.outputs.should_skip != 'true'
+        timeout-minutes: 20
         shell: bash
         run: |
           set -x

--- a/.github/workflows/tileir3.6-build-and-test.yml
+++ b/.github/workflows/tileir3.6-build-and-test.yml
@@ -56,8 +56,13 @@ jobs:
         with:
           backend: tileir
 
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
+
       - name: Build FlagTree
         if: steps.check_backend.outputs.should_skip != 'true'
+        timeout-minutes: 20
         shell: bash
         run: |
           set -x

--- a/.github/workflows/xpu3.6-build-and-test.yml
+++ b/.github/workflows/xpu3.6-build-and-test.yml
@@ -56,8 +56,13 @@ jobs:
         with:
           backend: xpu
 
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
+
       - name: Build FlagTree
         if: steps.check_backend.outputs.should_skip != 'true'
+        timeout-minutes: 20
         shell: bash
         run: |
           set -x


### PR DESCRIPTION
- Add 'Cleanup FlagTree Environment' step to ensure a clean state
- Set timeout-minutes for the 'Build FlagTree' step

<!-- PR Title Format:
[TLE][BUILD][TEST][CI/CD][DOC][PROTON][BACKEND][FLIR] Brief description
[LANGUAGE][AUTOTUNER][LAYOUT][PIPELINE][WarpSpecialization] Brief description
Do not set the following title tags: [FEATURE][BUG][FixBug][Refine] ...
-->
