### PR TITLE
[TLE][AMD] Add AMD tile and cumsum lowering

### DIFF
--- a/cmake/FlagTreeOptions.cmake
+++ b/cmake/FlagTreeOptions.cmake
@@ -468,6 +468,7 @@ function(flagtree_add_tle_generated_header_dependencies)
   # parallel build can compile those libraries before the generated .inc files.
   foreach(_flagtree_tle_header_target IN ITEMS
       TritonAnalysis
+      TritonAMDAnalysis
       TritonToTritonGPU
       TritonGPUTransforms
       TritonNvidiaGPUTransforms

--- a/python/test/tle/unit/test_tle_cumsum.py
+++ b/python/test/tle/unit/test_tle_cumsum.py
@@ -10,6 +10,8 @@ import torch
 import triton
 import triton.language as tl
 import triton.experimental.tle.language as tle
+from triton._flagtree_backend import FLAGTREE_BACKEND
+from triton._internal_testing import get_current_target, is_cuda, is_hip
 
 
 def _is_enflame_backend():
@@ -18,32 +20,15 @@ def _is_enflame_backend():
 
 
 def _is_hcu_backend():
-    try:
-        driver = triton.runtime.driver.active
-        return type(driver).__module__.startswith("triton.backends.hcu")
-    except Exception:
-        return False
+    return FLAGTREE_BACKEND == "hcu"
 
 
 _nv_mma_shared_layout = tl.constexpr(False if _is_hcu_backend() else True)
-threads_per_warp = 64 if _is_hcu_backend() else 32
-
-
-def _is_nvidia_cuda_backend():
-    try:
-        driver = triton.runtime.driver.active
-        target = driver.get_current_target()
-        return (target.backend == "cuda" and type(driver).__module__.startswith("triton.backends.nvidia"))
-    except Exception:
-        return False
+threads_per_warp = get_current_target().warp_size if is_hip() else 32
 
 
 def _is_amd_hip_backend():
-    try:
-        driver = triton.runtime.driver.active
-        return type(driver).__module__.startswith("triton.backends.amd")
-    except Exception:
-        return False
+    return is_hip() and not FLAGTREE_BACKEND
 
 
 def _require_cuda():
@@ -223,7 +208,7 @@ def test_tle_cumsum_exclusive_and_total(dtype, n, block, reverse, num_warps):
 
 
 @pytest.mark.skipif(
-    not _is_nvidia_cuda_backend(),
+    not is_cuda(),
     reason="PTX-specific regression guard requires NVIDIA CUDA backend",
 )
 def test_tle_cumsum_ptx_fastpath_regression_guard():

--- a/python/test/tle/unit/test_tle_cumsum.py
+++ b/python/test/tle/unit/test_tle_cumsum.py
@@ -10,7 +10,6 @@ import torch
 import triton
 import triton.language as tl
 import triton.experimental.tle.language as tle
-from triton._flagtree_backend import FLAGTREE_BACKEND
 
 
 def _is_enflame_backend():
@@ -19,12 +18,32 @@ def _is_enflame_backend():
 
 
 def _is_hcu_backend():
-    target = triton.runtime.driver.active.get_current_target()
-    return target.backend == "hip"
+    try:
+        driver = triton.runtime.driver.active
+        return type(driver).__module__.startswith("triton.backends.hcu")
+    except Exception:
+        return False
 
 
 _nv_mma_shared_layout = tl.constexpr(False if _is_hcu_backend() else True)
 threads_per_warp = 64 if _is_hcu_backend() else 32
+
+
+def _is_nvidia_cuda_backend():
+    try:
+        driver = triton.runtime.driver.active
+        target = driver.get_current_target()
+        return (target.backend == "cuda" and type(driver).__module__.startswith("triton.backends.nvidia"))
+    except Exception:
+        return False
+
+
+def _is_amd_hip_backend():
+    try:
+        driver = triton.runtime.driver.active
+        return type(driver).__module__.startswith("triton.backends.amd")
+    except Exception:
+        return False
 
 
 def _require_cuda():
@@ -203,9 +222,10 @@ def test_tle_cumsum_exclusive_and_total(dtype, n, block, reverse, num_warps):
         torch.testing.assert_close(total[0], expected_total)
 
 
-@pytest.mark.skipif(_is_enflame_backend(), reason="PTX-specific regression guard not applicable on Enflame GCU")
-@pytest.mark.skipif(_is_hcu_backend(), reason="PTX-specific regression guard not applicable on HCU")
-@pytest.mark.skipif(FLAGTREE_BACKEND == "ppu", reason="PTX-specific regression guard not applicable on PPU")
+@pytest.mark.skipif(
+    not _is_nvidia_cuda_backend(),
+    reason="PTX-specific regression guard requires NVIDIA CUDA backend",
+)
 def test_tle_cumsum_ptx_fastpath_regression_guard():
     block = 512
     x = torch.randint(-1024, 1024, (block, ), device="cuda", dtype=torch.int32)
@@ -275,6 +295,7 @@ def test_tle_cumsum_amdgcn_fastpath_regression_guard():
         "Detected predicated ds_write: possible regression to generic path"
 
 
+@pytest.mark.skipif(_is_amd_hip_backend(), reason="requires AMD local-pointer lowering")
 def test_tle_cumsum_helper_preserves_adjacent_sentinel():
     block = 512
     num_warps = block // threads_per_warp
@@ -296,6 +317,7 @@ def test_tle_cumsum_helper_preserves_adjacent_sentinel():
     torch.testing.assert_close(sentinel, expected_sentinel)
 
 
+@pytest.mark.skipif(_is_amd_hip_backend(), reason="requires AMD local-pointer lowering")
 def test_tle_cumsum_scalar_base_addptr_alias_regression():
     block = 512
     num_warps = block // threads_per_warp

--- a/test/Conversion/amd/tle_tile_ops_to_llvm.mlir
+++ b/test/Conversion/amd/tle_tile_ops_to_llvm.mlir
@@ -1,0 +1,69 @@
+// Copyright 2025-     FlagOS Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files
+// (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software,
+// and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// RUN: triton-opt %s -split-input-file --allocate-amdgpu-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx1201 --convert-builtin-func-to-llvm | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1201", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func @extract_tile_smem
+  // CHECK: rocdl.workitem.id.x
+  // CHECK-COUNT-2: rocdl.barrier
+  // CHECK-NOT: tle.extract_tile
+  // CHECK-NOT: nvvm.barrier
+  tt.func @extract_tile_smem(%src: tensor<32x32xf32, #blocked>, %idx: i32) {
+    %tile = tle.extract_tile %src[%idx] {tile_shape = array<i64: 16, 16>} : tensor<32x32xf32, #blocked>, i32 -> tensor<16x16xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1201", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func @insert_tile_smem
+  // CHECK: rocdl.workitem.id.x
+  // CHECK-COUNT-2: rocdl.barrier
+  // CHECK-NOT: tle.insert_tile
+  // CHECK-NOT: nvvm.barrier
+  tt.func @insert_tile_smem(%src: tensor<32x32xf32, #blocked>, %tile: tensor<16x16xf32, #blocked>, %idx: i32) {
+    %result = tle.insert_tile %src[%idx] = %tile {tile_shape = array<i64: 16, 16>} : tensor<32x32xf32, #blocked>, i32, tensor<16x16xf32, #blocked> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1201", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func @exclusive_cumsum
+  // CHECK-COUNT-6: rocdl.ds_bpermute
+  // CHECK-COUNT-2: rocdl.barrier
+  // CHECK-NOT: tle.exclusive_cumsum
+  // CHECK-NOT: nvvm.shfl
+  tt.func public @exclusive_cumsum(%arg0: tensor<128xi32, #blocked>, %out: !tt.ptr<i32>) {
+    %exclusive, %total = "tle.exclusive_cumsum"(%arg0) {axis = 0 : i32, reverse = false} : (tensor<128xi32, #blocked>) -> (tensor<128xi32, #blocked>, i32)
+    tt.store %out, %total : !tt.ptr<i32>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/Analysis/AMDGPUAllocation.cpp
+++ b/third_party/amd/lib/Analysis/AMDGPUAllocation.cpp
@@ -6,6 +6,11 @@
 
 #include "third_party/amd/include/Dialect/TritonAMDGPU/Utility/CommonUtils.h"
 
+#ifdef __TLE__
+#include "tle/dialect/include/IR/Dialect.h"
+#include <limits>
+#endif
+
 namespace mlir::triton::AMD {
 
 // Max shmem instruction in bits
@@ -138,6 +143,43 @@ unsigned AMDAllocationAnalysisScratchSizeFn(Operation *op) {
     return getConvertLayoutScratchInBytes(srcTy, dstTy,
                                           op->hasAttr(AttrSharedMemPadded));
   }
+
+#ifdef __TLE__
+  // Tile-level extension (TLE) ops stage data through shared memory; register
+  // their scratch sizes so attachAllocationSizeAndOffsetAttr assigns an
+  // allocation.offset (mirrors the NVIDIA scratch-size function).
+  if (auto cumsumOp = dyn_cast<mlir::triton::tle::ExclusiveCumsumOp>(op)) {
+    auto srcTy = dyn_cast<RankedTensorType>(cumsumOp.getSrc().getType());
+    if (!srcTy || srcTy.getRank() != 1)
+      return 0;
+    int64_t axisExtent = srcTy.getShape()[0];
+    if (ShapedType::isDynamic(axisExtent) || axisExtent <= 0)
+      return 0;
+    unsigned elemBytes =
+        static_cast<unsigned>(std::max<int>(1, getBitwidth(srcTy) / 8));
+    int64_t numWarps = std::max<int64_t>(1, triton::gpu::lookupNumWarps(op));
+    uint64_t totalBytes = (static_cast<uint64_t>(axisExtent) +
+                           static_cast<uint64_t>(numWarps) + 1ull) *
+                          elemBytes;
+    if (totalBytes > std::numeric_limits<unsigned>::max())
+      return 0;
+    return static_cast<unsigned>(totalBytes);
+  }
+  if (auto extractTileOp = dyn_cast<mlir::triton::tle::ExtractTileOp>(op)) {
+    auto dstTy = dyn_cast<RankedTensorType>(extractTileOp.getType());
+    if (!dstTy)
+      return 0;
+    return static_cast<unsigned>(dstTy.getNumElements() *
+                                 (getBitwidth(dstTy) / 8));
+  }
+  if (auto insertTileOp = dyn_cast<mlir::triton::tle::InsertTileOp>(op)) {
+    auto tileTy = dyn_cast<RankedTensorType>(insertTileOp.getTile().getType());
+    if (!tileTy)
+      return 0;
+    return static_cast<unsigned>(tileTy.getNumElements() *
+                                 (getBitwidth(tileTy) / 8));
+  }
+#endif
 
   return defaultAllocationAnalysisScratchSizeFn(op);
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
@@ -1,3 +1,14 @@
+if(FLAGTREE_TLE)
+    set(_TLE_LIBS
+        TritonTLEAnalysis
+        TritonNVIDIAGPUToLLVM
+        TleToLLVM
+        TritonTLETransforms
+    )
+else()
+    set(_TLE_LIBS "")
+endif()
+
 add_triton_library(TritonAMDGPUToLLVM
     AsyncUtility.cpp
     AtomicRMWOpsEmitter.cpp
@@ -40,4 +51,5 @@ add_triton_library(TritonAMDGPUToLLVM
     LLVMCore
     LLVMPasses
     LLVMSupport
+    ${_TLE_LIBS}
 )

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -27,6 +27,12 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
+#ifdef __TLE__
+#include "tle/dialect/include/Conversion/TleToLLVM/ExclusiveCumsumOpToLLVM.h"
+#include "tle/dialect/include/IR/Dialect.h"
+#include "tle/dialect/include/Transforms/PatternTleToLLVM.h"
+#endif
+
 namespace mlir::triton {
 #define GEN_PASS_DEF_CONVERTTRITONAMDGPUTOLLVM
 #include "TritonAMDGPUToLLVM/Passes.h.inc"
@@ -62,6 +68,25 @@ public:
     addLegalOp<triton::amdgpu::InstructionSchedHint>();
   }
 };
+
+#ifdef __TLE__
+// Conversion target for the dedicated TLE-to-LLVM partial conversion. Only
+// the tile-level extension ops that have AMD lowering patterns are illegal
+// (must be converted); every other op (including unsupported TLE ops) stays
+// legal and is reported later by the make_llir residual-op guard.
+class TleLLVMConversionTarget : public ConversionTarget {
+public:
+  explicit TleLLVMConversionTarget(MLIRContext &ctx) : ConversionTarget(ctx) {
+    addLegalDialect<LLVM::LLVMDialect, ROCDL::ROCDLDialect,
+                    NVVM::NVVMDialect>();
+    addIllegalOp<mlir::triton::tle::ExtractTileOp,
+                 mlir::triton::tle::InsertTileOp,
+                 mlir::triton::tle::ExclusiveCumsumOp>();
+    addLegalOp<mlir::UnrealizedConversionCastOp>();
+    markUnknownOpDynamicallyLegal([](Operation *) -> bool { return true; });
+  }
+};
+#endif
 
 class TritonAMDGPUToLLVMTypeConverter : public TritonGPUToLLVMTypeConverter {
 public:
@@ -176,6 +201,28 @@ struct ConvertTritonAMDGPUToLLVM
     // Make benefit for AMD specific patterns higher so they apply before common
     // patterns
     int AMDBenefit = commonBenefit + 1;
+
+#ifdef __TLE__
+    // Lower the supported tile-level extension (TLE) ops (extract_tile /
+    // insert_tile / exclusive_cumsum) to LLVM via the backend-agnostic
+    // conversion patterns, in a dedicated partial conversion (mirrors the
+    // NVIDIA / HCU path). Unsupported TLE ops remain legal in this focused
+    // conversion.
+    {
+      TleLLVMConversionTarget tleTarget(*context);
+      RewritePatternSet tlePatterns(context);
+      mlir::triton::tle::populateExtractTileOpToLLVMPatterns(
+          typeConverter, tlePatterns, targetInfo, commonBenefit);
+      mlir::triton::tle::populateInsertTileOpToLLVMPatterns(
+          typeConverter, tlePatterns, targetInfo, commonBenefit);
+      mlir::triton::tle::populateExclusiveCumsumOpToLLVMPatterns(
+          typeConverter, targetInfo, tlePatterns, commonBenefit);
+      if (failed(
+              applyPartialConversion(mod, tleTarget, std::move(tlePatterns))))
+        return signalPassFailure();
+    }
+#endif
+
     auto populatePatterns1 = [&](auto populateFunc, int benefit) {
       populateFunc(typeConverter, patterns, axisInfoAnalysis, allocation,
                    benefit);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -70,18 +70,13 @@ public:
 };
 
 #ifdef __TLE__
-// Conversion target for the dedicated TLE-to-LLVM partial conversion. Only
-// the tile-level extension ops that have AMD lowering patterns are illegal
-// (must be converted); every other op (including unsupported TLE ops) stays
-// legal and is reported later by the make_llir residual-op guard.
+// Reject unsupported TLE operations and accidental CUDA lowering in the
+// dedicated AMD TLE-to-LLVM partial conversion.
 class TleLLVMConversionTarget : public ConversionTarget {
 public:
   explicit TleLLVMConversionTarget(MLIRContext &ctx) : ConversionTarget(ctx) {
-    addLegalDialect<LLVM::LLVMDialect, ROCDL::ROCDLDialect,
-                    NVVM::NVVMDialect>();
-    addIllegalOp<mlir::triton::tle::ExtractTileOp,
-                 mlir::triton::tle::InsertTileOp,
-                 mlir::triton::tle::ExclusiveCumsumOp>();
+    addLegalDialect<LLVM::LLVMDialect, ROCDL::ROCDLDialect>();
+    addIllegalDialect<NVVM::NVVMDialect, mlir::triton::tle::TleDialect>();
     addLegalOp<mlir::UnrealizedConversionCastOp>();
     markUnknownOpDynamicallyLegal([](Operation *) -> bool { return true; });
   }
@@ -204,10 +199,9 @@ struct ConvertTritonAMDGPUToLLVM
 
 #ifdef __TLE__
     // Lower the supported tile-level extension (TLE) ops (extract_tile /
-    // insert_tile / exclusive_cumsum) to LLVM via the backend-agnostic
-    // conversion patterns, in a dedicated partial conversion (mirrors the
-    // NVIDIA / HCU path). Unsupported TLE ops remain legal in this focused
-    // conversion.
+    // insert_tile / exclusive_cumsum) via the backend-agnostic conversion
+    // patterns. The dedicated partial conversion rejects unsupported TLE ops
+    // and accidental NVVM emission.
     {
       TleLLVMConversionTarget tleTarget(*context);
       RewritePatternSet tlePatterns(context);

--- a/third_party/tle/dialect/lib/Conversion/TleToLLVM/ExclusiveCumsumOpToLLVM.cpp
+++ b/third_party/tle/dialect/lib/Conversion/TleToLLVM/ExclusiveCumsumOpToLLVM.cpp
@@ -122,7 +122,7 @@ static Value createWarpScanStepI32(Location loc,
                                    ConversionPatternRewriter &rewriter,
                                    const TargetInfoBase &targetInfo, Value val,
                                    int offset, Value laneId, Type elemTy) {
-  if (targetInfo.isHCU()) {
+  if (!targetInfo.isCuda()) {
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     Value shuffled = targetInfo.shuffleUp(rewriter, loc, val, offset);
     Value pred = b.icmp_sge(laneId, b.i32_val(offset));

--- a/third_party/tle/dialect/lib/Transforms/ExtractTileToLLVM.cpp
+++ b/third_party/tle/dialect/lib/Transforms/ExtractTileToLLVM.cpp
@@ -304,7 +304,7 @@ lowerExtractTileViaSMEM(ExtractTileOp op, ExtractTileOp::Adaptor adaptor,
   // ------------------------------------------------------------------
   // Step 4: __syncthreads() -- ensure all writes are visible
   // ------------------------------------------------------------------
-  if (targetInfo.isHCU())
+  if (!targetInfo.isCuda())
     targetInfo.barrier(loc, rewriter, /*isWarpSync=*/false);
   else
     rewriter.create<NVVM::Barrier0Op>(loc);
@@ -372,7 +372,7 @@ lowerExtractTileViaSMEM(ExtractTileOp op, ExtractTileOp::Adaptor adaptor,
   // ------------------------------------------------------------------
   // Step 6: __syncthreads() -- allow SMEM reuse after reads complete
   // ------------------------------------------------------------------
-  if (targetInfo.isHCU())
+  if (!targetInfo.isCuda())
     targetInfo.barrier(loc, rewriter, /*isWarpSync=*/false);
   else
     rewriter.create<NVVM::Barrier0Op>(loc);

--- a/third_party/tle/dialect/lib/Transforms/InsertTileToLLVM.cpp
+++ b/third_party/tle/dialect/lib/Transforms/InsertTileToLLVM.cpp
@@ -309,7 +309,7 @@ lowerInsertTileViaSMEMDynamic(InsertTileOp op, InsertTileOp::Adaptor adaptor,
     rewriter.create<LLVM::StoreOp>(loc, tileVals[i], sp, elemBytes);
   }
   // Synchronize threads after tile store.
-  if (targetInfo.isHCU())
+  if (!targetInfo.isCuda())
     targetInfo.barrier(loc, rewriter, /*isWarpSync=*/false);
   else
     rewriter.create<NVVM::Barrier0Op>(loc);
@@ -362,7 +362,7 @@ lowerInsertTileViaSMEMDynamic(InsertTileOp op, InsertTileOp::Adaptor adaptor,
     resultVals.push_back(merged);
   }
 
-  if (targetInfo.isHCU())
+  if (!targetInfo.isCuda())
     targetInfo.barrier(loc, rewriter, /*isWarpSync=*/false);
   else
     rewriter.create<NVVM::Barrier0Op>(loc);

--- a/third_party/tle/dialect/lib/Transforms/TleTileToLLVMUtils.cpp
+++ b/third_party/tle/dialect/lib/Transforms/TleTileToLLVMUtils.cpp
@@ -115,7 +115,7 @@ SmallVector<Value> computeThreadOffsets(Location loc,
 
   auto i32Ty = rewriter.getIntegerType(32);
   Value threadId;
-  if (targetInfo.isHCU())
+  if (!targetInfo.isCuda())
     threadId = getThreadId(rewriter, loc);
   else
     threadId = rewriter.create<NVVM::ThreadIdXOp>(loc, i32Ty);


### PR DESCRIPTION
## What

- Add AMD LLVM lowering for `tle.extract_tile`, `tle.insert_tile`, and `tle.exclusive_cumsum`.
- Register AMD shared-memory scratch allocation for the three operations.
- Route shared tile lowering through the existing `!targetInfo.isCuda()` boundary, preserving the CUDA/NVVM path without adding a target capability API.
- Use FlagTree backend identity helpers in the shared cumsum tests; HIP backends use the active target warp size while non-HIP backends retain the existing 32-thread test assumption.
- Reject unsupported TLE and accidental NVVM operations during AMD LLVM conversion.
- Fix clean parallel-build dependencies required by AMD targets.
- Add focused AMD correctness and `triton-opt + FileCheck` coverage.

## Why

The shared TLE lowering previously selected target-provided thread-id, barrier, and shuffle operations only for HCU. AMD implements those primitives but could not reuse the shared tile/cumsum lowering.

This PR is intentionally limited to AMD-owned implementation, the minimal shared predicates needed to select the non-CUDA path, and focused tests. It does not modify other backend-owned files.

## Testing

- Fresh `nvidia;amd`, `TRITON_BUILD_UT=ON`, `-j32` build: 379 steps completed.
- `TestOptimizeLDS`: 1/1 passed.
- Latest-head full incremental Ninja build and `libtriton.so` link: passed.
- gfx1201 cumsum suite: `9 passed, 4 expected skips` (NVIDIA PTX guard, HCU ISA guard, and two AMD local-pointer follow-ups).
- Backend policy checks: HIP wave32/wave64 uses target warp size; non-HIP warp sizes 12/128 retain 32 for these shared tests.
- AMD `triton-opt + FileCheck`: passed for extract, insert, and exclusive cumsum.
- Unsupported `tle.get_device_id` and accidental `nvvm.barrier0`: explicitly rejected during AMD conversion.
- Ruff 0.9.1, YAPF 0.43.0, clang-format 19.1.6, Python syntax, and `git diff --check`: passed.
- Rebased onto upstream `553537f6d`: conflict-free and 0 commits behind.