### PR TITLE
[CI] Optimize CI trigger conditions

### DIFF
--- a/.github/workflows/mthreads3.6-build-and-test.yml
+++ b/.github/workflows/mthreads3.6-build-and-test.yml
@@ -38,8 +38,7 @@ concurrency:
 jobs:
   mthreads36x-unit-test:
     runs-on: mthreads3.6
-    if: ${{ (github.repository == 'FlagTree/flagtree' || github.repository == 'flagos-ai/flagtree') &&
-              github.event.pull_request.draft == false }}
+    if: ${{ github.repository == 'flagos-ai/flagtree' && github.event.pull_request.draft == false }}
     steps:
       - name: Setup environment
         shell: bash

--- a/.github/workflows/mthreads3.6-build-and-test.yml
+++ b/.github/workflows/mthreads3.6-build-and-test.yml
@@ -25,6 +25,7 @@ on:
     branches: [ "main", "triton_v3.6.x" ]
   pull_request:
     branches: [ "main", "triton_v3.6.x" ]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -37,7 +38,8 @@ concurrency:
 jobs:
   mthreads36x-unit-test:
     runs-on: mthreads3.6
-    if: ${{ github.repository == 'FlagTree/flagtree' || github.repository == 'flagos-ai/flagtree' }}
+    if: ${{ (github.repository == 'FlagTree/flagtree' || github.repository == 'flagos-ai/flagtree') &&
+              github.event.pull_request.draft == false }}
     steps:
       - name: Setup environment
         shell: bash


### PR DESCRIPTION
Skip CI execution when PR is in draft state.
Add 'ready_for_review' to pull_request types,
ensuring CI runs when draft is converted to open.

<!-- PR Title Format:
[TLE][BUILD][TEST][CI/CD][DOC][PROTON][BACKEND][FLIR] Brief description
[LANGUAGE][AUTOTUNER][LAYOUT][PIPELINE][WarpSpecialization] Brief description
Do not set the following title tags: [FEATURE][BUG][FixBug][Refine] ...
-->
