### PR TITLE
[CI] Optimize workflow triggers, permissions, and environment control

### DIFF
--- a/.github/workflows/code-format-check.yml
+++ b/.github/workflows/code-format-check.yml
@@ -7,6 +7,7 @@ on:
     branches: [ "main", "triton_v3.2.x", "triton_v3.3.x", "triton_v3.4.x", "triton_v3.5.x"]
   pull_request:
     branches: [ "main", "triton_v3.2.x", "triton_v3.3.x", "triton_v3.4.x", "triton_v3.5.x"]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/nv3.4-build-and-test.yml
+++ b/.github/workflows/nv3.4-build-and-test.yml
@@ -7,6 +7,11 @@ on:
     branches: [ "triton_v3.4.x" ]
   pull_request:
     branches: [ "triton_v3.4.x" ]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -15,7 +20,7 @@ concurrency:
 jobs:
   nv-34x-unit-test:
     runs-on: nvidia3.5
-    if: ${{ github.repository == 'FlagTree/flagtree' || github.repository == 'flagos-ai/flagtree' }}
+    if: ${{ github.repository == 'flagos-ai/flagtree' && github.event.pull_request.draft == false }}
     steps:
       - name: Setup environment
         shell: bash
@@ -33,6 +38,10 @@ jobs:
         uses: flagos-ai/FlagTree/.github/actions/check-backend-changed@main
         with:
           backend: nvidia
+
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
 
       - name: Detect Target Branch
         shell: bash
@@ -54,6 +63,14 @@ jobs:
           pip uninstall -y triton
           source ~/env-3.4.sh
           MAX_JOBS=32 python3.12 -m pip install . --no-build-isolation
+
+      - name: Clear cache if ClearCache label present
+        if: steps.check_backend.outputs.should_skip != 'true'
+        id: clear_cache
+        uses: flagos-ai/FlagTree/.github/actions/clear-cache-if-labeled@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          backend: nvidia
 
       - name: Unit Test
         if: steps.check_backend.outputs.should_skip != 'true'

--- a/.github/workflows/sunrise-build-and-test.yml
+++ b/.github/workflows/sunrise-build-and-test.yml
@@ -5,6 +5,11 @@ on:
     branches: [ "triton_v3.4.x" ]
   pull_request:
     branches: [ "triton_v3.4.x" ]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -13,7 +18,7 @@ concurrency:
 jobs:
   sunrise-build-and-test:
     runs-on: flagtree-sunrise
-    if: ${{ github.repository == 'FlagTree/flagtree' || github.repository == 'flagos-ai/flagtree' }}
+    if: ${{ github.repository == 'flagos-ai/flagtree' && github.event.pull_request.draft == false }}
     steps:
       - name: Setup environment
         shell: bash
@@ -32,6 +37,10 @@ jobs:
         with:
           backend: sunrise
 
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
+
       - name: FlagTree Build on Sunrise
         if: steps.check_backend.outputs.should_skip != 'true'
         shell: bash
@@ -43,6 +52,14 @@ jobs:
           export TRITON_BUILD_PROTON=OFF
           export FLAGTREE_BACKEND=sunrise
           MAX_JOBS=32 python3 -m pip install . --no-build-isolation
+
+      - name: Clear cache if ClearCache label present
+        if: steps.check_backend.outputs.should_skip != 'true'
+        id: clear_cache
+        uses: flagos-ai/FlagTree/.github/actions/clear-cache-if-labeled@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          backend: sunrise
 
       - name: FlagTree Test on Sunrise
         if: steps.check_backend.outputs.should_skip != 'true'


### PR DESCRIPTION
- Refine CI triggers: skip CI for Draft PRs, but trigger tests when transitioning to ready_for_review.
- Add read permissions for `contents` and `pull-requests`.
- Add environment cleanup step before FlagTree build.
- Add conditional cache clearing step based on `ClearCache:<backend>` label before testing.

<!-- PR Title Format:
[TLE][BUILD][TEST][CI/CD][DOC][PROTON][BACKEND][FLIR] Brief description
[LANGUAGE][AUTOTUNER][LAYOUT][PIPELINE][WarpSpecialization] Brief description
Do not set the following title tags: [FEATURE][BUG][FixBug][Refine] ...
-->
