### PR TITLE
[CI] Remove '*.txt' from DOC label rules

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -71,7 +71,6 @@ DOC:
   - changed-files:
       - any-glob-to-any-file:
           - '**/*.md'
-          - '**/*.txt'
           - '**/*.rst'
           - '**/*.png'
           - '**/*.jpg'


### PR DESCRIPTION
<!-- PR Title Format:
[TLE][BUILD][TEST][CI/CD][DOC][PROTON][BACKEND][FLIR] Brief description
[LANGUAGE][AUTOTUNER][LAYOUT][PIPELINE][WarpSpecialization] Brief description
Do not set the following title tags: [FEATURE][BUG][FixBug][Refine] ...
-->
