### PR TITLE
[TLE][MTHREADS] Support barrier/wgmma/pipe/ws primitives

### DIFF
--- a/python/triton/experimental/tle/language/gpu/core.py
+++ b/python/triton/experimental/tle/language/gpu/core.py
@@ -306,6 +306,9 @@ def alloc(
         dtype: Data type
         layout: Memory layout encoding (optional)
         scope: Storage type (default to shared memory)
+        nv_mma_shared_layout: Select an MMA-consumer-defined shared layout when
+            ``layout`` is None. On mthreads this is materialized by the SQMMA
+            lowering rather than as an NVIDIA encoding.
         _semantic: Semantic analyzer (internal use)
 
     Returns:
@@ -330,7 +333,6 @@ def alloc(
         raise ValueError(f"Storage type must be tle.scope, but got {type(scope)}")
 
     layout = tl._unwrap_if_constexpr(layout)
-    auto_shared_layout = layout is None
     if layout is not None and not isinstance(layout, tle.shared_layout):
         # Handle constexpr None
         if hasattr(layout, 'value') and layout.value is None:
@@ -350,6 +352,8 @@ def alloc(
 
     # Map scope to storage (backward compatibility)
     storage = scope
+    mthreads_auto_sqmma_shared_layout = (mthreads_common.enabled() and storage == tle.smem
+                                         and mthreads_wgmma.use_auto_shared_layout(layout, nv_mma_shared_layout))
 
     try:
         unwrapped_shape = [tl._unwrap_if_constexpr(dim) for dim in shape]
@@ -363,7 +367,7 @@ def alloc(
 
         if layout is None:
             if storage == tle.smem:
-                if not nv_mma_shared_layout:
+                if mthreads_auto_sqmma_shared_layout or not nv_mma_shared_layout:
                     layout = tle.swizzled_shared_layout.make_default(rank=len(shape))
                     layout_handle = _semantic.builder.make_swizzled_shared_encoding_attr(
                         layout.vectorSize,
@@ -406,7 +410,7 @@ def alloc(
                 tensor_handle = _semantic.builder.create_local_alloc(mutable_ty, init_value.handle)
             else:
                 tensor_handle = _semantic.builder.create_local_alloc(full_shape, elem_type, layout_handle)
-            if auto_shared_layout and mthreads_common.enabled():
+            if mthreads_auto_sqmma_shared_layout:
                 mthreads_wgmma.mark_auto_shared_layout(_semantic.builder, tensor_handle)
         else:
             raise ValueError(f"Storage type {storage} not yet supported")

--- a/python/triton/experimental/tle/language/gpu/core.py
+++ b/python/triton/experimental/tle/language/gpu/core.py
@@ -27,6 +27,7 @@ from . import types as tle
 from .mthreads import common as mthreads_common
 from .mthreads import copy as mthreads_copy
 from .mthreads import warp_specialize as mthreads_warp_specialize
+from .mthreads import wgmma as mthreads_wgmma
 from .iluvatar import copy as iluvatar_copy
 from triton.compiler.code_generator import flatten_values_to_ir, unflatten_ir_values
 
@@ -328,6 +329,7 @@ def alloc(
         raise ValueError(f"Storage type must be tle.scope, but got {type(scope)}")
 
     layout = tl._unwrap_if_constexpr(layout)
+    auto_shared_layout = layout is None
     if layout is not None and not isinstance(layout, tle.shared_layout):
         # Handle constexpr None
         if hasattr(layout, 'value') and layout.value is None:
@@ -399,6 +401,8 @@ def alloc(
                 tensor_handle = _semantic.builder.create_local_alloc(mutable_ty, init_value.handle)
             else:
                 tensor_handle = _semantic.builder.create_local_alloc(full_shape, elem_type, layout_handle)
+            if auto_shared_layout and mthreads_common.enabled():
+                mthreads_wgmma.mark_auto_shared_layout(_semantic.builder, tensor_handle)
         else:
             raise ValueError(f"Storage type {storage} not yet supported")
 
@@ -789,16 +793,23 @@ def wgmma(
     """
     trans_a = _require_wgmma_bool(trans_a, "trans_a")
     trans_b = _require_wgmma_bool(trans_b, "trans_b")
-    a, b = _canonicalize_wgmma_operands(a, b, trans_a, trans_b, _semantic)
+    mthreads_enabled = mthreads_common.enabled()
+    if mthreads_enabled:
+        mthreads_wgmma.validate_operands(a, b, acc, trans_a, trans_b)
+    else:
+        a, b = _canonicalize_wgmma_operands(a, b, trans_a, trans_b, _semantic)
 
     m, k = [int(tl._unwrap_if_constexpr(dim)) for dim in a.type.shape]
     k_b, n = [int(tl._unwrap_if_constexpr(dim)) for dim in b.type.shape]
     if k != k_b:
         raise ValueError(f"wgmma shape mismatch: a is {a.type.shape}, b is {b.type.shape}")
-    if m < 64 or m % 64 != 0:
-        raise ValueError("wgmma result M dimension must be divisible by 64")
-    if n < 8 or n % 8 != 0:
-        raise ValueError("wgmma result N dimension must be divisible by 8")
+    if mthreads_enabled:
+        mthreads_wgmma.validate_dimensions(m, n)
+    else:
+        if m < 64 or m % 64 != 0:
+            raise ValueError("wgmma result M dimension must be divisible by 64")
+        if n < 8 or n % 8 != 0:
+            raise ValueError("wgmma result N dimension must be divisible by 8")
     if k < 16:
         raise ValueError("wgmma K dimension must be at least 16")
 
@@ -828,6 +839,9 @@ def wgmma(
         max_num_imprecise_acc = _require_wgmma_int(max_num_imprecise_acc, "max_num_imprecise_acc")
         if max_num_imprecise_acc < 0:
             raise ValueError("max_num_imprecise_acc must be non-negative")
+
+    if mthreads_enabled:
+        mthreads_wgmma.validate_options(max_num_imprecise_acc, out_dtype)
 
     ret_scalar_ty = _wgmma_ret_scalar_ty(a.dtype, out_dtype)
     ret_ty = tl.block_type(ret_scalar_ty, [m, n])
@@ -867,6 +881,8 @@ def wgmma_wait(pendings, acc=None, _semantic=None, _generator=None) -> tl.tensor
     pendings = _require_wgmma_int(pendings, "pendings")
     if pendings < 0:
         raise ValueError("wgmma_wait pendings must be non-negative")
+    if mthreads_common.enabled():
+        mthreads_wgmma.validate_wait_pendings(pendings)
     if not isinstance(acc, tl.tensor):
         raise ValueError(f"wgmma_wait acc must be a tl.tensor, got {type(acc).__name__}")
     result = _semantic.builder.create_tle_wgmma_wait(acc.handle, pendings)

--- a/python/triton/experimental/tle/language/gpu/core.py
+++ b/python/triton/experimental/tle/language/gpu/core.py
@@ -1083,9 +1083,12 @@ def copy(
             raise ValueError("copy barrier is only supported for TMA global-to-shared copy")
         return normcopy(src, dst, shape, direction, _semantic)
     if mthreads_enabled:
+        barrier_slot = None
         if barrier is not None:
-            raise ValueError("TMA copy barrier is only supported on NVIDIA backend")
-        return mthreads_copy.tmacopy(src, dst, direction, shape, offsets, _semantic)
+            if direction != CopyDirection.GM_TO_LOCAL:
+                raise ValueError("TMA copy barrier is only supported for global-to-shared TMA copy")
+            barrier_slot = _tma_completion_barrier_slot(barrier, _semantic)
+        return mthreads_copy.tmacopy(src, dst, direction, shape, offsets, barrier_slot, _semantic)
     else:
         return tmacopy(src, dst, direction, shape, offsets, barrier, _semantic)
 

--- a/python/triton/experimental/tle/language/gpu/core.py
+++ b/python/triton/experimental/tle/language/gpu/core.py
@@ -26,6 +26,7 @@ from enum import Enum
 from . import types as tle
 from .mthreads import common as mthreads_common
 from .mthreads import copy as mthreads_copy
+from .mthreads import warp_specialize as mthreads_warp_specialize
 from .iluvatar import copy as iluvatar_copy
 from triton.compiler.code_generator import flatten_values_to_ir, unflatten_ir_values
 
@@ -190,8 +191,12 @@ def warp_specialize(functions_and_args, worker_num_warps, worker_num_regs, _sema
     if _generator is None:
         raise ValueError("warp_specialize requires a Triton code generator")
     functions_and_args = tl._unwrap_if_constexpr(functions_and_args)
-    worker_num_warps = [tl._unwrap_if_constexpr(w) for w in tl._unwrap_if_constexpr(worker_num_warps)]
-    worker_num_regs = [tl._unwrap_if_constexpr(r) for r in tl._unwrap_if_constexpr(worker_num_regs)]
+    mthreads_enabled = mthreads_common.enabled()
+    if mthreads_enabled:
+        worker_num_warps, worker_num_regs = mthreads_warp_specialize.normalize_config(worker_num_warps, worker_num_regs)
+    else:
+        worker_num_warps = [tl._unwrap_if_constexpr(w) for w in tl._unwrap_if_constexpr(worker_num_warps)]
+        worker_num_regs = [tl._unwrap_if_constexpr(r) for r in tl._unwrap_if_constexpr(worker_num_regs)]
     if len(functions_and_args) < 1:
         raise ValueError("warp_specialize requires at least a default partition function")
     num_partitions = len(functions_and_args) - 1
@@ -204,10 +209,9 @@ def warp_specialize(functions_and_args, worker_num_warps, worker_num_regs, _sema
 
     builder = _semantic.builder
     insert_pt = builder.get_insertion_point()
-    # mthreads partitions are inlined without using NVIDIA WGMMA routing metadata.
-    mthreads_enabled = mthreads_common.enabled()
-    inline_partition_functions = mthreads_enabled or _is_wgmma_user_promise_marked(_generator)
-    if inline_partition_functions:
+    if mthreads_enabled:
+        call_jit_function = mthreads_warp_specialize.partition_function_caller(_generator)
+    elif _is_wgmma_user_promise_marked(_generator):
         call_jit_function = _generator.inline_JitFunction
     else:
         call_jit_function = _generator.call_JitFunction
@@ -232,9 +236,7 @@ def warp_specialize(functions_and_args, worker_num_warps, worker_num_regs, _sema
 
     builder.restore_insertion_point(insert_pt)
     if mthreads_enabled:
-        # Mthreads keeps explicit captures on the isolated partitions holder,
-        # matching its backend-local ttg.warp_specialize definition.
-        ws_op = builder.create_warp_specialize(result_types, worker_num_warps)
+        ws_op = mthreads_warp_specialize.create_op(builder, result_types, worker_num_warps)
     else:
         ws_op = builder.create_warp_specialize(result_types, worker_arg_handles, worker_num_warps)
     real_default_block = builder.create_block_with_parent(ws_op.get_default_region(), [])
@@ -246,7 +248,7 @@ def warp_specialize(functions_and_args, worker_num_warps, worker_num_regs, _sema
 
     builder.create_block_with_parent(ws_op.get_partition_op_holder(), [])
     if mthreads_enabled:
-        partitions_op = builder.create_warp_specialize_partitions(worker_arg_handles, num_partitions)
+        partitions_op = mthreads_warp_specialize.create_partitions(builder, worker_arg_handles, num_partitions)
     else:
         partitions_op = builder.create_warp_specialize_partitions(num_partitions)
     partition_arg_types = [arg.get_type() for arg in worker_arg_handles]

--- a/python/triton/experimental/tle/language/gpu/core.py
+++ b/python/triton/experimental/tle/language/gpu/core.py
@@ -24,6 +24,7 @@ import triton.language.core as tl
 from typing import Optional, Sequence
 from enum import Enum
 from . import types as tle
+from .mthreads import common as mthreads_common
 from .mthreads import copy as mthreads_copy
 from .iluvatar import copy as iluvatar_copy
 from triton.compiler.code_generator import flatten_values_to_ir, unflatten_ir_values
@@ -44,6 +45,9 @@ _WGMMA_PIPELINE_MODE_USER_PROMISE = "user_promise"
 
 def _mark_wgmma_user_promise(_semantic, _generator):
     if _generator is None or _semantic is None:
+        return
+    # This module attribute is NVIDIA-specific and must not leak into mthreads IR.
+    if mthreads_common.enabled():
         return
     _generator.module.set_attr(
         _WGMMA_PIPELINE_MODE_ATTR,
@@ -200,8 +204,9 @@ def warp_specialize(functions_and_args, worker_num_warps, worker_num_regs, _sema
 
     builder = _semantic.builder
     insert_pt = builder.get_insertion_point()
-    inline_user_promise = _is_wgmma_user_promise_marked(_generator)
-    if inline_user_promise:
+    # mthreads partitions are inlined without using NVIDIA WGMMA routing metadata.
+    inline_partition_functions = mthreads_common.enabled() or _is_wgmma_user_promise_marked(_generator)
+    if inline_partition_functions:
         call_jit_function = _generator.inline_JitFunction
     else:
         call_jit_function = _generator.call_JitFunction
@@ -921,7 +926,7 @@ def copy(
             tle.copy(tma_desc, local_buf, [64, 64], [x_offset, y_offset], barrier=bar)
             tle.gpu.barrier_wait(bar, phaseIdx=0)
     """
-    mthreads_enabled = mthreads_copy.enabled()
+    mthreads_enabled = mthreads_common.enabled()
     iluvatar_enabled = iluvatar_copy.enabled()
 
     def normcopy(

--- a/python/triton/experimental/tle/language/gpu/core.py
+++ b/python/triton/experimental/tle/language/gpu/core.py
@@ -205,7 +205,8 @@ def warp_specialize(functions_and_args, worker_num_warps, worker_num_regs, _sema
     builder = _semantic.builder
     insert_pt = builder.get_insertion_point()
     # mthreads partitions are inlined without using NVIDIA WGMMA routing metadata.
-    inline_partition_functions = mthreads_common.enabled() or _is_wgmma_user_promise_marked(_generator)
+    mthreads_enabled = mthreads_common.enabled()
+    inline_partition_functions = mthreads_enabled or _is_wgmma_user_promise_marked(_generator)
     if inline_partition_functions:
         call_jit_function = _generator.inline_JitFunction
     else:
@@ -230,7 +231,12 @@ def warp_specialize(functions_and_args, worker_num_warps, worker_num_regs, _sema
     worker_arg_handles, worker_items = _deduplicate_warp_specialize_captures(worker_items)
 
     builder.restore_insertion_point(insert_pt)
-    ws_op = builder.create_warp_specialize(result_types, worker_arg_handles, worker_num_warps)
+    if mthreads_enabled:
+        # Mthreads keeps explicit captures on the isolated partitions holder,
+        # matching its backend-local ttg.warp_specialize definition.
+        ws_op = builder.create_warp_specialize(result_types, worker_num_warps)
+    else:
+        ws_op = builder.create_warp_specialize(result_types, worker_arg_handles, worker_num_warps)
     real_default_block = builder.create_block_with_parent(ws_op.get_default_region(), [])
     default_block.merge_block_before(real_default_block)
     default_block = real_default_block
@@ -239,7 +245,10 @@ def warp_specialize(functions_and_args, worker_num_warps, worker_num_regs, _sema
     ws_op.set_requested_registers(worker_num_regs)
 
     builder.create_block_with_parent(ws_op.get_partition_op_holder(), [])
-    partitions_op = builder.create_warp_specialize_partitions(num_partitions)
+    if mthreads_enabled:
+        partitions_op = builder.create_warp_specialize_partitions(worker_arg_handles, num_partitions)
+    else:
+        partitions_op = builder.create_warp_specialize_partitions(num_partitions)
     partition_arg_types = [arg.get_type() for arg in worker_arg_handles]
     for idx, (worker_fn, worker_args, flattened, remapped) in enumerate(worker_items):
         block = builder.create_block_with_parent(partitions_op.get_region(idx), partition_arg_types)

--- a/python/triton/experimental/tle/language/gpu/core.py
+++ b/python/triton/experimental/tle/language/gpu/core.py
@@ -25,6 +25,7 @@ from typing import Optional, Sequence
 from enum import Enum
 from . import types as tle
 from .mthreads import common as mthreads_common
+from .mthreads import buffer as mthreads_buffer
 from .mthreads import copy as mthreads_copy
 from .mthreads import warp_specialize as mthreads_warp_specialize
 from .mthreads import wgmma as mthreads_wgmma
@@ -353,6 +354,10 @@ def alloc(
     try:
         unwrapped_shape = [tl._unwrap_if_constexpr(dim) for dim in shape]
         full_shape = unwrapped_shape
+        use_mthreads_buffer = (mthreads_common.enabled() and mthreads_buffer.needs_non_power_of_two_leading_dim(
+            _semantic.builder, unwrapped_shape))
+        if use_mthreads_buffer:
+            mthreads_buffer.validate_shape(unwrapped_shape)
         dtype = tl._unwrap_if_constexpr(dtype)
         elem_type = dtype.to_ir(_semantic.builder)
 
@@ -406,6 +411,15 @@ def alloc(
         else:
             raise ValueError(f"Storage type {storage} not yet supported")
 
+        if use_mthreads_buffer:
+            return mthreads_buffer.create_buffered_tensor(
+                tensor_handle,
+                dtype,
+                unwrapped_shape,
+                storage,
+                layout,
+                _semantic,
+            )
         return tle.buffered_tensor(tensor_handle, dtype, unwrapped_shape, storage, layout, _semantic)
 
     except Exception as e:

--- a/python/triton/experimental/tle/language/gpu/mthreads/__init__.py
+++ b/python/triton/experimental/tle/language/gpu/mthreads/__init__.py
@@ -18,6 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from . import common, copy, pipe, warp_specialize, wgmma
+from . import buffer, common, copy, pipe, warp_specialize, wgmma
 
-__all__ = ["common", "copy", "pipe", "warp_specialize", "wgmma"]
+__all__ = ["buffer", "common", "copy", "pipe", "warp_specialize", "wgmma"]

--- a/python/triton/experimental/tle/language/gpu/mthreads/__init__.py
+++ b/python/triton/experimental/tle/language/gpu/mthreads/__init__.py
@@ -18,6 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from . import common, copy
+from . import common, copy, warp_specialize
 
-__all__ = ["common", "copy"]
+__all__ = ["common", "copy", "warp_specialize"]

--- a/python/triton/experimental/tle/language/gpu/mthreads/__init__.py
+++ b/python/triton/experimental/tle/language/gpu/mthreads/__init__.py
@@ -18,6 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from . import common, copy, warp_specialize
+from . import common, copy, warp_specialize, wgmma
 
-__all__ = ["common", "copy", "warp_specialize"]
+__all__ = ["common", "copy", "warp_specialize", "wgmma"]

--- a/python/triton/experimental/tle/language/gpu/mthreads/buffer.py
+++ b/python/triton/experimental/tle/language/gpu/mthreads/buffer.py
@@ -1,0 +1,124 @@
+# Copyright 2025-     FlagOS Contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from math import prod
+
+from triton._utils import TRITON_MAX_TENSOR_NUMEL, is_power_of_two
+
+from .. import types as gpu_types
+
+
+def is_backend_builder(builder) -> bool:
+    return hasattr(builder, "mark_musa_tle_auto_shared_layout")
+
+
+def needs_non_power_of_two_leading_dim(builder, shape) -> bool:
+    if not is_backend_builder(builder) or not shape:
+        return False
+    return isinstance(shape[0], int) and shape[0] > 0 and not is_power_of_two(shape[0])
+
+
+def validate_shape(shape) -> tuple[int, ...]:
+    shape = tuple(shape)
+    if len(shape) < 2:
+        raise ValueError("mthreads TLE non-power-of-two buffered tensor requires rank >= 2")
+    for index, dim in enumerate(shape):
+        if not isinstance(dim, int):
+            raise TypeError(f"Shape element {index} must have type `constexpr[int]`, got `constexpr[{type(dim)}]")
+        if dim <= 0:
+            raise ValueError(f"Shape element {index} must be positive")
+        if index > 0 and not is_power_of_two(dim):
+            raise ValueError(f"Shape element {index} must be a power of 2")
+    numel = prod(shape)
+    if numel > TRITON_MAX_TENSOR_NUMEL:
+        raise ValueError(f"numel ({numel}) exceeds triton maximum tensor numel ({TRITON_MAX_TENSOR_NUMEL})")
+    return shape
+
+
+class buffered_tensor_type(gpu_types.buffered_tensor_type):
+
+    def __init__(self, element_ty, shape, storage, layout=None, semantic=None, alloc_shape=None):
+        shape = validate_shape(shape)
+        self.element_ty = element_ty
+        self.shape = shape
+        self.numel = prod(shape)
+        self.name = f"<{self.shape}, {self.element_ty}>"
+        self.storage = storage
+        self.layout = layout
+        self.alloc_shape = list(shape if alloc_shape is None else alloc_shape)
+        assert semantic, "buffered_tensor array must be created with a builder"
+        self.semantic = semantic
+
+    def _unflatten_ir(self, handles, cursor):
+        value = buffered_tensor(
+            handles[cursor],
+            self.scalar,
+            self.shape,
+            self.storage,
+            self.layout,
+            self.semantic,
+            alloc_shape=self.alloc_shape,
+        )
+        if hasattr(self, "_tle_remote_shard_id"):
+            shard_id = getattr(self, "_tle_remote_shard_id")
+            scope = getattr(self, "_tle_remote_scope", None)
+            setattr(value, "_tle_remote_shard_id", shard_id)
+            setattr(value, "_tle_remote_scope", scope)
+            setattr(value.type, "_tle_remote_shard_id", shard_id)
+            setattr(value.type, "_tle_remote_scope", scope)
+        return value, cursor + 1
+
+    def with_element_ty(self, scalar_ty):
+        return buffered_tensor_type(
+            scalar_ty,
+            self.shape,
+            self.storage,
+            self.layout,
+            self.semantic,
+            alloc_shape=self.alloc_shape,
+        )
+
+
+class buffered_tensor(gpu_types.buffered_tensor):
+
+    def __init__(self, handle, element_ty, shape, storage, layout=None, semantic=None, alloc_shape=None):
+        self.handle = handle
+        self.shape = list(shape)
+        self.type = buffered_tensor_type(
+            element_ty,
+            shape,
+            storage,
+            layout,
+            semantic,
+            alloc_shape=alloc_shape,
+        )
+        self.dtype = element_ty
+
+
+def create_buffered_tensor(handle, element_ty, shape, storage, layout, semantic, alloc_shape=None):
+    return buffered_tensor(
+        handle,
+        element_ty,
+        shape,
+        storage,
+        layout,
+        semantic,
+        alloc_shape=alloc_shape,
+    )

--- a/python/triton/experimental/tle/language/gpu/mthreads/common.py
+++ b/python/triton/experimental/tle/language/gpu/mthreads/common.py
@@ -18,6 +18,21 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from . import common, copy
+import os
 
-__all__ = ["common", "copy"]
+try:
+    from triton._flagtree_backend import FLAGTREE_BACKEND
+except ModuleNotFoundError:
+    FLAGTREE_BACKEND = os.environ.get("FLAGTREE_BACKEND", "")
+
+
+def _has_mthreads_libtriton() -> bool:
+    try:
+        from triton._C import libtriton
+    except ImportError:
+        return False
+    return hasattr(libtriton, "mthreads")
+
+
+def enabled() -> bool:
+    return FLAGTREE_BACKEND == "mthreads" or _has_mthreads_libtriton()

--- a/python/triton/experimental/tle/language/gpu/mthreads/copy.py
+++ b/python/triton/experimental/tle/language/gpu/mthreads/copy.py
@@ -85,7 +85,7 @@ def normalize_offsets(offsets, rank: int):
     return offsets_tuple
 
 
-def tmacopy(src, dst, direction, shape, offsets, _semantic) -> None:
+def tmacopy(src, dst, direction, shape, offsets, barrier=None, _semantic=None) -> None:
     shape = normalize_copy_shape(shape)
     desc = src if direction.name == "GM_TO_LOCAL" else dst
     buffer = dst if direction.name == "GM_TO_LOCAL" else src
@@ -101,4 +101,14 @@ def tmacopy(src, dst, direction, shape, offsets, _semantic) -> None:
     offset_values = _semantic._convert_to_ir_values(offset_values, require_i64=False)
     if not hasattr(_semantic.builder, "create_tma_copy"):
         raise RuntimeError("TLE TMA copy builder binding is not available")
+    if barrier is not None:
+        if direction.name != "GM_TO_LOCAL":
+            raise ValueError("TMA copy barrier is only supported for global-to-shared TMA copy")
+        if not isinstance(barrier, tle.barrier) or not barrier.is_slot:
+            raise ValueError("TMA copy barrier must be an indexed tle.gpu barrier slot")
+        if barrier.expect_bytes is None or int(barrier.expect_bytes) <= 0:
+            raise ValueError("TMA copy barrier must have positive expect_bytes")
+        _semantic.builder.create_tma_copy(src.handle, dst.handle, offset_values, barrier.handle,
+                                          int(barrier.expect_bytes))
+        return
     _semantic.builder.create_tma_copy(src.handle, dst.handle, offset_values)

--- a/python/triton/experimental/tle/language/gpu/mthreads/copy.py
+++ b/python/triton/experimental/tle/language/gpu/mthreads/copy.py
@@ -18,28 +18,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import os
-
 import triton.language.core as tl
 
 from .. import types as tle
-
-try:
-    from triton._flagtree_backend import FLAGTREE_BACKEND
-except ModuleNotFoundError:
-    FLAGTREE_BACKEND = os.environ.get("FLAGTREE_BACKEND", "")
-
-
-def _has_mthreads_libtriton() -> bool:
-    try:
-        from triton._C import libtriton
-    except ImportError:
-        return False
-    return hasattr(libtriton, "mthreads")
-
-
-def enabled() -> bool:
-    return FLAGTREE_BACKEND == "mthreads" or _has_mthreads_libtriton()
 
 
 def normalize_copy_shape(shape) -> tuple[int, ...]:

--- a/python/triton/experimental/tle/language/gpu/mthreads/pipe.py
+++ b/python/triton/experimental/tle/language/gpu/mthreads/pipe.py
@@ -18,6 +18,21 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from . import common, copy, pipe, warp_specialize, wgmma
 
-__all__ = ["common", "copy", "pipe", "warp_specialize", "wgmma"]
+def is_backend_builder(builder) -> bool:
+    # The mthreads-only libtriton can be loaded while backend-independent TLE
+    # frontend tests use a synthetic builder. Gate the restricted contract on
+    # a backend-local native capability so those public tests retain the
+    # portable pipe model.
+    return hasattr(builder, "mark_musa_tle_auto_shared_layout")
+
+
+def validate_pipe_options(scope, readers, one_shot, fields) -> None:
+    if scope != "cta":
+        raise ValueError("initial mthreads tle.pipe supports only scope='cta'")
+    if len(fields) != 1:
+        raise ValueError("initial mthreads tle.pipe requires exactly one payload field")
+    if readers is not None:
+        raise ValueError("initial mthreads tle.pipe supports only the default SPSC reader")
+    if one_shot:
+        raise ValueError("initial mthreads tle.pipe does not support one_shot=True")

--- a/python/triton/experimental/tle/language/gpu/mthreads/warp_specialize.py
+++ b/python/triton/experimental/tle/language/gpu/mthreads/warp_specialize.py
@@ -1,0 +1,68 @@
+# Copyright 2025-     FlagOS Contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import triton.language.core as tl
+
+
+def _normalize_static_int_sequence(values, name, *, require_positive=False):
+    values = tl._unwrap_if_constexpr(values)
+    if isinstance(values, tl.tuple):
+        values = tuple(values.values)
+    if not isinstance(values, (list, tuple)):
+        raise ValueError(f"mthreads TLE warp_specialize {name} must be a static sequence")
+
+    normalized = []
+    for index, value in enumerate(values):
+        value = tl._unwrap_if_constexpr(value)
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"mthreads TLE warp_specialize {name}[{index}] must be a compile-time integer")
+        if require_positive and value <= 0:
+            raise ValueError(f"mthreads TLE warp_specialize {name}[{index}] must be positive")
+        normalized.append(value)
+    return normalized
+
+
+def normalize_config(worker_num_warps, worker_num_regs):
+    worker_num_warps = _normalize_static_int_sequence(
+        worker_num_warps,
+        "worker_num_warps",
+        require_positive=True,
+    )
+    worker_num_regs = _normalize_static_int_sequence(
+        worker_num_regs,
+        "worker_num_regs",
+    )
+    return worker_num_warps, worker_num_regs
+
+
+def partition_function_caller(generator):
+    # Mthreads TLE regions are isolated from above and use direct SSA capture
+    # remapping, so partition functions must be emitted inline.
+    return generator.inline_JitFunction
+
+
+def create_op(builder, result_types, worker_num_warps):
+    # Mthreads keeps explicit captures on the isolated partitions holder rather
+    # than on the outer ttg.warp_specialize operation.
+    return builder.create_warp_specialize(result_types, worker_num_warps)
+
+
+def create_partitions(builder, explicit_captures, num_partitions):
+    return builder.create_warp_specialize_partitions(explicit_captures, num_partitions)

--- a/python/triton/experimental/tle/language/gpu/mthreads/wgmma.py
+++ b/python/triton/experimental/tle/language/gpu/mthreads/wgmma.py
@@ -25,6 +25,11 @@ def _unwrap(value):
     return value.value if isinstance(value, tl.constexpr) else value
 
 
+def use_auto_shared_layout(layout, nv_mma_shared_layout) -> bool:
+    """Whether an implicit mthreads shared layout may be selected by SQMMA."""
+    return layout is None and bool(_unwrap(nv_mma_shared_layout))
+
+
 def mark_auto_shared_layout(builder, handle) -> None:
     if not hasattr(builder, "mark_musa_tle_auto_shared_layout"):
         raise RuntimeError("mthreads TLE native binding mark_musa_tle_auto_shared_layout is unavailable")

--- a/python/triton/experimental/tle/language/gpu/mthreads/wgmma.py
+++ b/python/triton/experimental/tle/language/gpu/mthreads/wgmma.py
@@ -1,0 +1,71 @@
+# Copyright 2025-     FlagOS Contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import triton.language as tl
+
+
+def _unwrap(value):
+    return value.value if isinstance(value, tl.constexpr) else value
+
+
+def mark_auto_shared_layout(builder, handle) -> None:
+    if not hasattr(builder, "mark_musa_tle_auto_shared_layout"):
+        raise RuntimeError("mthreads TLE native binding mark_musa_tle_auto_shared_layout is unavailable")
+    builder.mark_musa_tle_auto_shared_layout(handle)
+
+
+def validate_operands(a, b, acc, trans_a: bool, trans_b: bool) -> None:
+    if trans_a or trans_b:
+        raise ValueError("initial mthreads TLE wgmma does not support trans_a/trans_b")
+    for name, operand in (("a", a), ("b", b)):
+        operand_type = getattr(operand, "type", None)
+        if not hasattr(operand_type, "storage"):
+            raise ValueError(f"initial mthreads TLE wgmma requires shared-memory memdesc {name}")
+        shape = tuple(int(_unwrap(dim)) for dim in operand_type.shape)
+        if len(shape) != 2:
+            raise ValueError(f"initial mthreads TLE wgmma requires rank-2 {name}, got {shape}")
+        if operand.dtype not in (tl.float16, tl.bfloat16, tl.float8e4nv):
+            raise ValueError("mthreads TLE wgmma requires f16, bf16, or fp8e4nv "
+                             f"{name}, got {operand.dtype}")
+    if a.dtype != b.dtype:
+        raise ValueError("mthreads TLE wgmma requires matching A/B dtypes, "
+                         f"got {a.dtype} and {b.dtype}")
+    if acc is not None and getattr(acc, "dtype", None) != tl.float32:
+        raise ValueError("mthreads TLE wgmma requires an f32 accumulator")
+
+
+def validate_options(max_num_imprecise_acc: int, out_dtype) -> None:
+    if max_num_imprecise_acc != 0:
+        raise ValueError("mthreads TLE wgmma requires max_num_imprecise_acc=0")
+    if out_dtype != tl.float32:
+        raise ValueError("mthreads TLE wgmma requires out_dtype=tl.float32")
+
+
+def validate_dimensions(m: int, n: int) -> None:
+    if m < 16 or m % 16 != 0:
+        raise ValueError("mthreads TLE wgmma result M dimension must be divisible by 16")
+    if n < 16 or n % 16 != 0:
+        raise ValueError("mthreads TLE wgmma result N dimension must be divisible by 16")
+
+
+def validate_wait_pendings(pendings: int) -> None:
+    if pendings != 0:
+        raise ValueError("mthreads TLE wgmma_wait currently requires pendings=0; "
+                         "non-zero pending groups are not supported")

--- a/python/triton/experimental/tle/language/pipe.py
+++ b/python/triton/experimental/tle/language/pipe.py
@@ -22,6 +22,8 @@
 import triton.language.core as tl
 
 from .gpu import types as gpu_types
+from .gpu.mthreads import common as mthreads_common
+from .gpu.mthreads import pipe as mthreads_pipe
 
 
 def _unwrap_pipe_constexpr(value):
@@ -109,6 +111,9 @@ def pipe(
         raise ValueError(f"tle.pipe one_shot must be a compile-time bool, got {type(one_shot).__name__}")
     if not fields:
         raise ValueError("tle.pipe requires at least one payload field")
+
+    if mthreads_common.enabled() and mthreads_pipe.is_backend_builder(_semantic.builder):
+        mthreads_pipe.validate_pipe_options(scope, reader_names, one_shot, fields)
 
     for field_name, field in fields.items():
         _validate_public_name("field", field_name)

--- a/third_party/mthreads/CMakeLists.txt
+++ b/third_party/mthreads/CMakeLists.txt
@@ -9,6 +9,15 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/tle/dialect/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/tle/frontend/include)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/tle/frontend/include)
 if(FLAGTREE_MTHREADS_TLE)
+  # The mthreads TLE frontend emits the backend-independent tle.pipe ops, but
+  # the standalone TLE plugin is intentionally disabled for mthreads builds.
+  # Build only the common TLE IR contract needed by the backend adapter.
+  add_subdirectory(
+    ${CMAKE_SOURCE_DIR}/third_party/tle/dialect/include/IR
+    ${CMAKE_BINARY_DIR}/third_party/tle/dialect/include/IR)
+  add_subdirectory(
+    ${CMAKE_SOURCE_DIR}/third_party/tle/dialect/lib/IR
+    ${CMAKE_BINARY_DIR}/third_party/tle/dialect/lib/IR)
   add_subdirectory(tle)
 endif()
 add_subdirectory(include)
@@ -20,12 +29,13 @@ if(TRITON_BUILD_PYTHON_MODULE)
         ${CMAKE_CURRENT_SOURCE_DIR}/tle/dialect/triton_mthreads_tle.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/tle/frontend/triton_mthreads_frontend.cc)
     set(_MTHREADS_TLE_PLUGIN_LIBS
-        MUSATLEIR MUSATLETransforms MUSATLEFrontendTransforms)
+        MUSATLEIR MUSATLETransforms MUSATLEFrontendTransforms TleIR)
     set(_MTHREADS_TLE_PLUGIN_DEPS
         MUSATLETableGen
         MUSATLETransforms
         MUSATLEFrontendTransformsIncGen
-        MUSATLEFrontendTransforms)
+        MUSATLEFrontendTransforms
+        TleTableGen)
   else()
     set(_MTHREADS_TLE_PLUGIN_SOURCES "")
     set(_MTHREADS_TLE_PLUGIN_LIBS "")

--- a/third_party/mthreads/backend/compiler.py
+++ b/third_party/mthreads/backend/compiler.py
@@ -780,6 +780,8 @@ class MUSABackend(BaseBackend):
             mthreads.passes.ttgpuir.add_tle_optimize_local_pointer_loads(pm)
         if hasattr(mthreads.passes.ttgpuir, "add_tle_optimize_local_pointer_stores"):
             mthreads.passes.ttgpuir.add_tle_optimize_local_pointer_stores(pm)
+        if hasattr(mthreads.passes.ttgpuir, "add_tle_lower_sqmma"):
+            mthreads.passes.ttgpuir.add_tle_lower_sqmma(pm)
         mthreads.passes.ttgpuir.add_accelerate_matmul(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)
         mthreads.passes.ttgpuir.add_optimize_dot_operands(pm)

--- a/third_party/mthreads/backend/compiler.py
+++ b/third_party/mthreads/backend/compiler.py
@@ -824,6 +824,8 @@ class MUSABackend(BaseBackend):
             mthreads.passes.ttgpuir.add_mark_inplace_loads(pm, opt.inplace_alias_pairs)
         if hasattr(mthreads.passes.ttgpuir, "add_tle_lower_barrier_allocations"):
             mthreads.passes.ttgpuir.add_tle_lower_barrier_allocations(pm)
+        if hasattr(mthreads.passes.ttgpuir, "add_tle_lower_tme_transactions"):
+            mthreads.passes.ttgpuir.add_tle_lower_tme_transactions(pm)
         mthreads.passes.ttgpuir.add_finalize_barriers(pm)
         pm.run(mod, "make_ttgir")
         metadata["uses_sqmma"] = _module_uses_sqmma(mod)

--- a/third_party/mthreads/backend/compiler.py
+++ b/third_party/mthreads/backend/compiler.py
@@ -822,6 +822,8 @@ class MUSABackend(BaseBackend):
         passes.common.add_canonicalizer(pm)
         if capability == 31:
             mthreads.passes.ttgpuir.add_mark_inplace_loads(pm, opt.inplace_alias_pairs)
+        if hasattr(mthreads.passes.ttgpuir, "add_tle_lower_barrier_allocations"):
+            mthreads.passes.ttgpuir.add_tle_lower_barrier_allocations(pm)
         mthreads.passes.ttgpuir.add_finalize_barriers(pm)
         pm.run(mod, "make_ttgir")
         metadata["uses_sqmma"] = _module_uses_sqmma(mod)

--- a/third_party/mthreads/backend/compiler.py
+++ b/third_party/mthreads/backend/compiler.py
@@ -782,6 +782,8 @@ class MUSABackend(BaseBackend):
             mthreads.passes.ttgpuir.add_tle_optimize_local_pointer_stores(pm)
         if hasattr(mthreads.passes.ttgpuir, "add_tle_lower_sqmma"):
             mthreads.passes.ttgpuir.add_tle_lower_sqmma(pm)
+        if hasattr(mthreads.passes.ttgpuir, "add_tle_lower_pipe"):
+            mthreads.passes.ttgpuir.add_tle_lower_pipe(pm)
         mthreads.passes.ttgpuir.add_accelerate_matmul(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)
         mthreads.passes.ttgpuir.add_optimize_dot_operands(pm)

--- a/third_party/mthreads/backend/compiler.py
+++ b/third_party/mthreads/backend/compiler.py
@@ -826,6 +826,8 @@ class MUSABackend(BaseBackend):
             mthreads.passes.ttgpuir.add_tle_lower_barrier_allocations(pm)
         if hasattr(mthreads.passes.ttgpuir, "add_tle_lower_tme_transactions"):
             mthreads.passes.ttgpuir.add_tle_lower_tme_transactions(pm)
+        if hasattr(mthreads.passes.ttgpuir, "add_tle_lower_barrier_operations"):
+            mthreads.passes.ttgpuir.add_tle_lower_barrier_operations(pm)
         mthreads.passes.ttgpuir.add_finalize_barriers(pm)
         pm.run(mod, "make_ttgir")
         metadata["uses_sqmma"] = _module_uses_sqmma(mod)

--- a/third_party/mthreads/backend/compiler.py
+++ b/third_party/mthreads/backend/compiler.py
@@ -833,6 +833,8 @@ class MUSABackend(BaseBackend):
         if hasattr(mthreads.passes.ttgpuir, "add_tle_lower_barrier_operations"):
             mthreads.passes.ttgpuir.add_tle_lower_barrier_operations(pm)
         mthreads.passes.ttgpuir.add_finalize_barriers(pm)
+        if hasattr(mthreads.passes.ttgpuir, "add_tle_prepare_warp_specialize"):
+            mthreads.passes.ttgpuir.add_tle_prepare_warp_specialize(pm)
         pm.run(mod, "make_ttgir")
         metadata["uses_sqmma"] = _module_uses_sqmma(mod)
         metadata["tensordesc_meta"] = mod.get_tensordesc_metadata()
@@ -843,14 +845,25 @@ class MUSABackend(BaseBackend):
         from triton._C.libtriton import llvm
 
         mod = src
+        total_num_warps = src.get_int_attr("ttg.total-num-warps")
+        launch_num_warps = total_num_warps if total_num_warps is not None else options.num_warps
+        metadata["num_warps"] = launch_num_warps
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
 
+        has_static_ws = total_num_warps is not None and hasattr(mthreads.passes.ttgpuir,
+                                                                "add_tle_lower_warp_specialize")
         passes.convert.add_scf_to_cf(pm)
         passes.convert.add_index_to_llvmir(pm)
         mthreads.passes.ttgpuir.add_allocate_shared_memory(pm, _capability_from_arch(arch))
         mthreads.passes.ttgpuir.add_mtgpu_to_llvm(pm, _capability_from_arch(arch))
         mthreads.passes.ttgpuir.add_to_llvmir(pm, _capability_from_arch(arch))
+        if has_static_ws:
+            # The retained operation still owns the producer and consumer
+            # regions here.  Lower their hardware barriers once, then emit the
+            # final two independent static CFG branches without control SMEM.
+            mthreads.passes.ttgpuir.add_tle_lower_warp_specialize(pm)
+            passes.convert.add_scf_to_cf(pm)
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)
         passes.convert.add_cf_to_llvmir(pm)
@@ -874,7 +887,7 @@ class MUSABackend(BaseBackend):
             llvm.link_extern_libs(llvm_mod, paths)
 
         llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3)
-        maxntidx = max(1, int(options.num_warps) * int(options.warp_size))
+        maxntidx = max(1, int(launch_num_warps) * int(options.warp_size))
         kernel_name_hint = src.get_entry_func_name() if hasattr(src, "get_entry_func_name") else ""
         mthreads.decorate_kernel_abi(llvm_mod, kernel_name_hint, maxntidx)
         metadata["uses_mulhi_helper"] = mthreads.module_uses_mulhi_helper(llvm_mod)
@@ -882,6 +895,7 @@ class MUSABackend(BaseBackend):
         metadata["shared"] = src.get_int_attr("ttg.shared")
 
         ret = str(llvm_mod)
+        metadata["uses_sqmma"] = bool(metadata.get("uses_sqmma")) or "llvm.musa.sqmma." in ret
         del llvm_mod
         del context
         return ret

--- a/third_party/mthreads/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/third_party/mthreads/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -726,7 +726,10 @@ def TTG_BarrierOp : TTG_Op<"barrier"> {
 }
 
 #ifdef __TLE__
-def TTG_TMACopyOp : TTG_Op<"tma_copy", [MemoryEffects<[MemRead, MemWrite]>]> {
+def TTG_TMACopyOp : TTG_Op<"tma_copy", [
+  AttrSizedOperandSegments,
+  MemoryEffects<[MemRead, MemWrite]>
+]> {
   let summary = "Pseudo op for descriptor-based copy between global tensor descriptor and shared memdesc.";
 
   let description = [{
@@ -738,11 +741,13 @@ def TTG_TMACopyOp : TTG_Op<"tma_copy", [MemoryEffects<[MemRead, MemWrite]>]> {
   let arguments = (ins
     TTG_TMACopyOperand:$src,
     TTG_TMACopyOperand:$dst,
-    Variadic<I32>:$indices
+    Variadic<I32>:$indices,
+    Optional<I32>:$completionBarrier
   );
 
   let assemblyFormat =
-      "$src `,` $dst `,` `[` $indices `]` attr-dict `:` type($src) `,` type($dst)";
+      "$src `,` $dst `,` `[` $indices `]` (`barrier` $completionBarrier^)? "
+      "attr-dict `:` type($src) `,` type($dst)";
 
   let hasVerifier = 1;
 }

--- a/third_party/mthreads/lib/Analysis/Allocation.cpp
+++ b/third_party/mthreads/lib/Analysis/Allocation.cpp
@@ -187,14 +187,40 @@ private:
       return;
     }
     if (auto ws = dyn_cast<gpu::WarpSpecializeOp>(op)) {
+#ifdef __TLE__
+      // The restricted mthreads TLE lowering passes captures directly as SSA
+      // values and has no dispatcher state.  Keep walking the nested regions
+      // so their real allocations are still analyzed, but do not reserve the
+      // generic capture mailbox for the container itself.
+      if (ws->hasAttr("musa_tle.static_warp_specialize"))
+        return;
+      auto [captureSize, captureAlign] = ws.getCaptureSizeAlign();
+      maybeAddScratchBuffer<BufferT::BufferKind::Scratch>(op, captureSize,
+                                                          captureAlign);
+      return;
+#else
       // `ttg.warp_specialize` needs memory to pass its explicit captures. Pack
       // the captures like a struct.
       auto [captureSize, captureAlign] = ws.getCaptureSizeAlign();
       maybeAddScratchBuffer<BufferT::BufferKind::Scratch>(op, captureSize,
                                                           captureAlign);
       return;
+#endif // __TLE__
     }
     if (auto func = dyn_cast<FunctionOpInterface>(op)) {
+#ifdef __TLE__
+      unsigned numWarpIndices = 0;
+      // Static mthreads TLE partitions are selected directly from tid.x and
+      // need no per-warp state array.  Preserve the original allocation for
+      // every other warp-specialize operation.
+      func.walk([&](gpu::WarpSpecializeOp op) {
+        if (!op->hasAttr("musa_tle.static_warp_specialize"))
+          numWarpIndices =
+              std::max(numWarpIndices, op.getTotalPartitionWarps());
+      });
+      maybeAddScratchBuffer<BufferT::BufferKind::Scratch>(op, numWarpIndices);
+      return;
+#else
       unsigned numWarpIndices = 0;
       // Warp specialization communicates states over shared memory to each
       // warp. Add space for an i8 for each warpgroup warp.
@@ -203,6 +229,7 @@ private:
       });
       maybeAddScratchBuffer<BufferT::BufferKind::Scratch>(op, numWarpIndices);
       return;
+#endif // __TLE__
     }
     unsigned bytes = scratchSizeGetter(op);
     maybeAddScratchBuffer<BufferT::BufferKind::Scratch>(op, bytes,
@@ -522,6 +549,24 @@ private:
       return buffer->owner ? buffer->owner->getParentOfType<scf::ForOp>()
                            : scf::ForOp();
     };
+#ifdef __TLE__
+    auto getStaticWarpExecutionRegion = [](Operation *owner,
+                                           Operation *ws) -> Region * {
+      while (owner && owner != ws) {
+        Region *region = owner->getParentRegion();
+        Operation *parent = region ? region->getParentOp() : nullptr;
+        if (parent == ws)
+          return region;
+        if (auto partitions =
+                dyn_cast_or_null<gpu::WarpSpecializePartitionsOp>(parent)) {
+          if (partitions->getParentOp() == ws)
+            return region;
+        }
+        owner = parent;
+      }
+      return nullptr;
+    };
+#endif // __TLE__
 
     // Reset interference graph
     interference.clear();
@@ -550,11 +595,26 @@ private:
         // each other.
         auto wsx = x->owner->getParentWithTrait<OpTrait::AsyncRegions>();
         auto wsy = y->owner->getParentWithTrait<OpTrait::AsyncRegions>();
+#ifdef __TLE__
+        bool differentConcurrentRegions =
+            x->owner->getParentRegion() != y->owner->getParentRegion();
+        if (wsx && wsx == wsy &&
+            wsx->hasAttr("musa_tle.static_warp_specialize")) {
+          Region *xRegion = getStaticWarpExecutionRegion(x->owner, wsx);
+          Region *yRegion = getStaticWarpExecutionRegion(y->owner, wsy);
+          differentConcurrentRegions = xRegion && yRegion && xRegion != yRegion;
+        }
+        if (wsx && wsy && wsx == wsy && differentConcurrentRegions &&
+            xSizeRange.intersects(ySizeRange)) {
+          interference[x].insert(y);
+        }
+#else
         if (wsx && wsy && wsx == wsy &&
             x->owner->getParentRegion() != y->owner->getParentRegion() &&
             xSizeRange.intersects(ySizeRange)) {
           interference[x].insert(y);
         }
+#endif // __TLE__
 
         // SQMMA local_alloc buffers in the same loop iteration are consumed
         // together by dot operations and must not alias. Keep this protection

--- a/third_party/mthreads/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/third_party/mthreads/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -855,6 +855,8 @@ void populateMUSATlePatterns(TritonGPUTypeConverter &typeConverter,
   MLIRContext *context = patterns.getContext();
   patterns.add<GenericOpPattern<mlir::triton::musa_tle::LocalPointersOp>,
                GenericOpPattern<mlir::triton::musa_tle::ExclusiveCumsumOp>,
+               GenericOpPattern<mlir::triton::musa_tle::SqmmaOp>,
+               GenericOpPattern<mlir::triton::musa_tle::SqmmaWaitOp>,
                MUSATLEExtractTilePattern, MUSATLEInsertTilePattern>(
       typeConverter, context);
 }

--- a/third_party/mthreads/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/third_party/mthreads/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -909,6 +909,18 @@ LogicalResult TMACopyOp::verify() {
   }
   if (globalToLocal && !memDescTy.getMutableMemory())
     return emitOpError("cannot copy into immutable memdesc");
+
+  if (getCompletionBarrier()) {
+    if (!globalToLocal)
+      return emitOpError(
+          "completion barrier is only supported for global-to-shared copy");
+    auto expectBytes = (*this)->getAttrOfType<IntegerAttr>("expect_bytes");
+    if (!expectBytes || expectBytes.getInt() <= 0)
+      return emitOpError(
+          "completion barrier requires a positive expect_bytes attribute");
+  } else if ((*this)->getAttr("expect_bytes")) {
+    return emitOpError("expect_bytes requires a completion barrier operand");
+  }
   return success();
 }
 #endif // __TLE__

--- a/third_party/mthreads/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/third_party/mthreads/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -1601,6 +1601,48 @@ bool backwardRematerialization(ModuleOp module) {
   return changed;
 }
 
+#ifdef __TLE__
+bool retargetTleSqmmaStores(ModuleOp module) {
+  bool changed = false;
+  SmallVector<StoreOp> stores;
+  module.walk([&](StoreOp store) { stores.push_back(store); });
+  for (StoreOp store : stores) {
+    if (!store || !store->getBlock())
+      continue;
+    auto valueConvert = store.getValue().getDefiningOp<ConvertLayoutOp>();
+    if (!valueConvert)
+      continue;
+    auto targetTy = dyn_cast<RankedTensorType>(valueConvert.getSrc().getType());
+    if (!targetTy || !targetTy.getEncoding())
+      continue;
+    if (!isa<MUSASqmmaEncodingAttr>(targetTy.getEncoding()))
+      continue;
+
+    auto ptrTy = dyn_cast<RankedTensorType>(store.getPtr().getType());
+    if (!ptrTy || ptrTy.getShape() != targetTy.getShape())
+      continue;
+    OpBuilder builder(store);
+    auto nativePtrTy = ptrTy.cloneWithEncoding(targetTy.getEncoding());
+    Value nativePtr = ConvertLayoutOp::create(builder, store.getLoc(),
+                                              nativePtrTy, store.getPtr());
+    store.getPtrMutable().assign(nativePtr);
+    store.getValueMutable().assign(valueConvert.getSrc());
+    if (Value oldMask = store.getMask()) {
+      auto maskTy = cast<RankedTensorType>(oldMask.getType());
+      auto nativeMaskTy = maskTy.cloneWithEncoding(targetTy.getEncoding());
+      Value nativeMask = ConvertLayoutOp::create(builder, store.getLoc(),
+                                                 nativeMaskTy, oldMask);
+      store.getMaskMutable().assign(nativeMask);
+    }
+    if (valueConvert->use_empty())
+      valueConvert.erase();
+    changed = true;
+  }
+
+  return changed;
+}
+#endif // __TLE__
+
 void hoistConvert(ModuleOp module) {
   SmallVector<ConvertLayoutOp> convertOps;
   module.walk([](FuncOp funcOp) {
@@ -1672,6 +1714,14 @@ public:
 
       // Cleanup dummy converts created during backward remat.
       cleanupConvertOps();
+#ifdef __TLE__
+      if (m->hasAttr("tle.enable_encoding_rematerialization")) {
+        changed |= retargetTleSqmmaStores(m);
+        cleanupConvertOps();
+      }
+#else
+      // Preserve the original non-TLE fixed-point behavior.
+#endif // __TLE__
     } while (changed);
     // 3. For remaining converts, try to hoist them above cast generating larger
     // size types in order to reduce the cost of the convert op.

--- a/third_party/mthreads/musa/include/Dialect/MUSA/IR/MUSAOps.td
+++ b/third_party/mthreads/musa/include/Dialect/MUSA/IR/MUSAOps.td
@@ -168,6 +168,16 @@ def MUSA_ArriveBarrierNoRetOp : MUSA_Op<"arrive_barrier_noret", []> {
   let hasVerifier = 1;
 }
 
+#ifdef __TLE__
+def MUSA_WarpArriveBarrierOp : MUSA_Op<"warp_arrive_barrier", []> {
+  let summary = "Perform a convergent warp arrival without returning phase";
+  let arguments = (ins I32:$barId, I32:$phaseId);
+  let assemblyFormat =
+      "$barId `,` $phaseId attr-dict `:` type($barId)";
+  let hasVerifier = 1;
+}
+#endif // __TLE__
+
 def MUSA_WaitBarrierOp : MUSA_Op<"wait_barrier", [
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   ]> {

--- a/third_party/mthreads/musa/include/TritonMUSACommon/TMEUtils.h
+++ b/third_party/mthreads/musa/include/TritonMUSACommon/TMEUtils.h
@@ -28,6 +28,15 @@ namespace mlir::triton::musa {
 namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
 
+#ifdef __TLE__
+inline constexpr llvm::StringLiteral kTMEIssueThreadAttr =
+    "musa.tme.issue_thread";
+inline constexpr llvm::StringLiteral kTMEExplicitCompletionAttr =
+    "musa.tme.explicit_completion";
+inline constexpr llvm::StringLiteral kTLEExpectBytesAttr =
+    "musa_tle.expect_bytes";
+#endif // __TLE__
+
 enum class TMECopyKind {
   GlobalToLocal,
   LocalToGlobal,

--- a/third_party/mthreads/musa/lib/Dialect/MUSA/IR/Dialect.cpp
+++ b/third_party/mthreads/musa/lib/Dialect/MUSA/IR/Dialect.cpp
@@ -522,6 +522,14 @@ LogicalResult ArriveBarrierNoRetOp::verify() {
 #endif // __TLE__
 }
 
+#ifdef __TLE__
+LogicalResult WarpArriveBarrierOp::verify() {
+  if (failed(verifyAsyncBarrierId(getOperation(), getBarId(), "barId")))
+    return failure();
+  return verifyNonNegativeI32Constant(getOperation(), getPhaseId(), "phaseId");
+}
+#endif // __TLE__
+
 LogicalResult WaitBarrierOp::verify() {
   if (failed(verifyAsyncBarrierId(getOperation(), getBarId(), "barId")))
     return failure();

--- a/third_party/mthreads/musa/lib/Dialect/MUSA/IR/Dialect.cpp
+++ b/third_party/mthreads/musa/lib/Dialect/MUSA/IR/Dialect.cpp
@@ -481,11 +481,31 @@ LogicalResult InitArrivalOp::verify() {
   return verifyNonNegativeI32Constant(getOperation(), getPhaseId(), "phaseId");
 }
 
+#ifdef __TLE__
+static LogicalResult verifyTMEIssueThread(Operation *op) {
+  Attribute attr = op->getAttr(triton::musa::kTMEIssueThreadAttr);
+  if (!attr)
+    return success();
+  auto issueThread = dyn_cast<IntegerAttr>(attr);
+  if (!issueThread || !issueThread.getType().isInteger(32) ||
+      issueThread.getInt() < 0)
+    return op->emitOpError("musa.tme.issue_thread must be a non-negative i32");
+  return success();
+}
+#endif // __TLE__
+
 LogicalResult BarrierAddTransOp::verify() {
   if (failed(verifyAsyncBarrierId(getOperation(), getBarId(), "barId")))
     return failure();
+#ifdef __TLE__
+  if (failed(verifyNonNegativeI32Constant(getOperation(), getTransBytes(),
+                                          "transBytes")))
+    return failure();
+  return verifyTMEIssueThread(getOperation());
+#else
   return verifyNonNegativeI32Constant(getOperation(), getTransBytes(),
                                       "transBytes");
+#endif // __TLE__
 }
 
 LogicalResult ArriveBarrierOp::verify() {
@@ -493,7 +513,13 @@ LogicalResult ArriveBarrierOp::verify() {
 }
 
 LogicalResult ArriveBarrierNoRetOp::verify() {
+#ifdef __TLE__
+  if (failed(verifyAsyncBarrierId(getOperation(), getBarId(), "barId")))
+    return failure();
+  return verifyTMEIssueThread(getOperation());
+#else
   return verifyAsyncBarrierId(getOperation(), getBarId(), "barId");
+#endif // __TLE__
 }
 
 LogicalResult WaitBarrierOp::verify() {
@@ -553,7 +579,13 @@ LogicalResult AsyncTMECopyGlobalToLocalOp::verify() {
   if (failed(verifyTMECopyShapeContract(getOperation(), getCoord(),
                                         getBlockShape())))
     return failure();
+#ifdef __TLE__
+  if (failed(verifyTMESwizzleContract(*this)))
+    return failure();
+  return verifyTMEIssueThread(getOperation());
+#else
   return verifyTMESwizzleContract(*this);
+#endif // __TLE__
 }
 
 LogicalResult AsyncTMECopyLocalToGlobalOp::verify() {

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -4,6 +4,9 @@
 #include "TritonMUSACommon/TMEUtils.h"
 #include "TritonMUSAGPUToLLVM/Utility.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#ifdef __TLE__
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#endif // __TLE__
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
@@ -16,6 +19,9 @@
 #include "triton/Tools/LayoutUtils.h"
 #include <algorithm>
 #include <functional>
+#ifdef __TLE__
+#include <limits>
+#endif // __TLE__
 #include <numeric>
 
 using namespace mlir;
@@ -900,8 +906,45 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp> {
 
     auto *ctx = rewriter.getContext();
     auto freeVarMasks = getFreeVariableMasks(ptr.getType());
+#ifdef __TLE__
     Value threadPred =
         emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
+    if (!isa<RankedTensorType>(ptr.getType())) {
+      auto partitions =
+          op->getParentOfType<triton::gpu::WarpSpecializePartitionsOp>();
+      auto ws = partitions ? dyn_cast<triton::gpu::WarpSpecializeOp>(
+                                 partitions->getParentOp())
+                           : triton::gpu::WarpSpecializeOp();
+      if (ws && ws->hasAttr("musa_tle.static_warp_specialize")) {
+        ModuleOp module = op->getParentOfType<ModuleOp>();
+        auto numWarps =
+            module->getAttrOfType<IntegerAttr>(triton::gpu::AttrNumWarpsName);
+        auto threadsPerWarp = module->getAttrOfType<IntegerAttr>(
+            triton::gpu::AttrNumThreadsPerWarp);
+        if (!numWarps || !threadsPerWarp || numWarps.getInt() <= 0 ||
+            threadsPerWarp.getInt() <= 0) {
+          return op.emitOpError(
+              "static WS partition store requires ttg.num-warps and "
+              "ttg.threads-per-warp");
+        }
+        if (numWarps.getInt() >
+            std::numeric_limits<int32_t>::max() / threadsPerWarp.getInt())
+          return op.emitOpError(
+              "static WS partition leader exceeds int32 range");
+        int64_t firstPartitionThread =
+            numWarps.getInt() * threadsPerWarp.getInt();
+        Value rawThreadId = ::mlir::gpu::ThreadIdOp::create(
+            rewriter, loc, ::mlir::gpu::Dimension::x);
+        rawThreadId =
+            arith::IndexCastOp::create(rewriter, loc, i32_ty, rawThreadId);
+        threadPred = b.icmp_eq(
+            rawThreadId, b.i32_val(static_cast<int32_t>(firstPartitionThread)));
+      }
+    }
+#else
+    Value threadPred =
+        emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
+#endif // __TLE__
     uint32_t regMask = freeVarMasks.lookup(str_attr("reg"));
 
     if (vec == 1) {

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUToLLVM/MUSAOpsToLLVM.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUToLLVM/MUSAOpsToLLVM.cpp
@@ -529,6 +529,25 @@ struct ArriveBarrierNoRetOpConversion
   }
 };
 
+#ifdef __TLE__
+struct WarpArriveBarrierOpConversion
+    : public ConvertOpToLLVMPattern<triton::musa::WarpArriveBarrierOp> {
+  using ConvertOpToLLVMPattern<
+      triton::musa::WarpArriveBarrierOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::musa::WarpArriveBarrierOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Value> operands = {adaptor.getBarId()};
+    LLVM::createLLVMIntrinsicCallOp(rewriter, op.getLoc(),
+                                    "llvm.musa.async.arrive.none.phaseid",
+                                    TypeRange{}, operands);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+#endif // __TLE__
+
 struct WaitBarrierOpConversion
     : public ConvertOpToLLVMPattern<triton::musa::WaitBarrierOp> {
   using ConvertOpToLLVMPattern<
@@ -580,8 +599,6 @@ struct AsyncTMECopyGlobalToLocalOpConversion
                                       memDescTy.getElementType(), loc, rewriter,
                                       this->getTypeConverter());
     }
-    Value descAddr = normalizeTMEDescriptorAddr(
-        adaptor.getDesc(), op.getDesc().getType(), loc, rewriter);
 
     auto sgAttr = op->getAttrOfType<triton::musa::TMESwizzleGranularityAttr>(
         "swizzleGranularity");
@@ -642,6 +659,8 @@ struct AsyncTMECopyGlobalToLocalOpConversion
     rewriter.setInsertionPointToEnd(currentBlock);
     LLVM::CondBrOp::create(rewriter, loc, launchPred, trueBlock, afterCall);
     rewriter.setInsertionPointToStart(trueBlock);
+    Value descAddr = normalizeTMEDescriptorAddr(
+        adaptor.getDesc(), op.getDesc().getType(), loc, rewriter);
     for (const auto &segment : loadSegments) {
       SmallVector<Value> operands = {
           adaptor.getBarId(), segment.dstAddr,  descAddr,
@@ -693,8 +712,6 @@ struct AsyncTMECopyLocalToGlobalOpConversion
                                       memDescTy.getElementType(), loc, rewriter,
                                       this->getTypeConverter());
     }
-    Value descAddr = normalizeTMEDescriptorAddr(
-        adaptor.getDesc(), op.getDesc().getType(), loc, rewriter);
 
     auto sgAttr = op->getAttrOfType<triton::musa::TMESwizzleGranularityAttr>(
         "swizzleGranularity");
@@ -723,11 +740,6 @@ struct AsyncTMECopyLocalToGlobalOpConversion
 #else
     Value launchPred = buildTMEIssuePredicate(adaptor.getPred(), loc, rewriter);
 #endif // __TLE__
-    SmallVector<Value> operands = {
-        srcAddr,     descAddr,           blockDim,
-        blockPos,    swizzleGranularity, swizzleStride,
-        swizzleLine, innerPersistence,   outerPersistence,
-        cachePolicy};
 
     Block *currentBlock = rewriter.getInsertionBlock();
     Block *afterCall =
@@ -736,6 +748,13 @@ struct AsyncTMECopyLocalToGlobalOpConversion
     rewriter.setInsertionPointToEnd(currentBlock);
     LLVM::CondBrOp::create(rewriter, loc, launchPred, trueBlock, afterCall);
     rewriter.setInsertionPointToStart(trueBlock);
+    Value descAddr = normalizeTMEDescriptorAddr(
+        adaptor.getDesc(), op.getDesc().getType(), loc, rewriter);
+    SmallVector<Value> operands = {
+        srcAddr,     descAddr,           blockDim,
+        blockPos,    swizzleGranularity, swizzleStride,
+        swizzleLine, innerPersistence,   outerPersistence,
+        cachePolicy};
     LLVM::createLLVMIntrinsicCallOp(rewriter, loc, intrinsic, TypeRange{},
                                     operands);
     LLVM::BrOp::create(rewriter, loc, afterCall);
@@ -791,4 +810,7 @@ void mlir::triton::MUSA::populateMUSAOpsToLLVMPatterns(
            WaitBarrierOpConversion, AsyncTMECopyGlobalToLocalOpConversion,
            AsyncTMECopyLocalToGlobalOpConversion, TMEStoreCommitOpConversion,
            TMEStoreReadWaitOpConversion>(typeConverter, benefit);
+#ifdef __TLE__
+  patterns.add<WarpArriveBarrierOpConversion>(typeConverter, benefit);
+#endif // __TLE__
 }

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUToLLVM/MUSAOpsToLLVM.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUToLLVM/MUSAOpsToLLVM.cpp
@@ -207,6 +207,32 @@ std::optional<int64_t> inferElemBytesFromMemDesc(Type type) {
   return static_cast<int64_t>((bitWidth + 7) / 8);
 }
 
+#ifdef __TLE__
+Value buildTMEIssuePredicate(Value userPred, Location loc,
+                             ConversionPatternRewriter &rewriter,
+                             Operation *issueOp = nullptr) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  int32_t issueThread = 0;
+  bool hasExplicitIssueThread = false;
+  if (issueOp) {
+    if (auto attr = issueOp->getAttrOfType<IntegerAttr>(
+            triton::musa::kTMEIssueThreadAttr)) {
+      issueThread = static_cast<int32_t>(attr.getInt());
+      hasExplicitIssueThread = true;
+    }
+  }
+  Value threadId;
+  if (hasExplicitIssueThread) {
+    threadId = ::mlir::gpu::ThreadIdOp::create(rewriter, loc,
+                                               ::mlir::gpu::Dimension::x);
+    threadId = arith::IndexCastOp::create(rewriter, loc, i32_ty, threadId);
+  } else {
+    threadId = getThreadId(rewriter, loc);
+  }
+  Value issuerPred = b.icmp_eq(threadId, b.i32_val(issueThread));
+  return b.and_(userPred, issuerPred);
+}
+#else
 Value buildTMEIssuePredicate(Value userPred, Location loc,
                              ConversionPatternRewriter &rewriter) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -214,6 +240,7 @@ Value buildTMEIssuePredicate(Value userPred, Location loc,
   Value issuerPred = b.icmp_eq(threadId, b.i32_val(0));
   return b.and_(userPred, issuerPred);
 }
+#endif // __TLE__
 
 Value buildTMEIssueOnlyPredicate(Location loc,
                                  ConversionPatternRewriter &rewriter) {
@@ -447,7 +474,12 @@ struct BarrierAddTransOpConversion
   matchAndRewrite(triton::musa::BarrierAddTransOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
+#ifdef __TLE__
+    Value launchPred =
+        buildTMEIssuePredicate(adaptor.getPred(), loc, rewriter, op);
+#else
     Value launchPred = buildTMEIssuePredicate(adaptor.getPred(), loc, rewriter);
+#endif // __TLE__
     SmallVector<Value> operands = {adaptor.getBarId(), adaptor.getTransBytes()};
     emitPredicatedVoidIntrinsic(rewriter, loc, launchPred,
                                 "llvm.musa.async.add.trans", operands);
@@ -482,7 +514,12 @@ struct ArriveBarrierNoRetOpConversion
   matchAndRewrite(triton::musa::ArriveBarrierNoRetOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
+#ifdef __TLE__
+    Value launchPred =
+        buildTMEIssuePredicate(adaptor.getPred(), loc, rewriter, op);
+#else
     Value launchPred = buildTMEIssuePredicate(adaptor.getPred(), loc, rewriter);
+#endif // __TLE__
     SmallVector<Value> operands = {adaptor.getBarId()};
     emitPredicatedVoidIntrinsic(rewriter, loc, launchPred,
                                 "llvm.musa.async.arrive.none.phaseid",
@@ -572,10 +609,21 @@ struct AsyncTMECopyGlobalToLocalOpConversion
     Value outerPersistence = materializeTMEEnumAttr(loc, outerAttr, rewriter);
     Value cachePolicy = materializeTMEEnumAttr(loc, cacheAttr, rewriter);
 
+#ifdef __TLE__
+    if (!op->hasAttr(triton::musa::kTMEExplicitCompletionAttr))
+      LLVM::createLLVMIntrinsicCallOp(rewriter, loc, "llvm.musa.barrier0",
+                                      TypeRange{}, {});
+#else
     LLVM::createLLVMIntrinsicCallOp(rewriter, loc, "llvm.musa.barrier0",
                                     TypeRange{}, {});
+#endif // __TLE__
 
+#ifdef __TLE__
+    Value launchPred =
+        buildTMEIssuePredicate(adaptor.getPred(), loc, rewriter, op);
+#else
     Value launchPred = buildTMEIssuePredicate(adaptor.getPred(), loc, rewriter);
+#endif // __TLE__
     auto recoveredContract =
         triton::musa::recoverAndVerifyGroupedTMELoadConsumerContract(op);
     if (failed(recoveredContract))
@@ -669,7 +717,12 @@ struct AsyncTMECopyLocalToGlobalOpConversion
     Value innerPersistence = materializeTMEEnumAttr(loc, innerAttr, rewriter);
     Value outerPersistence = materializeTMEEnumAttr(loc, outerAttr, rewriter);
     Value cachePolicy = materializeTMEEnumAttr(loc, cacheAttr, rewriter);
+#ifdef __TLE__
+    Value launchPred =
+        buildTMEIssuePredicate(adaptor.getPred(), loc, rewriter, op);
+#else
     Value launchPred = buildTMEIssuePredicate(adaptor.getPred(), loc, rewriter);
+#endif // __TLE__
     SmallVector<Value> operands = {
         srcAddr,     descAddr,           blockDim,
         blockPos,    swizzleGranularity, swizzleStride,

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -31,6 +31,11 @@
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/TypeConverter.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#ifdef __TLE__
+#include "mlir/Conversion/Passes.h"
+#include "mlir/Pass/PassManager.h"
+#include "triton/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.h"
+#endif // __TLE__
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -491,6 +496,34 @@ struct ConvertTritonMUSAGPUToLLVM
     TritonLLVMConversionTarget convTarget(*context);
     if (failed(applyPartialConversion(mod, convTarget, std::move(patterns))))
       return signalPassFailure();
+
+#ifdef __TLE__
+    // Warp-specialize is deliberately legal during the ordinary MUSA
+    // conversion so its producer/default regions remain structurally
+    // available to the TLE late-lowering pass.  Convert only the container
+    // boundary types here, after the nested operations have been converted.
+    SmallVector<Operation *> staticWarpSpecializeOps;
+    mod.walk([&](Operation *op) {
+      if (!isa<triton::gpu::WarpSpecializeOp,
+               triton::gpu::WarpSpecializePartitionsOp,
+               triton::gpu::WarpYieldOp, triton::gpu::WarpReturnOp>(op))
+        return;
+      auto ws = dyn_cast<triton::gpu::WarpSpecializeOp>(op);
+      if (!ws)
+        ws = op->getParentOfType<triton::gpu::WarpSpecializeOp>();
+      if (ws && ws->hasAttr("musa_tle.static_warp_specialize"))
+        staticWarpSpecializeOps.push_back(op);
+    });
+    for (Operation *op : staticWarpSpecializeOps)
+      mlir::triton::convertOpTypes(op, typeConverter);
+
+    if (!staticWarpSpecializeOps.empty()) {
+      OpPassManager cleanup;
+      cleanup.addPass(createReconcileUnrealizedCastsPass());
+      if (failed(runPipeline(cleanup, mod)))
+        return signalPassFailure();
+    }
+#endif // __TLE__
 
     if (failed(lowerPredicatedLoadStoreCalls(mod, computeCapability)))
       return signalPassFailure();

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/IssueBarrierInsertion.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/IssueBarrierInsertion.cpp
@@ -65,6 +65,14 @@ shouldInsertIssueBarrierBefore(triton::musa::AsyncTMECopyLocalToGlobalOp op) {
 }
 
 static bool shouldInsertIssueBarrierBefore(triton::musa::SquadDotOp op) {
+#ifdef __TLE__
+  for (Operation *parent = op->getParentOp(); parent;
+       parent = parent->getParentOp()) {
+    if (parent->hasAttr("musa_tle.static_warp_specialize") &&
+        op->hasAttr("musa_tle.explicit_sqmma"))
+      return false;
+  }
+
   Operation *prev = op->getPrevNode();
   auto prevBarrier = dyn_cast_or_null<ttg::BarrierOp>(prev);
   if (isIssueBarrier(prevBarrier))
@@ -79,6 +87,22 @@ static bool shouldInsertIssueBarrierBefore(triton::musa::SquadDotOp op) {
     return true;
 
   return triton::musa::needsSqmmaIssueBarrier(aMemDesc, bMemDesc);
+#else
+  Operation *prev = op->getPrevNode();
+  auto prevBarrier = dyn_cast_or_null<ttg::BarrierOp>(prev);
+  if (isIssueBarrier(prevBarrier))
+    return false;
+
+  Value aMemDesc = peelSqmmaIssueOperand(op.getA());
+  Value bMemDesc = peelSqmmaIssueOperand(op.getB());
+  if (!aMemDesc || !bMemDesc)
+    return true;
+  if (!isa<ttg::MemDescType>(aMemDesc.getType()) ||
+      !isa<ttg::MemDescType>(bMemDesc.getType()))
+    return true;
+
+  return triton::musa::needsSqmmaIssueBarrier(aMemDesc, bMemDesc);
+#endif // __TLE__
 }
 
 static void insertIssueBarrierBefore(Operation *op, RewriterBase &rewriter) {

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/SqmmaPipelineUtils.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/SqmmaPipelineUtils.cpp
@@ -476,6 +476,38 @@ collectPipelineSqmmaDots(scf::ForOp loop) {
 } // namespace
 
 void pipelineSqmma(ModuleOp moduleOp, unsigned numStages) {
+#ifdef __TLE__
+  SmallVector<scf::ForOp> loops;
+  moduleOp.walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
+
+  for (scf::ForOp loop : loops) {
+    if (tt::getNumStagesOrDefault(loop, numStages) < 1)
+      continue;
+
+    SmallVector<triton::musa::SquadDotOp> sqmmaDots =
+        collectPipelineSqmmaDots(loop);
+    llvm::erase_if(sqmmaDots, [](triton::musa::SquadDotOp dot) {
+      return dot->hasAttr("musa_tle.explicit_sqmma");
+    });
+    if (sqmmaDots.empty())
+      continue;
+
+    ProperlyAsyncDots properlyAsyncDots;
+    for (triton::musa::SquadDotOp sqmma : sqmmaDots) {
+      sqmma->setAttr("isAsync", BoolAttr::get(moduleOp.getContext(), true));
+      if (auto iterArgIdx = dotCanBeProperlyAsync(sqmma, loop)) {
+        properlyAsyncDots[sqmma] = *iterArgIdx;
+        continue;
+      }
+
+      auto wait = getOrCreateWaitAfter(sqmma);
+      (void)threadValuesThroughWait(wait, {sqmma.getResult()}, loop);
+    }
+
+    insertAsyncSqmmaWaitsInLoop(loop, properlyAsyncDots);
+    insertFinalWaitAfterLoop(loop, properlyAsyncDots);
+  }
+#else
   SmallVector<scf::ForOp> loops;
   moduleOp.walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
 
@@ -503,6 +535,7 @@ void pipelineSqmma(ModuleOp moduleOp, unsigned numStages) {
     insertAsyncSqmmaWaitsInLoop(loop, properlyAsyncDots);
     insertFinalWaitAfterLoop(loop, properlyAsyncDots);
   }
+#endif // __TLE__
 }
 
 } // namespace mlir::triton::musa::pipeline

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/TMELowering.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/TMELowering.cpp
@@ -198,6 +198,24 @@ static LogicalResult lowerTMACopy(ttg::TMACopyOp op, RewriterBase &rewriter) {
     if (failed(config))
       return op.emitOpError("unable to resolve final TME load config");
 
+    // An explicitly supplied TLE completion barrier belongs to the caller's
+    // staged pipeline.  Preserve that hardware barrier ID and defer its
+    // transaction accounting/arrival protocol to the TLE pipeline lowering;
+    // do not allocate a hidden per-copy barrier here.
+    if (Value completionBarrier = op.getCompletionBarrier()) {
+      auto expectBytes = op->getAttrOfType<IntegerAttr>("expect_bytes");
+      if (!expectBytes || expectBytes.getInt() <= 0)
+        return op.emitOpError(
+            "completion barrier requires positive expect_bytes");
+      auto asyncCopy = triton::musa::createAsyncTMECopyGlobalToLocal(
+          rewriter, loc, op.getSrc(), *coord, completionBarrier, op.getDst(),
+          pred, *config);
+      asyncCopy->setAttr("musa_tle.expect_bytes",
+                         rewriter.getI32IntegerAttr(expectBytes.getInt()));
+      rewriter.eraseOp(op);
+      return success();
+    }
+
     auto barId = triton::musa::reserveFreshBarrierId(op);
     if (failed(barId))
       return op.emitOpError("exhausted MUSA async barrier ids");

--- a/third_party/mthreads/python/test/unit/tle/benchmark/test_mm.py
+++ b/third_party/mthreads/python/test/unit/tle/benchmark/test_mm.py
@@ -1,0 +1,531 @@
+"""Benchmark native Triton MM, optimized TLE-WS MM, and Torch on MUSA.
+
+Pytest:
+    python -m pytest -q -s third_party/mthreads/python/test/unit/tle/benchmark/test_mm.py
+
+Command line:
+    python third_party/mthreads/python/test/unit/tle/benchmark/test_mm.py \
+        --shape 1024 1024 1024 --stages 1 2 3
+"""
+
+import argparse
+import os
+
+os.environ.setdefault("TRITON_BACKENDS_IN_TREE", "1")
+os.environ.setdefault("MUSA_LAUNCH_BLOCKING", "0")
+
+import pytest
+import torch
+import triton
+import triton.experimental.tle.language as tle
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+BLOCK_M = 256
+BLOCK_N = 256
+BLOCK_K = 64
+PANEL_WIDTH = 4
+NUM_WARPS = 16
+RTOL = 1.25e-1
+ATOL = 1.25e-1
+
+DEFAULT_SHAPES = (
+    (1024, 1024, 1024),
+    (2048, 2048, 2048),
+    (4096, 4096, 4096),
+    (8192, 8192, 8192),
+    (8192, 7168, 16384),
+)
+PYTEST_SHAPES = ((1024, 1024, 1024), )
+PYTEST_STAGES = (1, 2, 3)
+PYTEST_WARMUP = 5
+PYTEST_REP = 20
+BENCH_COLUMNS = (
+    "M",
+    "N",
+    "K",
+    "Stages",
+    "Torch (ms)",
+    "Triton (ms)",
+    "TLE-WS (ms)",
+    "Triton vs Torch",
+    "TLE-WS vs Torch",
+    "TLE-WS vs Triton",
+)
+_PYTEST_ROWS = []
+
+
+def _musa_available():
+    return hasattr(torch, "musa") and torch.musa.is_available()
+
+
+if not _musa_available() and __name__ != "__main__":
+    pytest.skip("MUSA device is not available", allow_module_level=True)
+
+
+@triton.jit
+def _native_rasterization_2d_column(
+    block_idx,
+    grid_x,
+    grid_y,
+    panel_width: tl.constexpr,
+):
+    panel_size = panel_width * grid_y
+    residual_panel_width = grid_x % panel_width
+    full_panels_size = grid_x // panel_width * panel_width * grid_y
+    panel_idx = block_idx // panel_size
+    panel_offset = block_idx % panel_size
+
+    width = tl.where(
+        block_idx >= full_panels_size,
+        residual_panel_width,
+        panel_width,
+    )
+    row_idx = panel_offset // width
+    mini_x = panel_offset % width
+    mini_x = tl.where(row_idx % 2 == 1, width - 1 - mini_x, mini_x)
+    row_idx = tl.where(panel_idx % 2 == 1, grid_y - 1 - row_idx, row_idx)
+    col_idx = panel_idx * panel_width + mini_x
+    return col_idx, row_idx
+
+
+@triton.jit
+def native_triton_mm_kernel(
+    a_desc,
+    b_desc,
+    c_ptr,
+    M,
+    N,
+    K,
+    block_m: tl.constexpr,
+    block_n: tl.constexpr,
+    block_k: tl.constexpr,
+    panel_width: tl.constexpr,
+    pipeline_stages: tl.constexpr,
+):
+    raw_bx = tl.program_id(axis=0)
+    raw_by = tl.program_id(axis=1)
+    grid_y = tl.cdiv(M, block_m)
+    grid_x = tl.cdiv(N, block_n)
+    block_idx = raw_bx + raw_by * grid_x
+    pid_n, pid_m = _native_rasterization_2d_column(
+        block_idx,
+        grid_x,
+        grid_y,
+        panel_width,
+    )
+
+    offset_a_m = pid_m * block_m
+    offset_b_n = pid_n * block_n
+    offset_m = offset_a_m + tl.arange(0, block_m)
+    offset_n = offset_b_n + tl.arange(0, block_n)
+    mask = (offset_m[:, None] < M) & (offset_n[None, :] < N)
+
+    acc = tl.zeros((block_m, block_n), dtype=tl.float32)
+    for k in tl.range(0, K, block_k, num_stages=pipeline_stages):
+        a = tl.load_tensor_descriptor(a_desc, [offset_a_m, k])
+        b = tl.load_tensor_descriptor(b_desc, [k, offset_b_n])
+        acc = tl.dot(a, b, acc=acc)
+
+    c_block_ptr = c_ptr + N * offset_m[:, None] + offset_n[None, :]
+    tl.store(c_block_ptr, acc.to(tl.float16), mask=mask)
+
+
+@triton.jit
+def _tle_ws_rasterization_2d_column(
+    block_idx,
+    grid_x,
+    grid_y,
+    panel_width: tl.constexpr,
+    full_panel: tl.constexpr,
+):
+    panel_size = panel_width * grid_y
+    panel_idx = block_idx // panel_size
+    panel_offset = block_idx % panel_size
+
+    if full_panel:
+        width = panel_width
+    else:
+        residual_panel_width = grid_x % panel_width
+        full_panels_size = grid_x // panel_width * panel_width * grid_y
+        width = tl.where(
+            block_idx >= full_panels_size,
+            residual_panel_width,
+            panel_width,
+        )
+    row_idx = panel_offset // width
+    mini_x = panel_offset % width
+    mini_x = tl.where(row_idx % 2 == 1, width - 1 - mini_x, mini_x)
+    row_idx = tl.where(panel_idx % 2 == 1, grid_y - 1 - row_idx, row_idx)
+    col_idx = panel_idx * panel_width + mini_x
+    return col_idx, row_idx
+
+
+@triton.jit
+def _tle_ws_mm_consumer(
+    a_reader,
+    b_reader,
+    c_ptr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    pid_m,
+    pid_n,
+    block_m: tl.constexpr,
+    block_n: tl.constexpr,
+    block_k: tl.constexpr,
+):
+    offset_m = pid_m * block_m + tl.arange(0, block_m)
+    offset_n = pid_n * block_n + tl.arange(0, block_n)
+    mask = (offset_m[:, None] < M) & (offset_n[None, :] < N)
+    k_tiles: tl.constexpr = tl.cdiv(K, block_k)
+
+    acc = tl.zeros((block_m, block_n), dtype=tl.float32)
+    for k_iter in tl.range(
+            0,
+            k_tiles,
+            num_stages=1,
+            loop_unroll_factor=k_tiles,
+    ):
+        a_wait = a_reader.wait(k_iter)
+        b_wait = b_reader.wait(k_iter)
+        acc = tle.gpu.wgmma(a_wait.slot.a, b_wait.slot.b, acc)
+        acc = tle.gpu.wgmma_wait(0, acc)
+        a_reader.release(k_iter)
+        b_reader.release(k_iter)
+
+    c_block_ptr = c_ptr + N * offset_m[:, None] + offset_n[None, :]
+    tl.store(c_block_ptr, acc.to(tl.float16), mask=mask)
+
+
+@triton.jit
+def _tle_ws_mm_producer(
+    a_writer,
+    b_writer,
+    a_desc,
+    b_desc,
+    K: tl.constexpr,
+    pid_m,
+    pid_n,
+    block_m: tl.constexpr,
+    block_n: tl.constexpr,
+    block_k: tl.constexpr,
+):
+    offset_a_m = pid_m * block_m
+    offset_b_n = pid_n * block_n
+    k_tiles: tl.constexpr = tl.cdiv(K, block_k)
+
+    for k_iter in tl.range(
+            0,
+            k_tiles,
+            num_stages=1,
+            loop_unroll_factor=k_tiles,
+    ):
+        offset_k = k_iter * block_k
+        a_slot = a_writer.acquire(k_iter)
+        b_slot = b_writer.acquire(k_iter)
+        tle.gpu.copy(
+            a_desc,
+            a_slot.a,
+            (block_m, block_k),
+            (offset_a_m, offset_k),
+        )
+        tle.gpu.copy(
+            b_desc,
+            b_slot.b,
+            (block_k, block_n),
+            (offset_k, offset_b_n),
+        )
+        a_writer.commit(k_iter)
+        b_writer.commit(k_iter)
+
+
+@triton.jit
+def tle_ws_mm_kernel(
+    a_desc,
+    b_desc,
+    c_ptr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    block_m: tl.constexpr,
+    block_n: tl.constexpr,
+    block_k: tl.constexpr,
+    panel_width: tl.constexpr,
+    pipeline_stages: tl.constexpr,
+    full_panel: tl.constexpr,
+):
+    raw_bx = tl.program_id(axis=0)
+    raw_by = tl.program_id(axis=1)
+    grid_x = tl.num_programs(axis=0)
+    grid_y = tl.num_programs(axis=1)
+    block_idx = raw_bx + raw_by * grid_x
+    pid_n, pid_m = _tle_ws_rasterization_2d_column(
+        block_idx,
+        grid_x,
+        grid_y,
+        panel_width,
+        full_panel,
+    )
+
+    a_smem = tle.gpu.alloc(
+        (pipeline_stages, block_m, block_k),
+        dtype=tl.float16,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=True,
+    )
+    b_smem = tle.gpu.alloc(
+        (pipeline_stages, block_k, block_n),
+        dtype=tl.float16,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=True,
+    )
+    a_pipe = tle.pipe(capacity=pipeline_stages, scope="cta", name="mm_a", a=a_smem)
+    b_pipe = tle.pipe(capacity=pipeline_stages, scope="cta", name="mm_b", b=b_smem)
+
+    tle.gpu.warp_specialize(
+        [
+            (
+                _tle_ws_mm_consumer,
+                (
+                    a_pipe.reader(),
+                    b_pipe.reader(),
+                    c_ptr,
+                    M,
+                    N,
+                    K,
+                    pid_m,
+                    pid_n,
+                    block_m,
+                    block_n,
+                    block_k,
+                ),
+            ),
+            (
+                _tle_ws_mm_producer,
+                (
+                    a_pipe.writer(),
+                    b_pipe.writer(),
+                    a_desc,
+                    b_desc,
+                    K,
+                    pid_m,
+                    pid_n,
+                    block_m,
+                    block_n,
+                    block_k,
+                ),
+            ),
+        ],
+        worker_num_warps=[4],
+        worker_num_regs=[24],
+    )
+
+
+def _validate_case(m, n, k, stages, block_m, block_n, block_k, panel_width):
+    if min(m, n, k) <= 0:
+        raise ValueError("M, N, and K must be positive")
+    if m % block_m or n % block_n or k % block_k:
+        raise ValueError("M/N/K must be divisible by BLOCK_M/BLOCK_N/BLOCK_K")
+    if stages not in (1, 2, 3):
+        raise ValueError("the optimized mthreads TLE-WS MM supports stages 1, 2, or 3")
+    if panel_width <= 0:
+        raise ValueError("panel_width must be positive")
+
+
+def _bench(fn, warmup, rep):
+    return float(triton.testing.do_bench(
+        fn,
+        device_type="musa",
+        warmup=warmup,
+        rep=rep,
+        return_mode="median",
+    ))
+
+
+def _speedup(reference_ms, candidate_ms):
+    return reference_ms / candidate_ms if candidate_ms else float("inf")
+
+
+def _run_case(
+    m,
+    n,
+    k,
+    stages,
+    warmup,
+    rep,
+    block_m=BLOCK_M,
+    block_n=BLOCK_N,
+    block_k=BLOCK_K,
+    panel_width=PANEL_WIDTH,
+    num_warps=NUM_WARPS,
+    seed=42,
+):
+    _validate_case(m, n, k, stages, block_m, block_n, block_k, panel_width)
+    torch.manual_seed(seed)
+    a = torch.randn((m, k), dtype=torch.float16, device="musa")
+    b = torch.randn((k, n), dtype=torch.float16, device="musa")
+    desc_a = TensorDescriptor.from_tensor(a, [block_m, block_k])
+    desc_b = TensorDescriptor.from_tensor(b, [block_k, block_n])
+    grid = (triton.cdiv(n, block_n), triton.cdiv(m, block_m), 1)
+    full_panel = grid[0] % panel_width == 0
+
+    def launch_torch():
+        return torch.mm(a, b)
+
+    def launch_triton():
+        output = torch.empty((m, n), dtype=torch.float16, device="musa")
+        native_triton_mm_kernel[grid](
+            desc_a,
+            desc_b,
+            output,
+            m,
+            n,
+            k,
+            block_m,
+            block_n,
+            block_k,
+            panel_width,
+            stages,
+            num_warps=num_warps,
+            num_stages=stages,
+        )
+        return output
+
+    def launch_tle_ws():
+        output = torch.empty((m, n), dtype=torch.float16, device="musa")
+        tle_ws_mm_kernel[grid](
+            desc_a,
+            desc_b,
+            output,
+            m,
+            n,
+            k,
+            block_m,
+            block_n,
+            block_k,
+            panel_width,
+            stages,
+            full_panel,
+            num_warps=num_warps,
+            num_stages=stages,
+        )
+        return output
+
+    torch_output = launch_torch()
+    triton_output = launch_triton()
+    tle_ws_output = launch_tle_ws()
+    torch.musa.synchronize()
+
+    reference = torch.mm(a.to(torch.float32), b.to(torch.float32))
+    torch.testing.assert_close(torch_output.float(), reference, rtol=RTOL, atol=ATOL)
+    torch.testing.assert_close(triton_output.float(), reference, rtol=RTOL, atol=ATOL)
+    torch.testing.assert_close(tle_ws_output.float(), reference, rtol=RTOL, atol=ATOL)
+    torch.musa.synchronize()
+
+    torch_ms = _bench(launch_torch, warmup, rep)
+    triton_ms = _bench(launch_triton, warmup, rep)
+    tle_ws_ms = _bench(launch_tle_ws, warmup, rep)
+    return {
+        "M": m,
+        "N": n,
+        "K": k,
+        "Stages": stages,
+        "Torch (ms)": torch_ms,
+        "Triton (ms)": triton_ms,
+        "TLE-WS (ms)": tle_ws_ms,
+        "Triton vs Torch": _speedup(torch_ms, triton_ms),
+        "TLE-WS vs Torch": _speedup(torch_ms, tle_ws_ms),
+        "TLE-WS vs Triton": _speedup(triton_ms, tle_ws_ms),
+    }
+
+
+def _format_value(column, value):
+    if column.endswith("(ms)"):
+        return f"{value:.6f}"
+    if " vs " in column:
+        return f"{value:.4f}x"
+    return str(value)
+
+
+def _print_table(title, rows):
+    string_rows = [[_format_value(column, row[column]) for column in BENCH_COLUMNS] for row in rows]
+    widths = [max(len(column), *(len(row[index]) for row in string_rows)) for index, column in enumerate(BENCH_COLUMNS)]
+    print(title)
+    print("  ".join(f"{column:>{widths[index]}}" for index, column in enumerate(BENCH_COLUMNS)))
+    for row in string_rows:
+        print("  ".join(f"{value:>{widths[index]}}" for index, value in enumerate(row)))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _print_pytest_results_once():
+    _PYTEST_ROWS.clear()
+    yield
+    if _PYTEST_ROWS:
+        _print_table("mthreads MM benchmark (correctness passed)", _PYTEST_ROWS)
+
+
+@pytest.mark.parametrize("shape", PYTEST_SHAPES)
+@pytest.mark.parametrize("stages", PYTEST_STAGES, ids=lambda value: f"stage{value}")
+def test_mm_correctness_and_benchmark(shape, stages):
+    _PYTEST_ROWS.append(_run_case(
+        *shape,
+        stages=stages,
+        warmup=PYTEST_WARMUP,
+        rep=PYTEST_REP,
+    ))
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description="Benchmark native Triton MM, optimized TLE-WS MM, and Torch on MUSA.")
+    parser.add_argument(
+        "--shape",
+        dest="shapes",
+        type=int,
+        nargs=3,
+        action="append",
+        metavar=("M", "N", "K"),
+        help="matrix shape; repeat to benchmark multiple shapes",
+    )
+    parser.add_argument("--stages", type=int, nargs="+", default=[1, 2, 3])
+    parser.add_argument("--warmup", type=int, default=25, help="do_bench warmup in milliseconds")
+    parser.add_argument("--rep", type=int, default=100, help="do_bench measurement time in milliseconds")
+    parser.add_argument("--block-m", type=int, default=BLOCK_M)
+    parser.add_argument("--block-n", type=int, default=BLOCK_N)
+    parser.add_argument("--block-k", type=int, default=BLOCK_K)
+    parser.add_argument("--panel-width", type=int, default=PANEL_WIDTH)
+    parser.add_argument("--num-warps", type=int, default=NUM_WARPS)
+    parser.add_argument("--seed", type=int, default=42)
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+    if args.warmup <= 0 or args.rep <= 0:
+        raise ValueError("warmup and rep must be positive")
+    if not _musa_available():
+        raise RuntimeError("MUSA device is not available")
+    shapes = [tuple(shape) for shape in args.shapes] if args.shapes else DEFAULT_SHAPES
+    rows = [
+        _run_case(
+            *shape,
+            stages=stages,
+            warmup=args.warmup,
+            rep=args.rep,
+            block_m=args.block_m,
+            block_n=args.block_n,
+            block_k=args.block_k,
+            panel_width=args.panel_width,
+            num_warps=args.num_warps,
+            seed=args.seed,
+        ) for shape in shapes for stages in args.stages
+    ]
+    _print_table(
+        "mthreads MM benchmark (correctness passed; "
+        f"llc_opt={os.environ.get('TRITON_MUSA_ENABLE_LLC_OPT', '0')})",
+        rows,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/third_party/mthreads/python/test/unit/tle/test_tle_alloc.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_alloc.py
@@ -61,6 +61,30 @@ def _alloc_explicit_swizzled_layout_roundtrip_kernel(src_ptr, out_ptr, LAYOUT: t
     tl.store(out_ptr + offs, values + 1.0)
 
 
+@triton.jit
+def _alloc_non_power_of_two_leading_kernel(
+    out_ptr,
+    STAGES: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    buf = tle.gpu.alloc(
+        (STAGES, BLOCK),
+        dtype=tl.float32,
+        nv_mma_shared_layout=False,
+    )
+    _consume_alloc(buf, out_ptr)
+
+
+@triton.jit
+def _alloc_non_power_of_two_tail_kernel(out_ptr):
+    buf = tle.gpu.alloc(
+        (3, 3),
+        dtype=tl.float32,
+        nv_mma_shared_layout=False,
+    )
+    _consume_alloc(buf, out_ptr)
+
+
 def test_tle_alloc_ttgir_emits_smem_memdesc():
     compiled = compile_musa(_alloc_kernel, signature={"out_ptr": "*fp32"})
     ttgir = compiled.asm["ttgir"]
@@ -71,6 +95,23 @@ def test_tle_alloc_ttgir_emits_smem_memdesc():
     assert "#ttg.swizzled_shared" in ttgir, ttgir
     assert "#ttg.nvmma_shared" not in ttgir, ttgir
     assert "tensor_memory" not in ttgir, ttgir
+
+
+def test_tle_alloc_supports_exact_three_stage_memdesc():
+    compiled = compile_musa(
+        _alloc_non_power_of_two_leading_kernel,
+        signature={"out_ptr": "*fp32", "STAGES": "constexpr", "BLOCK": "constexpr"},
+        constexprs={"STAGES": 3, "BLOCK": 128},
+    )
+    ttgir = compiled.asm["ttgir"]
+
+    assert "!ttg.memdesc<3x128xf32" in ttgir, ttgir
+    assert "!ttg.memdesc<4x128xf32" not in ttgir, ttgir
+
+
+def test_tle_alloc_keeps_power_of_two_constraint_for_slot_dimensions():
+    with pytest.raises(CompilationError, match="Shape element 1 must be a power of 2"):
+        compile_musa(_alloc_non_power_of_two_tail_kernel, signature={"out_ptr": "*fp32"})
 
 
 def test_tle_alloc_nv_mma_shared_layout_true_raises():

--- a/third_party/mthreads/python/test/unit/tle/test_tle_alloc.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_alloc.py
@@ -5,7 +5,7 @@ import triton.language as tl
 import triton.experimental.tle.language as tle
 from triton.compiler.errors import CompilationError
 
-from test_tle_utils import compile_musa, require_mthreads_libtriton
+from test_tle_utils import compile_musa, compile_to_ttir, require_mthreads_libtriton
 
 require_mthreads_libtriton()
 
@@ -114,14 +114,26 @@ def test_tle_alloc_keeps_power_of_two_constraint_for_slot_dimensions():
         compile_musa(_alloc_non_power_of_two_tail_kernel, signature={"out_ptr": "*fp32"})
 
 
-def test_tle_alloc_nv_mma_shared_layout_true_raises():
-    with pytest.raises(CompilationError, match="mthreads TLE alloc does not support nv_mma_shared_layout=True"):
-        compile_musa(_alloc_nv_mma_kernel, signature={"out_ptr": "*fp32"})
+def test_tle_alloc_nv_mma_shared_layout_true_marks_auto_layout():
+    ttir = compile_to_ttir(_alloc_nv_mma_kernel, signature={"out_ptr": "*fp32"})
+
+    assert ttir.count("musa_tle.auto_shared_layout") == 1, ttir
+    assert "#ttg.swizzled_shared" in ttir, ttir
+    assert "#ttg.nvmma_shared" not in ttir, ttir
 
 
-def test_tle_alloc_default_nv_mma_shared_layout_raises():
-    with pytest.raises(CompilationError, match="mthreads TLE alloc does not support nv_mma_shared_layout=True"):
-        compile_musa(_alloc_default_kernel, signature={"out_ptr": "*fp32"})
+def test_tle_alloc_default_marks_auto_layout():
+    ttir = compile_to_ttir(_alloc_default_kernel, signature={"out_ptr": "*fp32"})
+
+    assert ttir.count("musa_tle.auto_shared_layout") == 1, ttir
+    assert "#ttg.swizzled_shared" in ttir, ttir
+    assert "#ttg.nvmma_shared" not in ttir, ttir
+
+
+def test_tle_alloc_nv_mma_shared_layout_false_does_not_mark_auto_layout():
+    ttir = compile_to_ttir(_alloc_kernel, signature={"out_ptr": "*fp32"})
+
+    assert "musa_tle.auto_shared_layout" not in ttir, ttir
 
 
 def test_tle_alloc_explicit_swizzled_shared_layout_ttgir_emits_smem_memdesc():
@@ -136,6 +148,7 @@ def test_tle_alloc_explicit_swizzled_shared_layout_ttgir_emits_smem_memdesc():
     assert "#ttg.swizzled_shared" in ttgir, ttgir
     assert "#ttg.nvmma_shared" not in ttgir, ttgir
     assert "tensor_memory" not in ttgir, ttgir
+    assert "musa_tle.auto_shared_layout" not in ttgir, ttgir
 
 
 def test_tle_alloc_explicit_nv_mma_shared_layout_raises():

--- a/third_party/mthreads/python/test/unit/tle/test_tle_barrier.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_barrier.py
@@ -37,6 +37,31 @@ def _static_barrier_kernel(STAGES: tl.constexpr):
 
 
 @triton.jit
+def _four_group_barrier_kernel(STAGES: tl.constexpr):
+    full_a = tle.gpu.alloc_barriers(STAGES, arrive_count=1, init=tle.gpu.PENDING, expect_bytes=32768)
+    full_b = tle.gpu.alloc_barriers(STAGES, arrive_count=1, init=tle.gpu.PENDING, expect_bytes=32768)
+    empty_a = tle.gpu.alloc_barriers(STAGES, arrive_count=16, init=tle.gpu.READY)
+    empty_b = tle.gpu.alloc_barriers(STAGES, arrive_count=16, init=tle.gpu.READY)
+    for slot in tl.static_range(0, STAGES):
+        tle.gpu.barrier_wait(full_a[slot], phaseIdx=slot)
+        tle.gpu.barrier_wait(full_b[slot], phaseIdx=slot)
+        tle.gpu.barrier_arrive(empty_a[slot], phaseIdx=slot)
+        tle.gpu.barrier_arrive(empty_b[slot], phaseIdx=slot)
+
+
+@triton.jit
+def _exhausted_barrier_kernel():
+    bars_0 = tle.gpu.alloc_barriers(16)
+    bars_1 = tle.gpu.alloc_barriers(16)
+    bars_2 = tle.gpu.alloc_barriers(16)
+    bars_3 = tle.gpu.alloc_barriers(16)
+    tle.gpu.barrier_wait(bars_0[0], phaseIdx=0)
+    tle.gpu.barrier_wait(bars_1[0], phaseIdx=0)
+    tle.gpu.barrier_wait(bars_2[0], phaseIdx=0)
+    tle.gpu.barrier_wait(bars_3[0], phaseIdx=0)
+
+
+@triton.jit
 def _dynamic_barrier_kernel(stage, phase):
     bars = tle.gpu.alloc_barriers(
         2,
@@ -191,6 +216,40 @@ def _barrier_index_constants(ttir):
     return values
 
 
+def _constants(ir_text):
+    return {
+        name: int(value)
+        for name, value in re.findall(
+            r"(%[-\w.]+)\s*=\s*(?:arith\.)?constant\s+(-?\d+)\s*:\s*i32",
+            ir_text,
+        )
+    }
+
+
+def _init_arrivals(ir_text):
+    constants = _constants(ir_text)
+    return [(constants[bar_id], constants[arrive_count], constants[phase])
+            for bar_id, arrive_count, phase in re.findall(
+                r"ttmg\.init_arrival\s+(%[-\w.]+),\s*(%[-\w.]+),\s*(%[-\w.]+)",
+                ir_text,
+            )]
+
+
+def _assert_lowered_static_barrier_ir(ir_text, stages):
+    allocs, indices, waits, arrives = _extract_barrier_ops(ir_text)
+    assert (allocs, indices, waits, arrives) == (0, 0, 2 * stages, stages), ir_text
+    assert _init_arrivals(ir_text) == [
+        *[(slot + 1, 1, 0) for slot in range(stages)],
+        *[(stages + slot + 1, 16, 1) for slot in range(stages)],
+    ], ir_text
+    assert f"musa.max_bar_id = {2 * stages}" in ir_text, ir_text
+    assert "musa.next_bar_id" not in ir_text, ir_text
+    assert "ttmg.bar_record" in ir_text, ir_text
+    assert "ttg.memdesc_index" not in ir_text, ir_text
+    assert "ttg.local_alloc" not in ir_text, ir_text
+    assert "!ttg.memdesc" not in ir_text, ir_text
+
+
 def _assert_static_barrier_ir(ttir, stages):
     allocs, indices, waits, arrives = _extract_barrier_ops(ttir)
     assert allocs == 2, ttir
@@ -220,41 +279,124 @@ def _assert_static_barrier_ir(ttir, stages):
 
 @pytest.mark.parametrize("stages", [1, 2])
 def test_mthreads_tle_barrier_static_arrays_emit_mbarrier_ir(stages):
-    ir_modules = _compile_barrier_ir(
+    ttir, ttgir, allocated = _compile_barrier_ir(
         _static_barrier_kernel,
         {"STAGES": "constexpr"},
         {"STAGES": stages},
     )
-    for ir_text in ir_modules:
-        _assert_static_barrier_ir(ir_text, stages)
-    assert "ttg.shared = 0 : i32" in ir_modules[-1], ir_modules[-1]
+    _assert_static_barrier_ir(ttir, stages)
+    _assert_lowered_static_barrier_ir(ttgir, stages)
+    _assert_lowered_static_barrier_ir(allocated, stages)
+    assert "ttg.shared = 0 : i32" in allocated, allocated
+
+
+@pytest.mark.parametrize("stages", [1, 2])
+def test_mthreads_tle_four_barrier_groups_receive_contiguous_hardware_ids(stages):
+    ttir, ttgir, allocated = _compile_barrier_ir(
+        _four_group_barrier_kernel,
+        {"STAGES": "constexpr"},
+        {"STAGES": stages},
+    )
+    assert _extract_barrier_ops(ttir)[0] == 4, ttir
+    expected = [
+        *[(1 + slot, 1, 0) for slot in range(stages)],
+        *[(1 + stages + slot, 1, 0) for slot in range(stages)],
+        *[(1 + 2 * stages + slot, 16, 1) for slot in range(stages)],
+        *[(1 + 3 * stages + slot, 16, 1) for slot in range(stages)],
+    ]
+    for ir_text in (ttgir, allocated):
+        assert _init_arrivals(ir_text) == expected, ir_text
+        assert _extract_barrier_ops(ir_text)[0:2] == (0, 0), ir_text
+        assert f"musa.max_bar_id = {4 * stages}" in ir_text, ir_text
+        assert "musa.next_bar_id" not in ir_text, ir_text
+    assert "ttg.shared = 0 : i32" in allocated, allocated
+
+
+def _lower_backend_barrier_fixture(tmp_path, stages, existing_max=None):
+    function_attrs = ""
+    if existing_max is not None:
+        function_attrs = f" attributes {{musa.max_bar_id = {existing_max} : i32}}"
+    allocs = "\n".join(f"    %{index} = musa_tle.barrier.alloc "
+                       f"{{arrive_count = {1 if index < 2 else 16} : i32, "
+                       f"init_polarity = {0 if index < 2 else 1} : i32, "
+                       f"num_barriers = {stages} : i32}}" for index in range(4))
+    fixture = f"""module {{
+  tt.func public @barrier_fixture(){function_attrs} {{
+{allocs}
+    tt.return
+  }}
+}}
+"""
+    fixture_path = tmp_path / "barrier_fixture.ttgir"
+    fixture_path.write_text(fixture)
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    module = ir.parse_mlir_module(str(fixture_path), context)
+    pm = ir.pass_manager(context)
+    libtriton.mthreads.passes.ttgpuir.add_tle_lower_barrier_allocations(pm)
+    libtriton.mthreads.passes.ttgpuir.add_finalize_barriers(pm)
+    pm.run(module, "lower_backend_barrier_fixture")
+    return module.str_nodebug()
+
+
+def test_mthreads_tle_stage_three_barriers_use_backend_local_fixture(tmp_path):
+    lowered = _lower_backend_barrier_fixture(tmp_path, stages=3)
+    assert _init_arrivals(lowered) == [
+        *[(1 + slot, 1, 0) for slot in range(3)],
+        *[(4 + slot, 1, 0) for slot in range(3)],
+        *[(7 + slot, 16, 1) for slot in range(3)],
+        *[(10 + slot, 16, 1) for slot in range(3)],
+    ], lowered
+    assert "musa.max_bar_id = 12" in lowered, lowered
+    assert _extract_barrier_ops(lowered)[0:2] == (0, 0), lowered
+
+
+def test_mthreads_tle_barriers_follow_existing_musa_reservations(tmp_path):
+    lowered = _lower_backend_barrier_fixture(tmp_path, stages=1, existing_max=5)
+    assert _init_arrivals(lowered) == [
+        (6, 1, 0),
+        (7, 1, 0),
+        (8, 16, 1),
+        (9, 16, 1),
+    ], lowered
+    assert "musa.max_bar_id = 9" in lowered, lowered
+
+
+def test_mthreads_tle_barrier_id_exhaustion_has_stable_diagnostic(capfd):
+    with pytest.raises(RuntimeError, match="PassManager::run failed"):
+        _compile_barrier_ir(_exhausted_barrier_kernel, {})
+    stderr = capfd.readouterr().err
+    assert ("mthreads TLE barrier allocation exhausted hardware barrier ids: "
+            "cannot reserve 64 additional ids in [1, 63]") in stderr
 
 
 def test_mthreads_tle_barrier_preserves_dynamic_slot_and_phase():
-    ir_modules = _compile_barrier_ir(
+    ttir, ttgir, allocated = _compile_barrier_ir(
         _dynamic_barrier_kernel,
         {"stage": "i32", "phase": "i32"},
     )
-    for ir_text in ir_modules:
-        allocs, indices, waits, arrives = _extract_barrier_ops(ir_text)
-        assert (allocs, indices, waits, arrives) == (1, 1, 1, 1), ir_text
-        assert not re.search(r"(?<!musa_)tle\.barrier\.", ir_text), ir_text
-        assert "ttg.memdesc_index" not in ir_text, ir_text
-        assert "musa_tle.barrier.index" in ir_text, ir_text
-        assert "musa_tle.barrier.wait" in ir_text, ir_text
-        assert "musa_tle.barrier.arrive" in ir_text, ir_text
-        assert re.search(r"musa_tle\.barrier\.index\s+%[-\w.]+\[%arg0\]", ir_text), ir_text
+    assert _extract_barrier_ops(ttir) == (1, 1, 1, 1), ttir
+    assert re.search(r"musa_tle\.barrier\.index\s+%[-\w.]+\[%arg0\]", ttir), ttir
+    assert "num_barriers = 2" in ttir, ttir
+    for ir_text in (ttgir, allocated):
+        assert _extract_barrier_ops(ir_text) == (0, 0, 1, 1), ir_text
+        assert "arith.addi" in ir_text, ir_text
         assert re.search(r"arith\.andi\s+%arg1,", ir_text), ir_text
         assert "arith.xori" in ir_text, ir_text
-        assert "num_barriers = 2" in ir_text, ir_text
-    assert "ttg.shared = 0 : i32" in ir_modules[-1], ir_modules[-1]
+        assert _init_arrivals(ir_text) == [(1, 16, 1), (2, 16, 1)], ir_text
+    assert "ttg.shared = 0 : i32" in allocated, allocated
 
 
 def test_mthreads_tle_singleton_barrier_uses_indexed_slot():
-    for ir_text in _compile_barrier_ir(_singleton_barrier_kernel, {}):
-        allocs, indices, waits, arrives = _extract_barrier_ops(ir_text)
-        assert (allocs, indices, waits, arrives) == (1, 1, 1, 1), ir_text
-        assert _barrier_index_constants(ir_text) == [0], ir_text
+    ttir, ttgir, allocated = _compile_barrier_ir(_singleton_barrier_kernel, {})
+    assert _extract_barrier_ops(ttir) == (1, 1, 1, 1), ttir
+    assert _barrier_index_constants(ttir) == [0], ttir
+    for ir_text in (ttgir, allocated):
+        assert _extract_barrier_ops(ir_text) == (0, 0, 1, 1), ir_text
+        assert _init_arrivals(ir_text) == [(1, 1, 0)], ir_text
         assert "!ttg.memdesc" not in ir_text, ir_text
         assert "ttg.local_alloc" not in ir_text, ir_text
 
@@ -271,8 +413,10 @@ def test_mthreads_tle_barrier_bindings_are_backend_local():
             "create_barrier_arrive_mbarrier",
             "create_barrier_wait_named",
             "create_barrier_arrive_named",
+            "add_tle_lower_barrier_allocations",
     ):
-        assert hasattr(builder, name)
+        owner = (libtriton.mthreads.passes.ttgpuir if name.startswith("add_") else builder)
+        assert hasattr(owner, name)
 
 
 @pytest.mark.parametrize("kernel", [_named_barrier_kernel, _named_barrier_arrive_kernel])

--- a/third_party/mthreads/python/test/unit/tle/test_tle_barrier.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_barrier.py
@@ -113,6 +113,30 @@ def _non_integer_phase_kernel():
     tle.gpu.barrier_wait(bars[0], phaseIdx=0.0)
 
 
+@triton.jit
+def _completion_wait_missing_phase_kernel():
+    bar = tle.gpu.alloc_barrier(expect_bytes=32768)
+    tle.gpu.barrier_wait(bar)
+
+
+@triton.jit
+def _completion_arrive_missing_phase_kernel():
+    bar = tle.gpu.alloc_barrier(expect_bytes=32768)
+    tle.gpu.barrier_arrive(bar)
+
+
+@triton.jit
+def _ready_wait_missing_phase_kernel():
+    bar = tle.gpu.alloc_barrier(init=tle.gpu.READY)
+    tle.gpu.barrier_wait(bar)
+
+
+@triton.jit
+def _ready_arrive_missing_phase_kernel():
+    bar = tle.gpu.alloc_barrier(init=tle.gpu.READY)
+    tle.gpu.barrier_arrive(bar)
+
+
 def _extract_barrier_ops(ttir):
     allocs = re.findall(r"musa_tle\.barrier\.alloc", ttir)
     indices = re.findall(r"musa_tle\.barrier\.index", ttir)
@@ -270,6 +294,22 @@ def test_mthreads_tle_barrier_named_path_has_stable_diagnostic(kernel):
         (_block_slot_kernel, "barrier index must be a scalar integer"),
         (_non_integer_slot_kernel, "barrier index must be integer"),
         (_non_integer_phase_kernel, "barrier phaseIdx must be integer"),
+        (
+            _completion_wait_missing_phase_kernel,
+            "barrier_wait on a barrier with expect_bytes requires phaseIdx",
+        ),
+        (
+            _completion_arrive_missing_phase_kernel,
+            "barrier_arrive on a barrier with expect_bytes requires phaseIdx",
+        ),
+        (
+            _ready_wait_missing_phase_kernel,
+            "barrier_wait without phaseIdx selects named barrier, which does not support READY",
+        ),
+        (
+            _ready_arrive_missing_phase_kernel,
+            "barrier_arrive without phaseIdx selects named barrier, which does not support READY",
+        ),
     ],
 )
 def test_mthreads_tle_barrier_invalid_frontend_inputs_have_stable_diagnostics(kernel, diagnostic):

--- a/third_party/mthreads/python/test/unit/tle/test_tle_barrier.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_barrier.py
@@ -1,0 +1,293 @@
+"""Compile-only coverage for mthreads TLE barrier arrays and mbarriers."""
+
+import re
+
+import pytest
+import triton
+import triton.language as tl
+import triton.experimental.tle.language as tle
+from triton._C import libtriton
+from triton._C.libtriton import ir
+from triton.backends.compiler import Language
+from triton.compiler import ASTSource
+from triton.compiler.errors import CompilationError
+
+from test_tle_utils import compile_to_ttir, mthreads_backend, require_mthreads_libtriton
+
+require_mthreads_libtriton()
+
+
+@triton.jit
+def _static_barrier_kernel(STAGES: tl.constexpr):
+    full = tle.gpu.alloc_barriers(
+        STAGES,
+        arrive_count=1,
+        init=tle.gpu.PENDING,
+        expect_bytes=32768,
+    )
+    empty = tle.gpu.alloc_barriers(
+        STAGES,
+        arrive_count=16,
+        init=tle.gpu.READY,
+    )
+    for slot in tl.static_range(0, STAGES):
+        tle.gpu.barrier_wait(full[slot], phaseIdx=slot)
+        tle.gpu.barrier_wait(empty[slot], phaseIdx=slot)
+        tle.gpu.barrier_arrive(empty[slot], phaseIdx=slot)
+
+
+@triton.jit
+def _dynamic_barrier_kernel(stage, phase):
+    bars = tle.gpu.alloc_barriers(
+        2,
+        arrive_count=16,
+        init=tle.gpu.READY,
+    )
+    slot = bars[stage]
+    tle.gpu.barrier_wait(slot, phaseIdx=phase)
+    tle.gpu.barrier_arrive(slot, phaseIdx=phase)
+
+
+@triton.jit
+def _singleton_barrier_kernel():
+    bar = tle.gpu.alloc_barrier()
+    tle.gpu.barrier_wait(bar, phaseIdx=0)
+    tle.gpu.barrier_arrive(bar, phaseIdx=0)
+
+
+@triton.jit
+def _named_barrier_kernel():
+    bars = tle.gpu.alloc_barriers(2)
+    tle.gpu.barrier_wait(bars[0])
+
+
+@triton.jit
+def _named_barrier_arrive_kernel():
+    bars = tle.gpu.alloc_barriers(2)
+    tle.gpu.barrier_arrive(bars[0])
+
+
+@triton.jit
+def _invalid_num_barriers_kernel():
+    tle.gpu.alloc_barriers(0)
+
+
+@triton.jit
+def _too_many_barriers_kernel():
+    tle.gpu.alloc_barriers(64)
+
+
+@triton.jit
+def _invalid_arrive_count_kernel():
+    tle.gpu.alloc_barriers(1, arrive_count=0)
+
+
+@triton.jit
+def _invalid_expect_bytes_kernel():
+    tle.gpu.alloc_barriers(1, expect_bytes=0)
+
+
+@triton.jit
+def _block_slot_kernel():
+    bars = tle.gpu.alloc_barriers(2)
+    slot = bars[tl.arange(0, 2)]
+    tle.gpu.barrier_wait(slot, phaseIdx=0)
+
+
+@triton.jit
+def _non_integer_slot_kernel():
+    bars = tle.gpu.alloc_barriers(2)
+    slot = bars[0.0]
+    tle.gpu.barrier_wait(slot, phaseIdx=0)
+
+
+@triton.jit
+def _out_of_bounds_slot_kernel(STAGES: tl.constexpr, SLOT: tl.constexpr):
+    bars = tle.gpu.alloc_barriers(STAGES)
+    tle.gpu.barrier_wait(bars[SLOT], phaseIdx=0)
+
+
+@triton.jit
+def _non_integer_phase_kernel():
+    bars = tle.gpu.alloc_barriers(1)
+    tle.gpu.barrier_wait(bars[0], phaseIdx=0.0)
+
+
+def _extract_barrier_ops(ttir):
+    allocs = re.findall(r"musa_tle\.barrier\.alloc", ttir)
+    indices = re.findall(r"musa_tle\.barrier\.index", ttir)
+    waits = re.findall(r"musa_tle\.barrier\.wait", ttir)
+    arrives = re.findall(r"musa_tle\.barrier\.arrive", ttir)
+    return len(allocs), len(indices), len(waits), len(arrives)
+
+
+def _compile_barrier_ir(fn, signature, constexprs=None):
+    target, backend = mthreads_backend()
+    options = backend.parse_options({"num_stages": 1})
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+
+    src = ASTSource(fn=fn, signature=signature, constexprs=constexprs or {})
+    module = src.make_ir(
+        target,
+        options,
+        backend.get_codegen_implementation(options),
+        backend.get_module_map(),
+        context,
+    )
+    stages = {}
+    backend.add_stages(stages, options, Language.TRITON)
+    metadata = {}
+    module = stages["ttir"](module, metadata)
+    ttir = module.str_nodebug()
+    module = stages["ttgir"](module, metadata)
+    ttgir = module.str_nodebug()
+
+    pm = ir.pass_manager(context)
+    libtriton.mthreads.passes.ttgpuir.add_allocate_shared_memory(pm, 31)
+    pm.run(module, "allocate_barrier_shared_memory")
+    return ttir, ttgir, module.str_nodebug()
+
+
+def _barrier_index_constants(ttir):
+    constants = {
+        name: int(value)
+        for name, value in re.findall(
+            r"(%[-\w.]+)\s*=\s*(?:arith\.)?constant\s+(-?\d+)\s*:\s*i32",
+            ttir,
+        )
+    }
+    values = []
+    for index in re.findall(
+            r"musa_tle\.barrier\.index\s+%[-\w.]+\[(%[-\w.]+)\]",
+            ttir,
+    ):
+        values.append(constants.get(index))
+    return values
+
+
+def _assert_static_barrier_ir(ttir, stages):
+    allocs, indices, waits, arrives = _extract_barrier_ops(ttir)
+    assert allocs == 2, ttir
+    assert 2 * stages <= indices <= 3 * stages, ttir
+    assert waits == 2 * stages, ttir
+    assert arrives == stages, ttir
+    assert not re.search(r"(?<!musa_)tle\.barrier\.", ttir), ttir
+    assert "tle.wgmma_pipeline_mode" not in ttir, ttir
+
+    assert ttir.count("expect_bytes = 32768") == 1, ttir
+    assert ttir.count("init_polarity = 0") == 1, ttir
+    assert ttir.count("init_polarity = 1") == 1, ttir
+    assert ttir.count("num_barriers = %d" % stages) == 2, ttir
+    assert "arrive_count = 1" in ttir, ttir
+    assert "arrive_count = 16" in ttir, ttir
+    assert "ttg.memdesc_index" not in ttir, ttir
+    assert "ttg.local_alloc" not in ttir, ttir
+    assert "!ttg.memdesc" not in ttir, ttir
+    assert "#smem" not in ttir, ttir
+    assert re.search(r"%[-\w.]+\s*=\s*musa_tle\.barrier\.alloc", ttir), ttir
+
+    indices = _barrier_index_constants(ttir)
+    # TTGIR CSE may share the empty-barrier slot between wait and arrive.
+    assert 2 * stages <= len(indices) <= 3 * stages, ttir
+    assert set(indices) == set(range(stages)), ttir
+
+
+@pytest.mark.parametrize("stages", [1, 2])
+def test_mthreads_tle_barrier_static_arrays_emit_mbarrier_ir(stages):
+    ir_modules = _compile_barrier_ir(
+        _static_barrier_kernel,
+        {"STAGES": "constexpr"},
+        {"STAGES": stages},
+    )
+    for ir_text in ir_modules:
+        _assert_static_barrier_ir(ir_text, stages)
+    assert "ttg.shared = 0 : i32" in ir_modules[-1], ir_modules[-1]
+
+
+def test_mthreads_tle_barrier_preserves_dynamic_slot_and_phase():
+    ir_modules = _compile_barrier_ir(
+        _dynamic_barrier_kernel,
+        {"stage": "i32", "phase": "i32"},
+    )
+    for ir_text in ir_modules:
+        allocs, indices, waits, arrives = _extract_barrier_ops(ir_text)
+        assert (allocs, indices, waits, arrives) == (1, 1, 1, 1), ir_text
+        assert not re.search(r"(?<!musa_)tle\.barrier\.", ir_text), ir_text
+        assert "ttg.memdesc_index" not in ir_text, ir_text
+        assert "musa_tle.barrier.index" in ir_text, ir_text
+        assert "musa_tle.barrier.wait" in ir_text, ir_text
+        assert "musa_tle.barrier.arrive" in ir_text, ir_text
+        assert re.search(r"musa_tle\.barrier\.index\s+%[-\w.]+\[%arg0\]", ir_text), ir_text
+        assert re.search(r"arith\.andi\s+%arg1,", ir_text), ir_text
+        assert "arith.xori" in ir_text, ir_text
+        assert "num_barriers = 2" in ir_text, ir_text
+    assert "ttg.shared = 0 : i32" in ir_modules[-1], ir_modules[-1]
+
+
+def test_mthreads_tle_singleton_barrier_uses_indexed_slot():
+    for ir_text in _compile_barrier_ir(_singleton_barrier_kernel, {}):
+        allocs, indices, waits, arrives = _extract_barrier_ops(ir_text)
+        assert (allocs, indices, waits, arrives) == (1, 1, 1, 1), ir_text
+        assert _barrier_index_constants(ir_text) == [0], ir_text
+        assert "!ttg.memdesc" not in ir_text, ir_text
+        assert "ttg.local_alloc" not in ir_text, ir_text
+
+
+def test_mthreads_tle_barrier_bindings_are_backend_local():
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    builder = ir.builder(context)
+    for name in (
+            "create_barrier_alloc",
+            "create_barrier_wait_mbarrier",
+            "create_barrier_arrive_mbarrier",
+            "create_barrier_wait_named",
+            "create_barrier_arrive_named",
+    ):
+        assert hasattr(builder, name)
+
+
+@pytest.mark.parametrize("kernel", [_named_barrier_kernel, _named_barrier_arrive_kernel])
+def test_mthreads_tle_barrier_named_path_has_stable_diagnostic(kernel):
+    with pytest.raises(
+            CompilationError,
+            match="mthreads TLE named barrier backend is unsupported; phaseIdx is required",
+    ):
+        compile_to_ttir(kernel, {})
+
+
+@pytest.mark.parametrize(
+    "kernel,diagnostic",
+    [
+        (_invalid_num_barriers_kernel, "num_barriers must be positive"),
+        (_too_many_barriers_kernel, "mthreads TLE barrier allocation exceeds the 63 hardware barrier id limit"),
+        (_invalid_arrive_count_kernel, "arrive_count must be positive"),
+        (_invalid_expect_bytes_kernel, "expect_bytes must be positive when provided"),
+        (_block_slot_kernel, "barrier index must be a scalar integer"),
+        (_non_integer_slot_kernel, "barrier index must be integer"),
+        (_non_integer_phase_kernel, "barrier phaseIdx must be integer"),
+    ],
+)
+def test_mthreads_tle_barrier_invalid_frontend_inputs_have_stable_diagnostics(kernel, diagnostic):
+    with pytest.raises(CompilationError, match=diagnostic):
+        compile_to_ttir(kernel, {})
+
+
+@pytest.mark.parametrize(
+    "stages,slot",
+    [(1, -1), (1, 1), (2, -1), (2, 2)],
+)
+def test_mthreads_tle_barrier_rejects_constant_slot_out_of_bounds(stages, slot):
+    with pytest.raises(
+            CompilationError,
+            match=rf"barrier index {slot} out of bounds for {stages} barriers",
+    ):
+        compile_to_ttir(
+            _out_of_bounds_slot_kernel,
+            {"STAGES": "constexpr", "SLOT": "constexpr"},
+            {"STAGES": stages, "SLOT": slot},
+        )

--- a/third_party/mthreads/python/test/unit/tle/test_tle_barrier.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_barrier.py
@@ -162,11 +162,17 @@ def _ready_arrive_missing_phase_kernel():
     tle.gpu.barrier_arrive(bar)
 
 
+@triton.jit
+def _unsupported_arrive_increment_kernel():
+    bar = tle.gpu.alloc_barrier(arrive_count=4, init=tle.gpu.READY)
+    tle.gpu.barrier_arrive(bar, arrive_count=2, phaseIdx=0)
+
+
 def _extract_barrier_ops(ttir):
     allocs = re.findall(r"musa_tle\.barrier\.alloc", ttir)
     indices = re.findall(r"musa_tle\.barrier\.index", ttir)
-    waits = re.findall(r"musa_tle\.barrier\.wait", ttir)
-    arrives = re.findall(r"musa_tle\.barrier\.arrive", ttir)
+    waits = re.findall(r"(?:musa_tle\.barrier\.wait|ttmg\.wait_barrier)", ttir)
+    arrives = re.findall(r"(?:musa_tle\.barrier\.arrive|ttmg\.warp_arrive_barrier)", ttir)
     return len(allocs), len(indices), len(waits), len(arrives)
 
 
@@ -243,7 +249,12 @@ def _assert_single_initialization_rendezvous(ir_text, require_barrier_use=False)
     assert ir_text.index("ttmg.bar_record") < min(init_positions), ir_text
     assert max(init_positions) < rendezvous, ir_text
     if require_barrier_use:
-        use_positions = [match.start() for match in re.finditer(r"musa_tle\.barrier\.(?:wait|arrive)", ir_text)]
+        use_positions = [
+            match.start() for match in re.finditer(
+                r"(?:musa_tle\.barrier\.(?:wait|arrive)|ttmg\.(?:wait_barrier|warp_arrive_barrier))",
+                ir_text,
+            )
+        ]
         assert use_positions, ir_text
         assert rendezvous < min(use_positions), ir_text
 
@@ -253,7 +264,7 @@ def _assert_lowered_static_barrier_ir(ir_text, stages):
     assert (allocs, indices, waits, arrives) == (0, 0, 2 * stages, stages), ir_text
     assert _init_arrivals(ir_text) == [
         *[(slot + 1, 1, 0) for slot in range(stages)],
-        *[(stages + slot + 1, 16, 1) for slot in range(stages)],
+        *[(stages + slot + 1, 16, 0) for slot in range(stages)],
     ], ir_text
     assert f"musa.max_bar_id = {2 * stages}" in ir_text, ir_text
     assert "musa.next_bar_id" not in ir_text, ir_text
@@ -315,8 +326,8 @@ def test_mthreads_tle_four_barrier_groups_receive_contiguous_hardware_ids(stages
     expected = [
         *[(1 + slot, 1, 0) for slot in range(stages)],
         *[(1 + stages + slot, 1, 0) for slot in range(stages)],
-        *[(1 + 2 * stages + slot, 16, 1) for slot in range(stages)],
-        *[(1 + 3 * stages + slot, 16, 1) for slot in range(stages)],
+        *[(1 + 2 * stages + slot, 16, 0) for slot in range(stages)],
+        *[(1 + 3 * stages + slot, 16, 0) for slot in range(stages)],
     ]
     for ir_text in (ttgir, allocated):
         assert _init_arrivals(ir_text) == expected, ir_text
@@ -345,7 +356,8 @@ def _lower_backend_barrier_fixture(tmp_path, stages, existing_max=None, with_war
     allocs = "\n".join(f"    %{index} = musa_tle.barrier.alloc "
                        f"{{arrive_count = {1 if index < 2 else 16} : i32, "
                        f"init_polarity = {0 if index < 2 else 1} : i32, "
-                       f"num_barriers = {stages} : i32}}" for index in range(4))
+                       f"num_barriers = {stages} : i32"
+                       f"{', expect_bytes = 32768 : i32' if index < 2 else ''}}}" for index in range(4))
     warp_specialize = _empty_warp_specialize() if with_warp_specialize else ""
     fixture = f"""module {{
   tt.func public @barrier_fixture(){function_attrs} {{
@@ -375,8 +387,8 @@ def test_mthreads_tle_stage_three_barriers_use_backend_local_fixture(tmp_path):
     assert _init_arrivals(lowered) == [
         *[(1 + slot, 1, 0) for slot in range(3)],
         *[(4 + slot, 1, 0) for slot in range(3)],
-        *[(7 + slot, 16, 1) for slot in range(3)],
-        *[(10 + slot, 16, 1) for slot in range(3)],
+        *[(7 + slot, 16, 0) for slot in range(3)],
+        *[(10 + slot, 16, 0) for slot in range(3)],
     ], lowered
     assert "musa.max_bar_id = 12" in lowered, lowered
     assert _extract_barrier_ops(lowered)[0:2] == (0, 0), lowered
@@ -389,8 +401,8 @@ def test_mthreads_tle_stage_three_barriers_rendezvous_before_warp_specialize(tmp
     assert _init_arrivals(lowered) == [
         *[(1 + slot, 1, 0) for slot in range(3)],
         *[(4 + slot, 1, 0) for slot in range(3)],
-        *[(7 + slot, 16, 1) for slot in range(3)],
-        *[(10 + slot, 16, 1) for slot in range(3)],
+        *[(7 + slot, 16, 0) for slot in range(3)],
+        *[(10 + slot, 16, 0) for slot in range(3)],
     ], lowered
     assert lowered.count("ttg.barrier local") == 1, lowered
     assert lowered.count("ttg.warp_specialize(") == 1, lowered
@@ -533,8 +545,8 @@ def test_mthreads_tle_barriers_follow_existing_musa_reservations(tmp_path):
     assert _init_arrivals(lowered) == [
         (6, 1, 0),
         (7, 1, 0),
-        (8, 16, 1),
-        (9, 16, 1),
+        (8, 16, 0),
+        (9, 16, 0),
     ], lowered
     assert "musa.max_bar_id = 9" in lowered, lowered
     _assert_single_initialization_rendezvous(lowered)
@@ -561,7 +573,7 @@ def test_mthreads_tle_barrier_preserves_dynamic_slot_and_phase():
         assert "arith.addi" in ir_text, ir_text
         assert re.search(r"arith\.andi\s+%arg1,", ir_text), ir_text
         assert "arith.xori" in ir_text, ir_text
-        assert _init_arrivals(ir_text) == [(1, 16, 1), (2, 16, 1)], ir_text
+        assert _init_arrivals(ir_text) == [(1, 16, 0), (2, 16, 0)], ir_text
         _assert_single_initialization_rendezvous(ir_text, require_barrier_use=True)
     assert "ttg.shared = 0 : i32" in allocated, allocated
 
@@ -591,6 +603,7 @@ def test_mthreads_tle_barrier_bindings_are_backend_local():
             "create_barrier_wait_named",
             "create_barrier_arrive_named",
             "add_tle_lower_barrier_allocations",
+            "add_tle_lower_barrier_operations",
     ):
         owner = (libtriton.mthreads.passes.ttgpuir if name.startswith("add_") else builder)
         assert hasattr(owner, name)
@@ -611,6 +624,10 @@ def test_mthreads_tle_barrier_named_path_has_stable_diagnostic(kernel):
         (_invalid_num_barriers_kernel, "num_barriers must be positive"),
         (_too_many_barriers_kernel, "mthreads TLE barrier allocation exceeds the 63 hardware barrier id limit"),
         (_invalid_arrive_count_kernel, "arrive_count must be positive"),
+        (
+            _unsupported_arrive_increment_kernel,
+            "mthreads hardware barrier arrive requires arrive_count = 1",
+        ),
         (_invalid_expect_bytes_kernel, "expect_bytes must be positive when provided"),
         (_block_slot_kernel, "barrier index must be a scalar integer"),
         (_non_integer_slot_kernel, "barrier index must be integer"),

--- a/third_party/mthreads/python/test/unit/tle/test_tle_barrier.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_barrier.py
@@ -7,7 +7,7 @@ import triton
 import triton.language as tl
 import triton.experimental.tle.language as tle
 from triton._C import libtriton
-from triton._C.libtriton import ir
+from triton._C.libtriton import ir, passes
 from triton.backends.compiler import Language
 from triton.compiler import ASTSource
 from triton.compiler.errors import CompilationError
@@ -235,6 +235,19 @@ def _init_arrivals(ir_text):
             )]
 
 
+def _assert_single_initialization_rendezvous(ir_text, require_barrier_use=False):
+    init_positions = [match.start() for match in re.finditer("ttmg.init_arrival", ir_text)]
+    assert init_positions, ir_text
+    assert ir_text.count("ttg.barrier local") == 1, ir_text
+    rendezvous = ir_text.index("ttg.barrier local")
+    assert ir_text.index("ttmg.bar_record") < min(init_positions), ir_text
+    assert max(init_positions) < rendezvous, ir_text
+    if require_barrier_use:
+        use_positions = [match.start() for match in re.finditer(r"musa_tle\.barrier\.(?:wait|arrive)", ir_text)]
+        assert use_positions, ir_text
+        assert rendezvous < min(use_positions), ir_text
+
+
 def _assert_lowered_static_barrier_ir(ir_text, stages):
     allocs, indices, waits, arrives = _extract_barrier_ops(ir_text)
     assert (allocs, indices, waits, arrives) == (0, 0, 2 * stages, stages), ir_text
@@ -248,6 +261,7 @@ def _assert_lowered_static_barrier_ir(ir_text, stages):
     assert "ttg.memdesc_index" not in ir_text, ir_text
     assert "ttg.local_alloc" not in ir_text, ir_text
     assert "!ttg.memdesc" not in ir_text, ir_text
+    _assert_single_initialization_rendezvous(ir_text, require_barrier_use=True)
 
 
 def _assert_static_barrier_ir(ttir, stages):
@@ -309,10 +323,22 @@ def test_mthreads_tle_four_barrier_groups_receive_contiguous_hardware_ids(stages
         assert _extract_barrier_ops(ir_text)[0:2] == (0, 0), ir_text
         assert f"musa.max_bar_id = {4 * stages}" in ir_text, ir_text
         assert "musa.next_bar_id" not in ir_text, ir_text
+        _assert_single_initialization_rendezvous(ir_text, require_barrier_use=True)
     assert "ttg.shared = 0 : i32" in allocated, allocated
 
 
-def _lower_backend_barrier_fixture(tmp_path, stages, existing_max=None):
+def _empty_warp_specialize(body=""):
+    return f"""    ttg.warp_specialize() attributes {{requestedRegisters = array<i32: 24>}}
+    default {{
+      ttg.warp_yield
+    }}
+    partition0() num_warps(4) {{
+{body}      ttg.warp_return
+    }} : () -> ()
+"""
+
+
+def _lower_backend_barrier_fixture(tmp_path, stages, existing_max=None, with_warp_specialize=False):
     function_attrs = ""
     if existing_max is not None:
         function_attrs = f" attributes {{musa.max_bar_id = {existing_max} : i32}}"
@@ -320,9 +346,11 @@ def _lower_backend_barrier_fixture(tmp_path, stages, existing_max=None):
                        f"{{arrive_count = {1 if index < 2 else 16} : i32, "
                        f"init_polarity = {0 if index < 2 else 1} : i32, "
                        f"num_barriers = {stages} : i32}}" for index in range(4))
+    warp_specialize = _empty_warp_specialize() if with_warp_specialize else ""
     fixture = f"""module {{
   tt.func public @barrier_fixture(){function_attrs} {{
 {allocs}
+{warp_specialize}
     tt.return
   }}
 }}
@@ -352,6 +380,152 @@ def test_mthreads_tle_stage_three_barriers_use_backend_local_fixture(tmp_path):
     ], lowered
     assert "musa.max_bar_id = 12" in lowered, lowered
     assert _extract_barrier_ops(lowered)[0:2] == (0, 0), lowered
+    _assert_single_initialization_rendezvous(lowered)
+
+
+def test_mthreads_tle_stage_three_barriers_rendezvous_before_warp_specialize(tmp_path):
+    lowered = _lower_backend_barrier_fixture(tmp_path, stages=3, with_warp_specialize=True)
+    assert len(_init_arrivals(lowered)) == 12, lowered
+    assert _init_arrivals(lowered) == [
+        *[(1 + slot, 1, 0) for slot in range(3)],
+        *[(4 + slot, 1, 0) for slot in range(3)],
+        *[(7 + slot, 16, 1) for slot in range(3)],
+        *[(10 + slot, 16, 1) for slot in range(3)],
+    ], lowered
+    assert lowered.count("ttg.barrier local") == 1, lowered
+    assert lowered.count("ttg.warp_specialize(") == 1, lowered
+    init_positions = [match.start() for match in re.finditer("ttmg.init_arrival", lowered)]
+    rendezvous = lowered.index("ttg.barrier local")
+    warp_specialize = lowered.index("ttg.warp_specialize(")
+    assert max(init_positions) < rendezvous < warp_specialize, lowered
+    assert "musa.max_bar_id = 12" in lowered, lowered
+
+
+def test_mthreads_tle_barrier_rendezvous_lowers_to_local_cta_sync(tmp_path):
+    fixture = """module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 16 : i32,
+    ttg.target = "musa:ph1", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @barrier_init_sync() attributes {musa.max_bar_id = 1 : i32, noinline = false} {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    ttmg.bar_record %c1 : i32
+    ttmg.init_arrival %c1, %c1, %c0 : i32
+    ttg.barrier local
+    tt.return
+  }
+}
+"""
+    fixture_path = tmp_path / "barrier_init_sync.ttgir"
+    fixture_path.write_text(fixture)
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    module = ir.parse_mlir_module(str(fixture_path), context)
+    pm = ir.pass_manager(context)
+    passes.convert.add_scf_to_cf(pm)
+    passes.convert.add_index_to_llvmir(pm)
+    libtriton.mthreads.passes.ttgpuir.add_allocate_shared_memory(pm, 31)
+    libtriton.mthreads.passes.ttgpuir.add_mtgpu_to_llvm(pm, 31)
+    libtriton.mthreads.passes.ttgpuir.add_to_llvmir(pm, 31)
+    passes.common.add_canonicalizer(pm)
+    passes.common.add_cse(pm)
+    passes.convert.add_cf_to_llvmir(pm)
+    passes.convert.add_arith_to_llvmir(pm)
+    passes.common.add_canonicalizer(pm)
+    passes.common.add_cse(pm)
+    pm.run(module, "lower_barrier_init_sync")
+    llir = module.str_nodebug()
+
+    assert llir.count('llvm.call_intrinsic "llvm.musa.async.bar.record"') == 1, llir
+    assert llir.count('llvm.call_intrinsic "llvm.musa.async.init.arrival"') == 1, llir
+    assert llir.count('llvm.call_intrinsic "llvm.musa.syncthreads.lm"') == 1, llir
+    assert "llvm.musa.barrier0" not in llir, llir
+    assert (llir.index("llvm.musa.async.bar.record") < llir.index("llvm.musa.async.init.arrival") <
+            llir.index("llvm.musa.syncthreads.lm")), llir
+
+
+@pytest.mark.parametrize("placement", ["after", "partition"])
+def test_mthreads_tle_rejects_barrier_allocations_that_do_not_dominate_warp_specialize(tmp_path, capfd, placement):
+    alloc = ("    %bar = musa_tle.barrier.alloc "
+             "{arrive_count = 1 : i32, init_polarity = 0 : i32, num_barriers = 1 : i32}\n")
+    if placement == "after":
+        body = _empty_warp_specialize() + alloc
+    else:
+        body = _empty_warp_specialize(body=alloc.replace("    ", "      ", 1))
+    fixture = f"""module {{
+  tt.func public @invalid_barrier_fixture() {{
+{body}    tt.return
+  }}
+}}
+"""
+    fixture_path = tmp_path / f"invalid_barrier_{placement}.ttgir"
+    fixture_path.write_text(fixture)
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    module = ir.parse_mlir_module(str(fixture_path), context)
+    pm = ir.pass_manager(context)
+    libtriton.mthreads.passes.ttgpuir.add_tle_lower_barrier_allocations(pm)
+    with pytest.raises(RuntimeError, match="PassManager::run failed"):
+        pm.run(module, "reject_invalid_ws_barrier_placement")
+    stderr = capfd.readouterr().err
+    if placement == "after":
+        assert ("requires barrier allocations in the function entry block before the first top-level "
+                "warp_specialize") in stderr
+    else:
+        assert "requires allocations in the function entry block" in stderr
+
+
+def test_mthreads_tle_rejects_barrier_use_before_final_allocation(tmp_path, capfd):
+    fixture = """module {
+  tt.func public @barrier_use_before_final_allocation() {
+    %c0 = arith.constant 0 : i32
+    %first = musa_tle.barrier.alloc {arrive_count = 1 : i32, init_polarity = 0 : i32, num_barriers = 1 : i32}
+    %slot = musa_tle.barrier.index %first[%c0]
+    musa_tle.barrier.wait %slot, %c0
+    %second = musa_tle.barrier.alloc {arrive_count = 1 : i32, init_polarity = 0 : i32, num_barriers = 1 : i32}
+    tt.return
+  }
+}
+"""
+    fixture_path = tmp_path / "barrier_use_before_final_allocation.ttgir"
+    fixture_path.write_text(fixture)
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    module = ir.parse_mlir_module(str(fixture_path), context)
+    pm = ir.pass_manager(context)
+    libtriton.mthreads.passes.ttgpuir.add_tle_lower_barrier_allocations(pm)
+    with pytest.raises(RuntimeError, match="PassManager::run failed"):
+        pm.run(module, "reject_barrier_use_before_final_allocation")
+    stderr = capfd.readouterr().err
+    assert "requires all allocations before the first barrier use" in stderr
+
+
+def test_mthreads_tle_does_not_add_rendezvous_without_barrier_allocations(tmp_path):
+    fixture = """module {
+  tt.func public @no_barrier_allocations() {
+    tt.return
+  }
+}
+"""
+    fixture_path = tmp_path / "no_barrier_allocations.ttgir"
+    fixture_path.write_text(fixture)
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    module = ir.parse_mlir_module(str(fixture_path), context)
+    pm = ir.pass_manager(context)
+    libtriton.mthreads.passes.ttgpuir.add_tle_lower_barrier_allocations(pm)
+    pm.run(module, "preserve_function_without_barrier_allocations")
+    assert "ttg.barrier local" not in module.str_nodebug()
 
 
 def test_mthreads_tle_barriers_follow_existing_musa_reservations(tmp_path):
@@ -363,6 +537,7 @@ def test_mthreads_tle_barriers_follow_existing_musa_reservations(tmp_path):
         (9, 16, 1),
     ], lowered
     assert "musa.max_bar_id = 9" in lowered, lowered
+    _assert_single_initialization_rendezvous(lowered)
 
 
 def test_mthreads_tle_barrier_id_exhaustion_has_stable_diagnostic(capfd):
@@ -387,6 +562,7 @@ def test_mthreads_tle_barrier_preserves_dynamic_slot_and_phase():
         assert re.search(r"arith\.andi\s+%arg1,", ir_text), ir_text
         assert "arith.xori" in ir_text, ir_text
         assert _init_arrivals(ir_text) == [(1, 16, 1), (2, 16, 1)], ir_text
+        _assert_single_initialization_rendezvous(ir_text, require_barrier_use=True)
     assert "ttg.shared = 0 : i32" in allocated, allocated
 
 
@@ -399,6 +575,7 @@ def test_mthreads_tle_singleton_barrier_uses_indexed_slot():
         assert _init_arrivals(ir_text) == [(1, 1, 0)], ir_text
         assert "!ttg.memdesc" not in ir_text, ir_text
         assert "ttg.local_alloc" not in ir_text, ir_text
+        _assert_single_initialization_rendezvous(ir_text, require_barrier_use=True)
 
 
 def test_mthreads_tle_barrier_bindings_are_backend_local():

--- a/third_party/mthreads/python/test/unit/tle/test_tle_barrier_lowering.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_barrier_lowering.py
@@ -1,0 +1,330 @@
+"""Lowering and runtime coverage for mthreads TLE hardware barriers."""
+
+import re
+
+import pytest
+import torch
+import triton
+import triton.language as tl
+import triton.experimental.tle.language as tle
+from triton._C import libtriton
+from triton._C.libtriton import ir, passes
+from triton.compiler import ASTSource
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+from test_tle_utils import mthreads_backend, musa_target, require_mthreads_libtriton
+
+require_mthreads_libtriton()
+
+
+@triton.jit
+def _completion_barrier_phase_reuse_pipeline(desc, out, STAGES: tl.constexpr):
+    block: tl.constexpr = 128
+    # Exercise two complete phase-parity cycles for every physical slot.
+    iterations: tl.constexpr = 4 * STAGES
+    smem = tle.gpu.alloc(
+        (STAGES, block),
+        dtype=tl.float16,
+        nv_mma_shared_layout=False,
+    )
+    full = tle.gpu.alloc_barriers(
+        STAGES,
+        arrive_count=1,
+        init=tle.gpu.PENDING,
+        expect_bytes=block * 2,
+    )
+    empty = tle.gpu.alloc_barriers(
+        STAGES,
+        arrive_count=4,
+        init=tle.gpu.READY,
+    )
+    for iteration in tl.static_range(0, iterations):
+        tle.gpu.barrier_wait(empty[iteration % STAGES], phaseIdx=iteration // STAGES)
+        tle.gpu.copy(
+            desc,
+            smem.slot(iteration % STAGES),
+            (block, ),
+            (iteration * block, ),
+            barrier=full[iteration % STAGES],
+        )
+        tle.gpu.barrier_wait(full[iteration % STAGES], phaseIdx=iteration // STAGES)
+        value = tl.load(tle.gpu.local_ptr(smem.slot(iteration % STAGES), (0, )))
+        tl.store(out + iteration, value)
+        tle.gpu.barrier_arrive(empty[iteration % STAGES], phaseIdx=iteration // STAGES)
+
+
+@triton.jit
+def _non_ws_single_slot_pipeline(desc, out, STAGES: tl.constexpr, SLOT: tl.constexpr):
+    block: tl.constexpr = 128
+    smem = tle.gpu.alloc(
+        (STAGES, block),
+        dtype=tl.float16,
+        nv_mma_shared_layout=False,
+    )
+    full = tle.gpu.alloc_barriers(
+        STAGES,
+        arrive_count=1,
+        init=tle.gpu.PENDING,
+        expect_bytes=block * 2,
+    )
+    empty = tle.gpu.alloc_barriers(
+        STAGES,
+        arrive_count=4,
+        init=tle.gpu.READY,
+    )
+    tle.gpu.barrier_wait(empty[SLOT], phaseIdx=0)
+    tle.gpu.copy(
+        desc,
+        smem.slot(SLOT),
+        (block, ),
+        (SLOT * block, ),
+        barrier=full[SLOT],
+    )
+    tle.gpu.barrier_wait(full[SLOT], phaseIdx=0)
+    value = tl.load(tle.gpu.local_ptr(smem.slot(SLOT), (0, )))
+    tl.store(out, value)
+    tle.gpu.barrier_arrive(empty[SLOT], phaseIdx=0)
+
+
+@triton.jit
+def _ready_barrier_probe(out):
+    ready = tle.gpu.alloc_barriers(1, arrive_count=4, init=tle.gpu.READY)
+    tle.gpu.barrier_wait(ready[0], phaseIdx=0)
+    tl.store(out, 1)
+    tle.gpu.barrier_arrive(ready[0], phaseIdx=0)
+
+
+@triton.jit(do_not_specialize=["slot", "first_phase"])
+def _ready_barrier_array_phase_reuse(out, slot, first_phase):
+    ready = tle.gpu.alloc_barriers(2, arrive_count=4, init=tle.gpu.READY)
+    for iteration in tl.static_range(0, 2):
+        phase = first_phase + iteration
+        tle.gpu.barrier_wait(ready[slot], phaseIdx=phase)
+        tl.store(out + iteration, slot * 10 + iteration)
+        tle.gpu.barrier_arrive(ready[slot], phaseIdx=phase)
+
+
+def _parse_fixture(tmp_path, body, name="barrier_operations"):
+    fixture = f"""module attributes {{"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32,
+    ttg.target = "musa:ph1", "ttg.threads-per-warp" = 32 : i32}} {{
+  tt.func public @{name}() attributes {{musa.max_bar_id = 3 : i32, noinline = false}} {{
+{body}    tt.return
+  }}
+}}
+"""
+    fixture_path = tmp_path / f"{name}.ttgir"
+    fixture_path.write_text(fixture)
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    return context, ir.parse_mlir_module(str(fixture_path), context)
+
+
+def _lower_barrier_operations(module, context):
+    pm = ir.pass_manager(context)
+    libtriton.mthreads.passes.ttgpuir.add_tle_lower_barrier_operations(pm)
+    pm.run(module, "lower_tle_barrier_operations")
+    return module.str_nodebug()
+
+
+def _compile_phase_reuse(stages):
+    source = ASTSource(
+        fn=_completion_barrier_phase_reuse_pipeline,
+        signature={"desc": "tensordesc<fp16[128]>", "out": "*fp16", "STAGES": "constexpr"},
+        constexprs={"STAGES": stages},
+    )
+    return triton.compile(
+        source,
+        target=musa_target(),
+        options={"num_warps": 4, "num_stages": 1},
+    )
+
+
+def test_mthreads_tle_barrier_operations_lower_and_are_idempotent(tmp_path):
+    body = """    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c2 = arith.constant 2 : i32
+    %c3 = arith.constant 3 : i32
+    musa_tle.barrier.wait %c1, %c0
+    musa_tle.barrier.wait %c2, %c1
+    musa_tle.barrier.arrive %c3, %c1 {arrive_count = 1 : i32}
+"""
+    context, module = _parse_fixture(tmp_path, body)
+    lowered = _lower_barrier_operations(module, context)
+
+    assert "musa_tle.barrier.wait" not in lowered, lowered
+    assert "musa_tle.barrier.arrive" not in lowered, lowered
+    assert lowered.count("ttmg.wait_barrier") == 2, lowered
+    assert lowered.count("ttmg.warp_arrive_barrier") == 1, lowered
+    assert "ttmg.arrive_barrier_noret" not in lowered, lowered
+    constants = {
+        name: int(value)
+        for name, value in re.findall(
+            r"(%[-\w.]+)\s*=\s*arith\.constant\s+(-?\d+)\s*:\s*i32",
+            lowered,
+        )
+    }
+    waits = re.findall(r"ttmg\.wait_barrier\s+(%[-\w.]+),\s*(%[-\w.]+)", lowered)
+    assert [(constants[barrier], constants[phase]) for barrier, phase in waits] == [(1, 0), (2, 1)]
+    arrive = re.search(r"ttmg\.warp_arrive_barrier\s+(%[-\w.]+)", lowered).group(1)
+    assert constants[arrive] == 3
+
+    rerun = _lower_barrier_operations(module, context)
+    assert rerun == lowered
+
+
+def test_mthreads_tle_consumer_arrival_is_warp_convergent_in_llvm(tmp_path):
+    body = """    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    ttmg.bar_record %c1 : i32
+    musa_tle.barrier.wait %c1, %c0
+    musa_tle.barrier.arrive %c1, %c0 {arrive_count = 1 : i32}
+"""
+    context, module = _parse_fixture(tmp_path, body, "barrier_operations_llvm")
+    _lower_barrier_operations(module, context)
+
+    pm = ir.pass_manager(context)
+    passes.convert.add_scf_to_cf(pm)
+    passes.convert.add_index_to_llvmir(pm)
+    libtriton.mthreads.passes.ttgpuir.add_allocate_shared_memory(pm, 31)
+    libtriton.mthreads.passes.ttgpuir.add_mtgpu_to_llvm(pm, 31)
+    libtriton.mthreads.passes.ttgpuir.add_to_llvmir(pm, 31)
+    passes.common.add_canonicalizer(pm)
+    passes.common.add_cse(pm)
+    passes.convert.add_cf_to_llvmir(pm)
+    passes.convert.add_arith_to_llvmir(pm)
+    passes.common.add_canonicalizer(pm)
+    passes.common.add_cse(pm)
+    pm.run(module, "lower_tle_barrier_operations_to_llvm")
+    llir = module.str_nodebug()
+
+    assert llir.count('llvm.call_intrinsic "llvm.musa.async.wait"') == 1, llir
+    assert llir.count('llvm.call_intrinsic "llvm.musa.async.arrive.none.phaseid"') == 1, llir
+    assert "gpu.thread_id" not in llir, llir
+    assert "llvm.musa.read.ptx.sreg.tid.x" not in llir, llir
+
+
+@pytest.mark.parametrize("stages", [1, 2])
+def test_mthreads_tle_completion_copy_phase_reuse_compiles_to_mubin(stages):
+    compiled = _compile_phase_reuse(stages)
+    ttgir = compiled.asm["ttgir"]
+    llir = compiled.asm["llir"]
+
+    assert "musa_tle.barrier." not in ttgir, ttgir
+    assert ttgir.count("ttmg.wait_barrier") == 8 * stages, ttgir
+    assert ttgir.count("ttmg.warp_arrive_barrier") == 4 * stages, ttgir
+    assert ttgir.count("ttmg.arrive_barrier_noret") == 4 * stages, ttgir
+    assert "llvm.musa.async.wait" in llir, llir
+    assert "llvm.musa.async.arrive.none.phaseid" in llir, llir
+    assert "llvm.musa.tme.ld.tile.1d" in llir, llir
+    assert re.search(r"\bphi\s+i64\b", llir) is None, llir
+    assert compiled.asm["mubin"], compiled.asm.keys()
+
+
+@pytest.mark.parametrize("stages,slot", [(1, 0), (2, 0), (2, 1)])
+def test_mthreads_tle_completion_copy_single_slot_compiles_to_mubin(stages, slot):
+    source = ASTSource(
+        fn=_non_ws_single_slot_pipeline,
+        signature={
+            "desc": "tensordesc<fp16[128]>",
+            "out": "*fp16",
+            "STAGES": "constexpr",
+            "SLOT": "constexpr",
+        },
+        constexprs={"STAGES": stages, "SLOT": slot},
+    )
+    compiled = triton.compile(source, target=musa_target(), options={"num_warps": 4, "num_stages": 1})
+    ttgir = compiled.asm["ttgir"]
+    llir = compiled.asm["llir"]
+
+    assert "musa_tle.barrier." not in ttgir, ttgir
+    assert ttgir.count("ttmg.wait_barrier") == 2, ttgir
+    assert ttgir.count("ttmg.warp_arrive_barrier") == 1, ttgir
+    assert ttgir.count("ttmg.arrive_barrier_noret") == 1, ttgir
+    assert "llvm.musa.async.wait" in llir, llir
+    assert "llvm.musa.async.arrive" in llir, llir
+    assert "llvm.musa.async.arrive.none.phaseid" in llir, llir
+    assert "llvm.musa.tme.ld.tile.1d" in llir, llir
+    assert compiled.asm["mubin"], compiled.asm.keys()
+
+
+@pytest.mark.skipif(not torch.musa.is_available(), reason="MUSA device is not available")
+def test_mthreads_tle_ready_barrier_reinitializes_across_launches():
+    for _ in range(2):
+        out = torch.zeros((1, ), device="musa", dtype=torch.int32)
+        _ready_barrier_probe[(1, )](out, num_warps=4, num_stages=1)
+        torch.musa.synchronize()
+        assert out.cpu().item() == 1
+
+
+@pytest.mark.skipif(not torch.musa.is_available(), reason="MUSA device is not available")
+@pytest.mark.parametrize("slot", [0, 1])
+def test_mthreads_tle_ready_barrier_array_dynamic_slot_and_phase_runtime(slot):
+    for _ in range(2):
+        out = torch.empty((2, ), device="musa", dtype=torch.int32)
+        _ready_barrier_array_phase_reuse[(1, )](
+            out,
+            slot,
+            0,
+            num_warps=4,
+            num_stages=1,
+        )
+        torch.musa.synchronize()
+
+        expected = torch.tensor([slot * 10, slot * 10 + 1], dtype=torch.int32)
+        torch.testing.assert_close(out.cpu(), expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.musa.is_available(), reason="MUSA device is not available")
+@pytest.mark.parametrize("stages", [1, 2])
+def test_mthreads_tle_completion_copy_phase_reuse_runtime(stages):
+    block = 128
+    iterations = 4 * stages
+    for launch in range(2):
+        start = launch * iterations * block
+        src = torch.arange(
+            start,
+            start + iterations * block,
+            device="musa",
+            dtype=torch.float16,
+        )
+        out = torch.empty((iterations, ), device="musa", dtype=torch.float16)
+        desc = TensorDescriptor.from_tensor(src, [block])
+
+        _completion_barrier_phase_reuse_pipeline[(1, )](
+            desc,
+            out,
+            STAGES=stages,
+            num_warps=4,
+            num_stages=1,
+        )
+        torch.musa.synchronize()
+
+        torch.testing.assert_close(out.cpu(), src[::block].cpu(), rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.musa.is_available(), reason="MUSA device is not available")
+@pytest.mark.parametrize("stages,slot", [(1, 0), (2, 0), (2, 1)])
+def test_mthreads_tle_completion_copy_single_slot_runtime(stages, slot):
+    block = 128
+    src = torch.arange(
+        stages * block,
+        device="musa",
+        dtype=torch.float16,
+    )
+    out = torch.empty((1, ), device="musa", dtype=torch.float16)
+    desc = TensorDescriptor.from_tensor(src, [block])
+
+    _non_ws_single_slot_pipeline[(1, )](
+        desc,
+        out,
+        STAGES=stages,
+        SLOT=slot,
+        num_warps=4,
+        num_stages=1,
+    )
+    torch.musa.synchronize()
+
+    expected = src[slot * block:slot * block + 1]
+    torch.testing.assert_close(out.cpu(), expected.cpu(), rtol=0, atol=0)

--- a/third_party/mthreads/python/test/unit/tle/test_tle_copy.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_copy.py
@@ -235,14 +235,15 @@ def test_tle_tma_completion_barrier_preserves_mthreads_contract(
     barrier_name = re.search(r"\],\s*(%[-\w.]+),\s*%", async_line).group(1)
     assert _i32_constants(ttgir)[barrier_name] == slot + 1, ttgir
     assert f"blockShape = array<i32: {block_m}, {block_n}>" in async_line, ttgir
-    assert "musa_tle.expect_bytes = 32768 : i32" in async_line, ttgir
+    assert "musa.tme.explicit_completion" in async_line, ttgir
+    assert "musa.tme.issue_thread = 0 : i32" in async_line, ttgir
     init_lines = [line for line in ttgir.splitlines() if "ttmg.init_arrival" in line]
     assert len(init_lines) == stages, ttgir
     constants = _i32_constants(ttgir)
     init_ids = [constants[re.search(r"ttmg\.init_arrival\s+(%[-\w.]+)", line).group(1)] for line in init_lines]
     assert init_ids == list(range(1, stages + 1)), ttgir
-    assert "ttmg.barrier_add_trans" not in ttgir, ttgir
-    assert "ttmg.arrive_barrier" not in ttgir, ttgir
+    assert "ttmg.barrier_add_trans" in ttgir, ttgir
+    assert "ttmg.arrive_barrier_noret" in ttgir, ttgir
     assert "ttmg.wait_barrier" not in ttgir, ttgir
     assert f"musa.max_bar_id = {stages}" in ttgir, ttgir
 
@@ -267,6 +268,17 @@ def test_tle_tma_copy_without_completion_barrier_keeps_implicit_sync():
     assert "ttmg.wait_barrier" in ttgir, ttgir
     assert "musa.max_bar_id = 1" in ttgir, ttgir
     assert "ttg.shared = 32768 : i32" in allocated, allocated
+
+
+def test_tle_tma_copy_without_completion_barrier_keeps_legacy_barrier0():
+    compiled = compile_musa(
+        _tma_implicit_completion_copy_kernel,
+        signature={"desc": "tensordesc<fp16[256, 64]>"},
+    )
+    llir = compiled.asm["llir"]
+
+    assert "call void @llvm.musa.barrier0()" in llir, llir
+    assert "call void @llvm.musa.tme.ld.tile.2d" in llir, llir
 
 
 @pytest.mark.parametrize(

--- a/third_party/mthreads/python/test/unit/tle/test_tle_copy.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_copy.py
@@ -17,6 +17,16 @@ from test_tle_utils import compile_musa, mthreads_backend, require_mthreads_libt
 require_mthreads_libtriton()
 
 
+def _i32_constants(ir_text):
+    return {
+        name: int(value)
+        for name, value in re.findall(
+            r"(%[-\w.]+)\s*=\s*(?:arith\.)?constant\s+(-?\d+)\s*:\s*i32",
+            ir_text,
+        )
+    }
+
+
 @triton.jit
 def _normal_copy_roundtrip_kernel(src, dst, BLOCK: tl.constexpr):
     offsets = tl.arange(0, BLOCK)
@@ -219,20 +229,22 @@ def test_tle_tma_completion_barrier_preserves_mthreads_contract(
     else:
         assert re.search(r"\[%c0_i32, %arg\d+\] barrier", ttir), ttir
 
-    barrier_match = re.search(
-        r"(%[-\w.]+)\s*=\s*musa_tle\.barrier\.index",
-        ttgir,
-    )
-    assert barrier_match, ttgir
+    assert "musa_tle.barrier.alloc" not in ttgir, ttgir
+    assert "musa_tle.barrier.index" not in ttgir, ttgir
     async_line = next(line for line in ttgir.splitlines() if "ttmg.async_tme_copy_global_to_local" in line)
-    assert f", {barrier_match.group(1)}," in async_line, ttgir
+    barrier_name = re.search(r"\],\s*(%[-\w.]+),\s*%", async_line).group(1)
+    assert _i32_constants(ttgir)[barrier_name] == slot + 1, ttgir
     assert f"blockShape = array<i32: {block_m}, {block_n}>" in async_line, ttgir
     assert "musa_tle.expect_bytes = 32768 : i32" in async_line, ttgir
-    assert "ttmg.init_arrival" not in ttgir, ttgir
+    init_lines = [line for line in ttgir.splitlines() if "ttmg.init_arrival" in line]
+    assert len(init_lines) == stages, ttgir
+    constants = _i32_constants(ttgir)
+    init_ids = [constants[re.search(r"ttmg\.init_arrival\s+(%[-\w.]+)", line).group(1)] for line in init_lines]
+    assert init_ids == list(range(1, stages + 1)), ttgir
     assert "ttmg.barrier_add_trans" not in ttgir, ttgir
     assert "ttmg.arrive_barrier" not in ttgir, ttgir
     assert "ttmg.wait_barrier" not in ttgir, ttgir
-    assert "musa.max_bar_id" not in ttgir, ttgir
+    assert f"musa.max_bar_id = {stages}" in ttgir, ttgir
 
     assert f"ttg.shared = {stages * 32768} : i32" in allocated, allocated
 

--- a/third_party/mthreads/python/test/unit/tle/test_tle_copy.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_copy.py
@@ -1,11 +1,18 @@
+import re
+
 import pytest
 import torch
 import triton
 import triton.language as tl
 import triton.experimental.tle.language as tle
+from triton._C import libtriton
+from triton._C.libtriton import ir
+from triton.backends.compiler import Language
+from triton.compiler import ASTSource
+from triton.compiler.errors import CompilationError
 from triton.tools.tensor_descriptor import TensorDescriptor
 
-from test_tle_utils import compile_musa, require_mthreads_libtriton
+from test_tle_utils import compile_musa, mthreads_backend, require_mthreads_libtriton
 
 require_mthreads_libtriton()
 
@@ -55,6 +62,234 @@ def _tma_copy_missing_offsets_kernel(desc, BLOCK: tl.constexpr):
 def _tma_copy_wrong_offset_rank_kernel(desc, BLOCK: tl.constexpr):
     smem = tle.gpu.alloc((BLOCK, ), dtype=tl.float16, nv_mma_shared_layout=False)
     tle.gpu.copy(desc, smem, (BLOCK, ), (0, 0))
+
+
+@triton.jit
+def _tma_completion_copy_kernel(
+    desc,
+    dynamic_k,
+    STAGES: tl.constexpr,
+    SLOT: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    TRANSPOSE_OFFSETS: tl.constexpr,
+):
+    smem = tle.gpu.alloc(
+        (STAGES, BLOCK_M, BLOCK_N),
+        dtype=tl.float16,
+        nv_mma_shared_layout=False,
+    )
+    full = tle.gpu.alloc_barriers(
+        STAGES,
+        arrive_count=1,
+        init=tle.gpu.PENDING,
+        expect_bytes=32768,
+    )
+    offsets = (dynamic_k, 0) if TRANSPOSE_OFFSETS else (0, dynamic_k)
+    tle.gpu.copy(
+        desc,
+        smem.slot(SLOT),
+        (BLOCK_M, BLOCK_N),
+        offsets,
+        barrier=full[SLOT],
+    )
+
+
+@triton.jit
+def _tma_implicit_completion_copy_kernel(desc):
+    smem = tle.gpu.alloc((256, 64), dtype=tl.float16, nv_mma_shared_layout=False)
+    tle.gpu.copy(desc, smem, (256, 64), (0, 0))
+
+
+@triton.jit
+def _tma_completion_unindexed_barrier_kernel(desc):
+    smem = tle.gpu.alloc((256, 64), dtype=tl.float16, nv_mma_shared_layout=False)
+    full = tle.gpu.alloc_barriers(2, expect_bytes=32768)
+    tle.gpu.copy(desc, smem, (256, 64), (0, 0), barrier=full)
+
+
+@triton.jit
+def _tma_completion_missing_bytes_kernel(desc):
+    smem = tle.gpu.alloc((256, 64), dtype=tl.float16, nv_mma_shared_layout=False)
+    full = tle.gpu.alloc_barrier()
+    tle.gpu.copy(desc, smem, (256, 64), (0, 0), barrier=full)
+
+
+@triton.jit
+def _tma_completion_wrong_direction_kernel(desc):
+    smem = tle.gpu.alloc((256, 64), dtype=tl.float16, nv_mma_shared_layout=False)
+    full = tle.gpu.alloc_barrier(expect_bytes=32768)
+    tle.gpu.copy(smem, desc, (256, 64), (0, 0), barrier=full)
+
+
+@triton.jit
+def _tma_completion_dynamic_bytes_kernel(desc, expect_bytes):
+    smem = tle.gpu.alloc((256, 64), dtype=tl.float16, nv_mma_shared_layout=False)
+    full = tle.gpu.alloc_barrier(expect_bytes=expect_bytes)
+    tle.gpu.copy(desc, smem, (256, 64), (0, 0), barrier=full)
+
+
+@triton.jit
+def _tma_completion_wrong_barrier_type_kernel(desc):
+    smem = tle.gpu.alloc((256, 64), dtype=tl.float16, nv_mma_shared_layout=False)
+    tle.gpu.copy(desc, smem, (256, 64), (0, 0), barrier=0)
+
+
+def _compile_tma_completion_ir(fn, signature, constexprs=None):
+    target, backend = mthreads_backend()
+    options = backend.parse_options({"num_stages": 1})
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+
+    src = ASTSource(fn=fn, signature=signature, constexprs=constexprs or {})
+    module = src.make_ir(
+        target,
+        options,
+        backend.get_codegen_implementation(options),
+        backend.get_module_map(),
+        context,
+    )
+    stages = {}
+    backend.add_stages(stages, options, Language.TRITON)
+    metadata = {}
+    module = stages["ttir"](module, metadata)
+    ttir = module.str_nodebug()
+    module = stages["ttgir"](module, metadata)
+    ttgir = module.str_nodebug()
+
+    pm = ir.pass_manager(context)
+    libtriton.mthreads.passes.ttgpuir.add_allocate_shared_memory(pm, 31)
+    pm.run(module, "allocate_tma_completion_shared_memory")
+    return ttir, ttgir, module.str_nodebug()
+
+
+@pytest.mark.parametrize(
+    "stages,slot,block_m,block_n,transpose_offsets",
+    [
+        (1, 0, 256, 64, False),
+        (1, 0, 64, 256, True),
+        (2, 0, 256, 64, False),
+        (2, 1, 256, 64, False),
+        (2, 0, 64, 256, True),
+        (2, 1, 64, 256, True),
+    ],
+)
+def test_tle_tma_completion_barrier_preserves_mthreads_contract(
+    stages,
+    slot,
+    block_m,
+    block_n,
+    transpose_offsets,
+):
+    ttir, ttgir, allocated = _compile_tma_completion_ir(
+        _tma_completion_copy_kernel,
+        signature={
+            "desc": f"tensordesc<fp16[{block_m}, {block_n}]>",
+            "dynamic_k": "i32",
+            "STAGES": "constexpr",
+            "SLOT": "constexpr",
+            "BLOCK_M": "constexpr",
+            "BLOCK_N": "constexpr",
+            "TRANSPOSE_OFFSETS": "constexpr",
+        },
+        constexprs={
+            "STAGES": stages,
+            "SLOT": slot,
+            "BLOCK_M": block_m,
+            "BLOCK_N": block_n,
+            "TRANSPOSE_OFFSETS": transpose_offsets,
+        },
+    )
+
+    assert ttir.count("ttg.tma_copy") == 1, ttir
+    assert ttir.count("musa_tle.barrier.alloc") == 1, ttir
+    assert ttir.count("musa_tle.barrier.index") == 1, ttir
+    assert ttir.count("ttg.memdesc_index") == 1, ttir
+    assert "barrier %" in ttir, ttir
+    assert "expect_bytes = 32768 : i32" in ttir, ttir
+    assert f"tensor<{block_m}x{block_n}xf16>" in ttir, ttir
+    assert re.search(
+        rf"!tt\.tensordesc<tensor<{block_m}x{block_n}xf16",
+        ttir,
+    ), ttir
+    assert "tt.make_tensor_descriptor" not in ttir, ttir
+    if transpose_offsets:
+        assert re.search(r"\[%arg\d+, %c0_i32\] barrier", ttir), ttir
+    else:
+        assert re.search(r"\[%c0_i32, %arg\d+\] barrier", ttir), ttir
+
+    barrier_match = re.search(
+        r"(%[-\w.]+)\s*=\s*musa_tle\.barrier\.index",
+        ttgir,
+    )
+    assert barrier_match, ttgir
+    async_line = next(line for line in ttgir.splitlines() if "ttmg.async_tme_copy_global_to_local" in line)
+    assert f", {barrier_match.group(1)}," in async_line, ttgir
+    assert f"blockShape = array<i32: {block_m}, {block_n}>" in async_line, ttgir
+    assert "musa_tle.expect_bytes = 32768 : i32" in async_line, ttgir
+    assert "ttmg.init_arrival" not in ttgir, ttgir
+    assert "ttmg.barrier_add_trans" not in ttgir, ttgir
+    assert "ttmg.arrive_barrier" not in ttgir, ttgir
+    assert "ttmg.wait_barrier" not in ttgir, ttgir
+    assert "musa.max_bar_id" not in ttgir, ttgir
+
+    assert f"ttg.shared = {stages * 32768} : i32" in allocated, allocated
+
+
+def test_tle_tma_copy_without_completion_barrier_keeps_implicit_sync():
+    ttir, ttgir, allocated = _compile_tma_completion_ir(
+        _tma_implicit_completion_copy_kernel,
+        signature={"desc": "tensordesc<fp16[256, 64]>"},
+    )
+
+    assert "ttg.tma_copy" in ttir, ttir
+    assert "!tt.tensordesc<tensor<256x64xf16" in ttir, ttir
+    assert "tt.make_tensor_descriptor" not in ttir, ttir
+    assert " barrier " not in next(line for line in ttir.splitlines() if "ttg.tma_copy" in line), ttir
+    assert "expect_bytes" not in next(line for line in ttir.splitlines() if "ttg.tma_copy" in line), ttir
+    assert "ttmg.init_arrival" in ttgir, ttgir
+    assert "ttmg.barrier_add_trans" in ttgir, ttgir
+    assert "ttmg.async_tme_copy_global_to_local" in ttgir, ttgir
+    assert "ttmg.arrive_barrier_noret" in ttgir, ttgir
+    assert "ttmg.wait_barrier" in ttgir, ttgir
+    assert "musa.max_bar_id = 1" in ttgir, ttgir
+    assert "ttg.shared = 32768 : i32" in allocated, allocated
+
+
+@pytest.mark.parametrize(
+    "fn,signature,message",
+    [
+        (
+            _tma_completion_unindexed_barrier_kernel,
+            {"desc": "tensordesc<fp16[256, 64]>"},
+            "TMA copy barrier arrays must be indexed",
+        ),
+        (
+            _tma_completion_missing_bytes_kernel,
+            {"desc": "tensordesc<fp16[256, 64]>"},
+            "TMA copy barrier must be allocated with expect_bytes",
+        ),
+        (
+            _tma_completion_wrong_direction_kernel,
+            {"desc": "tensordesc<fp16[256, 64]>"},
+            "TMA copy barrier is only supported for global-to-shared TMA copy",
+        ),
+        (
+            _tma_completion_dynamic_bytes_kernel,
+            {"desc": "tensordesc<fp16[256, 64]>", "expect_bytes": "i32"},
+            "expect_bytes must be a compile-time integer or None",
+        ),
+        (
+            _tma_completion_wrong_barrier_type_kernel,
+            {"desc": "tensordesc<fp16[256, 64]>"},
+            "TMA copy barrier expects tle.gpu barrier",
+        ),
+    ],
+)
+def test_tle_tma_completion_barrier_rejects_invalid_inputs(fn, signature, message):
+    with pytest.raises(CompilationError, match=message):
+        _compile_tma_completion_ir(fn, signature)
 
 
 def test_tle_copy_normal_gmem_to_smem_lowers_to_async_copy():

--- a/third_party/mthreads/python/test/unit/tle/test_tle_pipe.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_pipe.py
@@ -1,0 +1,540 @@
+"""Compile and runtime coverage for the mthreads single-field TLE pipe contract."""
+
+import re
+
+import pytest
+import torch
+import triton
+import triton.language as tl
+import triton.experimental.tle.language as tle
+from triton._C import libtriton
+from triton._C.libtriton import ir
+from triton.backends.compiler import Language
+from triton.compiler import ASTSource
+from triton.compiler.errors import CompilationError
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+from test_tle_utils import mthreads_backend, require_mthreads_libtriton
+
+require_mthreads_libtriton()
+
+
+@triton.jit
+def _pipe_consumer(reader, out, ITERATIONS: tl.constexpr):
+    for iteration in tl.static_range(0, ITERATIONS):
+        wait = reader.wait(iteration)
+        tl.store(out + iteration, iteration + tl.where(wait.is_closed, 1000, 0))
+        reader.release(iteration)
+
+
+@triton.jit
+def _pipe_producer(writer, desc, BLOCK: tl.constexpr, ITERATIONS: tl.constexpr):
+    for iteration in tl.static_range(0, ITERATIONS):
+        slot = writer.acquire(iteration)
+        tle.gpu.copy(desc, slot.data, (BLOCK, ), (iteration * BLOCK, ))
+        writer.commit(iteration)
+
+
+@triton.jit
+def _dual_pipe_consumer(first, second, out, ITERATIONS: tl.constexpr):
+    for iteration in tl.static_range(0, ITERATIONS):
+        first_wait = first.wait(iteration)
+        second_wait = second.wait(iteration)
+        tl.store(out + iteration,
+                 iteration + tl.where(first_wait.is_closed, 1000, 0) + tl.where(second_wait.is_closed, 2000, 0))
+        first.release(iteration)
+        second.release(iteration)
+
+
+@triton.jit
+def _dual_pipe_producer(first, second, first_desc, second_desc, BLOCK: tl.constexpr, ITERATIONS: tl.constexpr):
+    for iteration in tl.static_range(0, ITERATIONS):
+        first_slot = first.acquire(iteration)
+        second_slot = second.acquire(iteration)
+        tle.gpu.copy(first_desc, first_slot.data, (BLOCK, ), (iteration * BLOCK, ))
+        tle.gpu.copy(second_desc, second_slot.data, (BLOCK, ), (iteration * BLOCK, ))
+        first.commit(iteration)
+        second.commit(iteration)
+
+
+@triton.jit
+def _dual_pipe_kernel(
+    first_desc,
+    second_desc,
+    out,
+    STAGES: tl.constexpr,
+    BLOCK: tl.constexpr,
+    ITERATIONS: tl.constexpr,
+):
+    first_smem = tle.gpu.alloc((STAGES, BLOCK), dtype=tl.float16, nv_mma_shared_layout=False)
+    second_smem = tle.gpu.alloc((STAGES, BLOCK), dtype=tl.float16, nv_mma_shared_layout=False)
+    first = tle.pipe(capacity=STAGES, name="first", data=first_smem)
+    second = tle.pipe(capacity=STAGES, name="second", data=second_smem)
+    tle.gpu.warp_specialize(
+        [
+            (_dual_pipe_consumer, (first.reader(), second.reader(), out, ITERATIONS)),
+            (
+                _dual_pipe_producer,
+                (first.writer(), second.writer(), first_desc, second_desc, BLOCK, ITERATIONS),
+            ),
+        ],
+        worker_num_warps=[4],
+        worker_num_regs=[24],
+    )
+
+
+@triton.jit
+def _pipe_kernel(desc, out, STAGES: tl.constexpr, BLOCK: tl.constexpr, ITERATIONS: tl.constexpr):
+    smem = tle.gpu.alloc(
+        (STAGES, BLOCK),
+        dtype=tl.float16,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    pipe = tle.pipe(capacity=STAGES, scope="cta", name="data_pipe", data=smem)
+    tle.gpu.warp_specialize(
+        [
+            (_pipe_consumer, (pipe.reader(), out, ITERATIONS)),
+            (_pipe_producer, (pipe.writer(), desc, BLOCK, ITERATIONS)),
+        ],
+        worker_num_warps=[4],
+        worker_num_regs=[24],
+    )
+
+
+@triton.jit
+def _non_ws_pipe_mm_kernel(
+    a_desc,
+    b_desc,
+    out,
+    K_TILES: tl.constexpr,
+    STAGES: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    a_smem = tle.gpu.alloc(
+        (STAGES, BLOCK_M, BLOCK_K),
+        dtype=tl.float16,
+        layout=None,
+        nv_mma_shared_layout=False,
+    )
+    b_smem = tle.gpu.alloc(
+        (STAGES, BLOCK_K, BLOCK_N),
+        dtype=tl.float16,
+        layout=None,
+        nv_mma_shared_layout=False,
+    )
+    a_pipe = tle.pipe(capacity=STAGES, name="runtime_a", a=a_smem)
+    b_pipe = tle.pipe(capacity=STAGES, name="runtime_b", b=b_smem)
+    a_writer = a_pipe.writer()
+    b_writer = b_pipe.writer()
+    a_reader = a_pipe.reader()
+    b_reader = b_pipe.reader()
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k_iter in tl.static_range(0, K_TILES):
+        a_slot = a_writer.acquire(k_iter)
+        b_slot = b_writer.acquire(k_iter)
+        k_offset = k_iter * BLOCK_K
+        tle.gpu.copy(a_desc, a_slot.a, (BLOCK_M, BLOCK_K), (0, k_offset))
+        tle.gpu.copy(b_desc, b_slot.b, (BLOCK_K, BLOCK_N), (k_offset, 0))
+        a_writer.commit(k_iter)
+        b_writer.commit(k_iter)
+
+        a_wait = a_reader.wait(k_iter)
+        b_wait = b_reader.wait(k_iter)
+        acc = tle.gpu.wgmma(a_wait.slot.a, b_wait.slot.b, acc)
+        acc = tle.gpu.wgmma_wait(0, acc)
+        a_reader.release(k_iter)
+        b_reader.release(k_iter)
+
+    offsets = tl.arange(0, BLOCK_M)[:, None] * BLOCK_N + tl.arange(0, BLOCK_N)[None, :]
+    tl.store(out + offsets, acc.to(tl.float16))
+
+
+@triton.jit
+def _baseline_consumer(out, ITERATIONS: tl.constexpr):
+    for iteration in tl.static_range(0, ITERATIONS):
+        tl.store(out + iteration, iteration)
+
+
+@triton.jit
+def _baseline_producer(smem, desc, BLOCK: tl.constexpr, ITERATIONS: tl.constexpr, STAGES: tl.constexpr):
+    for iteration in tl.static_range(0, ITERATIONS):
+        tle.gpu.copy(desc, smem.slot(iteration % STAGES), (BLOCK, ), (iteration * BLOCK, ))
+
+
+@triton.jit
+def _baseline_kernel(desc, out, STAGES: tl.constexpr, BLOCK: tl.constexpr, ITERATIONS: tl.constexpr):
+    smem = tle.gpu.alloc(
+        (STAGES, BLOCK),
+        dtype=tl.float16,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    tle.gpu.warp_specialize(
+        [
+            (_baseline_consumer, (out, ITERATIONS)),
+            (_baseline_producer, (smem, desc, BLOCK, ITERATIONS, STAGES)),
+        ],
+        worker_num_warps=[4],
+        worker_num_regs=[24],
+    )
+
+
+@triton.jit
+def _local_store_producer(writer, BLOCK: tl.constexpr, ITERATIONS: tl.constexpr):
+    for iteration in tl.static_range(0, ITERATIONS):
+        slot = writer.acquire(iteration)
+        tl.store(tle.gpu.local_ptr(slot.data, (0, )), 0.0)
+        writer.commit(iteration)
+
+
+@triton.jit
+def _double_tme_producer(writer, desc, BLOCK: tl.constexpr, ITERATIONS: tl.constexpr):
+    for iteration in tl.static_range(0, ITERATIONS):
+        slot = writer.acquire(iteration)
+        tle.gpu.copy(desc, slot.data, (BLOCK, ), (iteration * BLOCK, ))
+        tle.gpu.copy(desc, slot.data, (BLOCK, ), (iteration * BLOCK, ))
+        writer.commit(iteration)
+
+
+@triton.jit
+def _close_producer(writer, desc, BLOCK: tl.constexpr, ITERATIONS: tl.constexpr):
+    for iteration in tl.static_range(0, ITERATIONS):
+        slot = writer.acquire(iteration)
+        tle.gpu.copy(desc, slot.data, (BLOCK, ), (iteration * BLOCK, ))
+        writer.commit(iteration)
+        writer.close(iteration)
+
+
+@triton.jit
+def _invalid_pipe_kernel(
+    desc,
+    out,
+    STAGES: tl.constexpr,
+    BLOCK: tl.constexpr,
+    ITERATIONS: tl.constexpr,
+    KIND: tl.constexpr,
+):
+    smem = tle.gpu.alloc(
+        (STAGES, BLOCK),
+        dtype=tl.float16,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    pipe = tle.pipe(capacity=STAGES, scope="cta", name="invalid_pipe", data=smem)
+    if KIND == 0:
+        tle.gpu.warp_specialize(
+            [
+                (_pipe_consumer, (pipe.reader(), out, ITERATIONS)),
+                (_local_store_producer, (pipe.writer(), BLOCK, ITERATIONS)),
+            ],
+            worker_num_warps=[4],
+            worker_num_regs=[24],
+        )
+    elif KIND == 1:
+        tle.gpu.warp_specialize(
+            [
+                (_pipe_consumer, (pipe.reader(), out, ITERATIONS)),
+                (_double_tme_producer, (pipe.writer(), desc, BLOCK, ITERATIONS)),
+            ],
+            worker_num_warps=[4],
+            worker_num_regs=[24],
+        )
+    else:
+        tle.gpu.warp_specialize(
+            [
+                (_pipe_consumer, (pipe.reader(), out, ITERATIONS)),
+                (_close_producer, (pipe.writer(), desc, BLOCK, ITERATIONS)),
+            ],
+            worker_num_warps=[4],
+            worker_num_regs=[24],
+        )
+
+
+@triton.jit
+def _misplaced_pipe_kernel(desc, out, STAGES: tl.constexpr, BLOCK: tl.constexpr, ITERATIONS: tl.constexpr):
+    smem = tle.gpu.alloc(
+        (STAGES, BLOCK),
+        dtype=tl.float16,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    pipe = tle.pipe(capacity=STAGES, scope="cta", name="misplaced", data=smem)
+    tle.gpu.warp_specialize(
+        [
+            (_pipe_producer, (pipe.writer(), desc, BLOCK, ITERATIONS)),
+            (_pipe_consumer, (pipe.reader(), out, ITERATIONS)),
+        ],
+        worker_num_warps=[4],
+        worker_num_regs=[24],
+    )
+
+
+@triton.jit
+def _multi_field_kernel(desc, out, STAGES: tl.constexpr, BLOCK: tl.constexpr, ITERATIONS: tl.constexpr):
+    first = tle.gpu.alloc((STAGES, BLOCK), dtype=tl.float16, nv_mma_shared_layout=False)
+    second = tle.gpu.alloc((STAGES, BLOCK), dtype=tl.float16, nv_mma_shared_layout=False)
+    tle.pipe(capacity=STAGES, first=first, second=second)
+
+
+@triton.jit
+def _named_reader_kernel(desc, out, STAGES: tl.constexpr, BLOCK: tl.constexpr, ITERATIONS: tl.constexpr):
+    smem = tle.gpu.alloc((STAGES, BLOCK), dtype=tl.float16, nv_mma_shared_layout=False)
+    tle.pipe(capacity=STAGES, readers=("consumer", ), data=smem)
+
+
+@triton.jit
+def _one_shot_kernel(desc, out, STAGES: tl.constexpr, BLOCK: tl.constexpr, ITERATIONS: tl.constexpr):
+    smem = tle.gpu.alloc((STAGES, BLOCK), dtype=tl.float16, nv_mma_shared_layout=False)
+    tle.pipe(capacity=STAGES, one_shot=True, data=smem)
+
+
+def _compile_pipeline(fn, stages):
+    target, backend = mthreads_backend()
+    options = backend.parse_options({"num_warps": 16, "num_stages": 1})
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    source = ASTSource(
+        fn=fn,
+        signature={
+            "desc": "tensordesc<fp16[128]>",
+            "out": "*i32",
+            "STAGES": "constexpr",
+            "BLOCK": "constexpr",
+            "ITERATIONS": "constexpr",
+        },
+        constexprs={"STAGES": stages, "BLOCK": 128, "ITERATIONS": 2 * stages},
+    )
+    module = source.make_ir(
+        target,
+        options,
+        backend.get_codegen_implementation(options),
+        backend.get_module_map(),
+        context,
+    )
+    compiler_stages = {}
+    backend.add_stages(compiler_stages, options, Language.TRITON)
+    metadata = {}
+    module = compiler_stages["ttir"](module, metadata)
+    ttir = module.str_nodebug()
+    module = compiler_stages["ttgir"](module, metadata)
+    ttgir = module.str_nodebug()
+
+    pm = ir.pass_manager(context)
+    libtriton.mthreads.passes.ttgpuir.add_allocate_shared_memory(pm, 31)
+    pm.run(module, "allocate_pipe_shared_memory")
+    return ttir, ttgir, module.str_nodebug()
+
+
+def _compile_invalid_pipeline(fn, kind=None):
+    target, backend = mthreads_backend()
+    options = backend.parse_options({"num_warps": 16, "num_stages": 1})
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    signature = {
+        "desc": "tensordesc<fp16[128]>",
+        "out": "*i32",
+        "STAGES": "constexpr",
+        "BLOCK": "constexpr",
+        "ITERATIONS": "constexpr",
+    }
+    constexprs = {"STAGES": 2, "BLOCK": 128, "ITERATIONS": 2}
+    if kind is not None:
+        signature["KIND"] = "constexpr"
+        constexprs["KIND"] = kind
+    source = ASTSource(fn=fn, signature=signature, constexprs=constexprs)
+    module = source.make_ir(
+        target,
+        options,
+        backend.get_codegen_implementation(options),
+        backend.get_module_map(),
+        context,
+    )
+    compiler_stages = {}
+    backend.add_stages(compiler_stages, options, Language.TRITON)
+    metadata = {}
+    module = compiler_stages["ttir"](module, metadata)
+    return compiler_stages["ttgir"](module, metadata)
+
+
+def _compile_dual_pipeline(stages):
+    target, backend = mthreads_backend()
+    options = backend.parse_options({"num_warps": 16, "num_stages": 1})
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    source = ASTSource(
+        fn=_dual_pipe_kernel,
+        signature={
+            "first_desc": "tensordesc<fp16[128]>",
+            "second_desc": "tensordesc<fp16[128]>",
+            "out": "*i32",
+            "STAGES": "constexpr",
+            "BLOCK": "constexpr",
+            "ITERATIONS": "constexpr",
+        },
+        constexprs={"STAGES": stages, "BLOCK": 128, "ITERATIONS": 2 * stages},
+    )
+    module = source.make_ir(
+        target,
+        options,
+        backend.get_codegen_implementation(options),
+        backend.get_module_map(),
+        context,
+    )
+    compiler_stages = {}
+    backend.add_stages(compiler_stages, options, Language.TRITON)
+    metadata = {}
+    module = compiler_stages["ttir"](module, metadata)
+    module = compiler_stages["ttgir"](module, metadata)
+    return module.str_nodebug()
+
+
+def _shared_bytes(allocated):
+    return int(re.search(r"ttg\.shared = (\d+) : i32", allocated).group(1))
+
+
+def _i32_constants(ir_text):
+    return {
+        name: int(value)
+        for name, value in re.findall(r"(%[-\w.]+)\s*=\s*arith\.constant\s+(-?\d+)\s*:\s*i32", ir_text)
+    }
+
+
+@pytest.mark.parametrize("stages", [1, 2])
+def test_mthreads_single_field_pipe_lowers_to_hardware_barriers(stages):
+    ttir, ttgir, allocated = _compile_pipeline(_pipe_kernel, stages)
+
+    assert ttir.count("tle.pipe.create") == 1, ttir
+    assert ttir.count("tle.pipe.writer_acquire") == 2 * stages, ttir
+    assert ttir.count("tle.pipe.writer_commit") == 2 * stages, ttir
+    assert ttir.count("tle.pipe.reader_wait") == 2 * stages, ttir
+    assert ttir.count("tle.pipe.reader_release") == 2 * stages, ttir
+    assert "tle.pipe." not in ttgir, ttgir
+    assert ttgir.count("ttmg.init_arrival") == 2 * stages, ttgir
+    assert f"musa.max_bar_id = {2 * stages}" in ttgir, ttgir
+    assert "ttmg.barrier_add_trans" in ttgir, ttgir
+    assert "ttmg.wait_barrier" in ttgir, ttgir
+    assert "ttmg.warp_arrive_barrier" in ttgir, ttgir
+    assert "ttmg.async_tme_copy_global_to_local" in ttgir, ttgir
+    assert "tle.pipe." not in allocated, allocated
+    assert "1000" not in ttgir, ttgir
+
+    constants = _i32_constants(ttgir)
+    arrivals = re.findall(r"ttmg\.init_arrival\s+(%[-\w.]+),\s+(%[-\w.]+),\s+(%[-\w.]+)", ttgir)
+    assert [constants[count] for _, count, _ in arrivals] == [1] * stages + [16] * stages
+    assert [constants[phase] for _, _, phase in arrivals] == [0] * (2 * stages)
+    assert ttgir.count("ttmg.barrier_add_trans") == 2 * stages
+    assert all("%c256" in line for line in ttgir.splitlines() if "ttmg.barrier_add_trans" in line)
+
+
+@pytest.mark.parametrize("stages", [1, 2])
+def test_mthreads_pipe_barrier_ids_add_no_shared_memory(stages):
+    _, _, pipe_allocated = _compile_pipeline(_pipe_kernel, stages)
+    _, _, baseline_allocated = _compile_pipeline(_baseline_kernel, stages)
+
+    assert _shared_bytes(pipe_allocated) == _shared_bytes(baseline_allocated)
+    ws_line = next(line for line in pipe_allocated.splitlines() if "ttg.warp_specialize(" in line)
+    # Only the payload, descriptor, and ordinary scalar captures remain. The
+    # two full/empty hardware barrier base IDs are rematerialized constants.
+    assert "data_pipe" not in ws_line
+
+
+@pytest.mark.parametrize("stages", [1, 2])
+def test_mthreads_two_single_field_pipes_keep_independent_barrier_rings(stages):
+    ttgir = _compile_dual_pipeline(stages)
+    assert "tle.pipe." not in ttgir, ttgir
+    assert ttgir.count("ttmg.init_arrival") == 4 * stages, ttgir
+    assert ttgir.count("ttmg.barrier_add_trans") == 4 * stages, ttgir
+    assert ttgir.count("ttmg.async_tme_copy_global_to_local") == 4 * stages, ttgir
+    assert f"musa.max_bar_id = {4 * stages}" in ttgir, ttgir
+
+
+@pytest.mark.parametrize(
+    "kernel,diagnostic",
+    [
+        (_multi_field_kernel, "requires exactly one payload field"),
+        (_named_reader_kernel, "supports only the default SPSC reader"),
+        (_one_shot_kernel, "does not support one_shot=True"),
+    ],
+)
+def test_mthreads_pipe_rejects_unsupported_frontend_options(kernel, diagnostic):
+    with pytest.raises(CompilationError, match=diagnostic):
+        _compile_invalid_pipeline(kernel)
+
+
+@pytest.mark.parametrize(
+    "kind,diagnostic",
+    [
+        (0, "requires exactly one TME copy between acquire and commit; found 0"),
+        (1, "requires exactly one TME copy between acquire and commit; found 2"),
+        (2, "does not support writer.close"),
+    ],
+)
+def test_mthreads_pipe_rejects_unsupported_producer_protocol(capfd, kind, diagnostic):
+    with pytest.raises(RuntimeError, match="PassManager::run failed"):
+        _compile_invalid_pipeline(_invalid_pipe_kernel, kind)
+    assert diagnostic in capfd.readouterr().err
+
+
+def test_mthreads_pipe_rejects_writer_in_default_partition(capfd):
+    with pytest.raises(RuntimeError, match="PassManager::run failed"):
+        _compile_invalid_pipeline(_misplaced_pipe_kernel)
+    assert "requires writer operations either outside warp_specialize or in the worker partition 0" in capfd.readouterr(
+    ).err
+
+
+@pytest.mark.parametrize(
+    "block_m,block_n,k_tiles,stages",
+    [
+        pytest.param(128, 128, 4, 1, id="m128-n128-k256-stage1"),
+        pytest.param(128, 128, 4, 2, id="m128-n128-k256-stage2"),
+        pytest.param(256, 256, 1, 1, id="m256-n256-k64-stage1"),
+    ],
+)
+def test_mthreads_non_ws_pipe_mm_runtime(block_m, block_n, k_tiles, stages):
+    torch.manual_seed(42)
+    block_k = 64
+    k = k_tiles * block_k
+    a = torch.randn((block_m, k), dtype=torch.float16, device="musa")
+    b = torch.randn((k, block_n), dtype=torch.float16, device="musa")
+    out = torch.empty((block_m, block_n), dtype=torch.float16, device="musa")
+    a_desc = TensorDescriptor.from_tensor(a, [block_m, block_k])
+    b_desc = TensorDescriptor.from_tensor(b, [block_k, block_n])
+    reference = torch.matmul(a.to(torch.float32), b.to(torch.float32))
+
+    for _ in range(2):
+        out.fill_(float("nan"))
+        _non_ws_pipe_mm_kernel[(1, )](
+            a_desc,
+            b_desc,
+            out,
+            K_TILES=k_tiles,
+            STAGES=stages,
+            BLOCK_M=block_m,
+            BLOCK_N=block_n,
+            BLOCK_K=block_k,
+            num_warps=4,
+            num_stages=1,
+        )
+        torch.musa.synchronize()
+        torch.testing.assert_close(out.to(torch.float32), reference, rtol=1.25e-1, atol=1.25e-1)
+
+
+def test_mthreads_pipe_bindings_are_optional_and_backend_local():
+    assert hasattr(libtriton.ir.builder, "create_pipe_create")
+    assert hasattr(libtriton.ir.builder, "create_pipe_writer_acquire")
+    assert hasattr(libtriton.ir.builder, "create_pipe_writer_commit")
+    assert hasattr(libtriton.ir.builder, "create_pipe_writer_close")
+    assert hasattr(libtriton.ir.builder, "create_pipe_reader_wait")
+    assert hasattr(libtriton.ir.builder, "create_pipe_reader_release")
+    assert hasattr(libtriton.mthreads.passes.ttgpuir, "add_tle_lower_pipe")

--- a/third_party/mthreads/python/test/unit/tle/test_tle_pipe.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_pipe.py
@@ -501,7 +501,7 @@ def _i32_constants(ir_text):
     }
 
 
-@pytest.mark.parametrize("stages", [1, 2])
+@pytest.mark.parametrize("stages", [1, 2, 3])
 def test_mthreads_single_field_pipe_lowers_to_hardware_barriers(stages):
     ttir, ttgir, allocated = _compile_pipeline(_pipe_kernel, stages)
 
@@ -528,7 +528,7 @@ def test_mthreads_single_field_pipe_lowers_to_hardware_barriers(stages):
     assert all("%c256" in line for line in ttgir.splitlines() if "ttmg.barrier_add_trans" in line)
 
 
-@pytest.mark.parametrize("stages", [1, 2])
+@pytest.mark.parametrize("stages", [1, 2, 3])
 def test_mthreads_pipe_barrier_ids_add_no_shared_memory(stages):
     _, _, pipe_allocated = _compile_pipeline(_pipe_kernel, stages)
     _, _, baseline_allocated = _compile_pipeline(_baseline_kernel, stages)
@@ -540,7 +540,7 @@ def test_mthreads_pipe_barrier_ids_add_no_shared_memory(stages):
     assert "musa_tle.static_ws." not in pipe_allocated, pipe_allocated
 
 
-@pytest.mark.parametrize("stages", [1, 2])
+@pytest.mark.parametrize("stages", [1, 2, 3])
 def test_mthreads_two_single_field_pipes_keep_independent_barrier_rings(stages):
     ttgir = _compile_dual_pipeline(stages)
     assert "tle.pipe." not in ttgir, ttgir
@@ -589,6 +589,7 @@ def test_mthreads_pipe_rejects_writer_in_default_partition(capfd):
     [
         pytest.param(128, 128, 4, 1, id="m128-n128-k256-stage1"),
         pytest.param(128, 128, 4, 2, id="m128-n128-k256-stage2"),
+        pytest.param(128, 128, 7, 3, id="m128-n128-k448-stage3"),
         pytest.param(256, 256, 1, 1, id="m256-n256-k64-stage1"),
     ],
 )
@@ -621,12 +622,14 @@ def test_mthreads_non_ws_pipe_mm_runtime(block_m, block_n, k_tiles, stages):
         torch.testing.assert_close(out.to(torch.float32), reference, rtol=1.25e-1, atol=1.25e-1)
 
 
-@pytest.mark.parametrize("stages", [1, 2], ids=["stage1", "stage2"])
+@pytest.mark.parametrize("stages", [1, 2, 3], ids=["stage1", "stage2", "stage3"])
 def test_mthreads_ws_pipe_mm_runtime(stages):
     torch.manual_seed(42)
     block_m = block_n = 256
     block_k = 64
-    k_tiles = 4
+    # Seven tiles exercise a full two-phase cycle and then reuse slot zero for
+    # the third generation when capacity is three.
+    k_tiles = 7
     k = k_tiles * block_k
     a = torch.randn((block_m, k), dtype=torch.float16, device="musa")
     b = torch.randn((k, block_n), dtype=torch.float16, device="musa")

--- a/third_party/mthreads/python/test/unit/tle/test_tle_pipe.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_pipe.py
@@ -155,6 +155,97 @@ def _non_ws_pipe_mm_kernel(
 
 
 @triton.jit
+def _ws_pipe_mm_consumer(
+    a_reader,
+    b_reader,
+    out,
+    K_TILES: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k_iter in tl.range(0, K_TILES, num_stages=1):
+        a_wait = a_reader.wait(k_iter)
+        b_wait = b_reader.wait(k_iter)
+        acc = tle.gpu.wgmma(a_wait.slot.a, b_wait.slot.b, acc)
+        acc = tle.gpu.wgmma_wait(0, acc)
+        a_reader.release(k_iter)
+        b_reader.release(k_iter)
+
+    offsets = tl.arange(0, BLOCK_M)[:, None] * BLOCK_N + tl.arange(0, BLOCK_N)[None, :]
+    tl.store(out + offsets, acc.to(tl.float16))
+
+
+@triton.jit
+def _ws_pipe_mm_producer(
+    a_writer,
+    b_writer,
+    a_desc,
+    b_desc,
+    K_TILES: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    for k_iter in tl.range(0, K_TILES, num_stages=1):
+        a_slot = a_writer.acquire(k_iter)
+        b_slot = b_writer.acquire(k_iter)
+        k_offset = k_iter * BLOCK_K
+        tle.gpu.copy(a_desc, a_slot.a, (BLOCK_M, BLOCK_K), (0, k_offset))
+        tle.gpu.copy(b_desc, b_slot.b, (BLOCK_K, BLOCK_N), (k_offset, 0))
+        a_writer.commit(k_iter)
+        b_writer.commit(k_iter)
+
+
+@triton.jit
+def _ws_pipe_mm_kernel(
+    a_desc,
+    b_desc,
+    out,
+    K_TILES: tl.constexpr,
+    STAGES: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    a_smem = tle.gpu.alloc(
+        (STAGES, BLOCK_M, BLOCK_K),
+        dtype=tl.float16,
+        nv_mma_shared_layout=False,
+    )
+    b_smem = tle.gpu.alloc(
+        (STAGES, BLOCK_K, BLOCK_N),
+        dtype=tl.float16,
+        nv_mma_shared_layout=False,
+    )
+    a_pipe = tle.pipe(capacity=STAGES, name="ws_runtime_a", a=a_smem)
+    b_pipe = tle.pipe(capacity=STAGES, name="ws_runtime_b", b=b_smem)
+    tle.gpu.warp_specialize(
+        [
+            (
+                _ws_pipe_mm_consumer,
+                (a_pipe.reader(), b_pipe.reader(), out, K_TILES, BLOCK_M, BLOCK_N),
+            ),
+            (
+                _ws_pipe_mm_producer,
+                (
+                    a_pipe.writer(),
+                    b_pipe.writer(),
+                    a_desc,
+                    b_desc,
+                    K_TILES,
+                    BLOCK_M,
+                    BLOCK_N,
+                    BLOCK_K,
+                ),
+            ),
+        ],
+        worker_num_warps=[4],
+        worker_num_regs=[24],
+    )
+
+
+@triton.jit
 def _baseline_consumer(out, ITERATIONS: tl.constexpr):
     for iteration in tl.static_range(0, ITERATIONS):
         tl.store(out + iteration, iteration)
@@ -443,10 +534,10 @@ def test_mthreads_pipe_barrier_ids_add_no_shared_memory(stages):
     _, _, baseline_allocated = _compile_pipeline(_baseline_kernel, stages)
 
     assert _shared_bytes(pipe_allocated) == _shared_bytes(baseline_allocated)
-    ws_line = next(line for line in pipe_allocated.splitlines() if "ttg.warp_specialize(" in line)
-    # Only the payload, descriptor, and ordinary scalar captures remain. The
-    # two full/empty hardware barrier base IDs are rematerialized constants.
-    assert "data_pipe" not in ws_line
+    assert pipe_allocated.count("ttg.warp_specialize") == 1, pipe_allocated
+    ws_line = next(line for line in pipe_allocated.splitlines() if "ttg.warp_specialize" in line)
+    assert "allocation.offset" not in ws_line, ws_line
+    assert "musa_tle.static_ws." not in pipe_allocated, pipe_allocated
 
 
 @pytest.mark.parametrize("stages", [1, 2])
@@ -524,6 +615,64 @@ def test_mthreads_non_ws_pipe_mm_runtime(block_m, block_n, k_tiles, stages):
             BLOCK_N=block_n,
             BLOCK_K=block_k,
             num_warps=4,
+            num_stages=1,
+        )
+        torch.musa.synchronize()
+        torch.testing.assert_close(out.to(torch.float32), reference, rtol=1.25e-1, atol=1.25e-1)
+
+
+@pytest.mark.parametrize("stages", [1, 2], ids=["stage1", "stage2"])
+def test_mthreads_ws_pipe_mm_runtime(stages):
+    torch.manual_seed(42)
+    block_m = block_n = 256
+    block_k = 64
+    k_tiles = 4
+    k = k_tiles * block_k
+    a = torch.randn((block_m, k), dtype=torch.float16, device="musa")
+    b = torch.randn((k, block_n), dtype=torch.float16, device="musa")
+    out = torch.empty((block_m, block_n), dtype=torch.float16, device="musa")
+    a_desc = TensorDescriptor.from_tensor(a, [block_m, block_k])
+    b_desc = TensorDescriptor.from_tensor(b, [block_k, block_n])
+    reference = torch.matmul(a.to(torch.float32), b.to(torch.float32))
+
+    compiled = _ws_pipe_mm_kernel.warmup(
+        a_desc,
+        b_desc,
+        out,
+        K_TILES=k_tiles,
+        STAGES=stages,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        BLOCK_K=block_k,
+        grid=(1, ),
+        num_warps=16,
+        num_stages=1,
+    )
+    assert compiled.metadata.num_warps == 20
+    assert compiled.metadata.shared == stages * 65536
+    assert '"ttg.total-num-warps" = 20 : i32' in compiled.asm["ttgir"]
+    assert compiled.asm["ttgir"].count("ttg.warp_specialize") == 1
+    assert "musa_tle.static_ws." not in compiled.asm["ttgir"]
+    assert "ttg.warp_specialize" not in compiled.asm["llir"]
+    assert "ttg.convert_layout" not in compiled.asm["ttgir"]
+    assert "swizzleGranularity = 1 : i32" in compiled.asm["ttgir"]
+    assert "swizzleGranularity = 2 : i32" in compiled.asm["ttgir"]
+    assert "builtin.unrealized_conversion_cast" not in compiled.asm["llir"]
+    assert compiled.asm["llir"].count("call void @llvm.musa.syncthreads.lm()") == 1
+    assert f"llvm.musa.async.bar.record(i32 {4 * stages})" in compiled.asm["llir"]
+
+    for _ in range(2):
+        out.fill_(float("nan"))
+        _ws_pipe_mm_kernel[(1, )](
+            a_desc,
+            b_desc,
+            out,
+            K_TILES=k_tiles,
+            STAGES=stages,
+            BLOCK_M=block_m,
+            BLOCK_N=block_n,
+            BLOCK_K=block_k,
+            num_warps=16,
             num_stages=1,
         )
         torch.musa.synchronize()

--- a/third_party/mthreads/python/test/unit/tle/test_tle_pipe.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_pipe.py
@@ -118,13 +118,13 @@ def _non_ws_pipe_mm_kernel(
         (STAGES, BLOCK_M, BLOCK_K),
         dtype=tl.float16,
         layout=None,
-        nv_mma_shared_layout=False,
+        nv_mma_shared_layout=True,
     )
     b_smem = tle.gpu.alloc(
         (STAGES, BLOCK_K, BLOCK_N),
         dtype=tl.float16,
         layout=None,
-        nv_mma_shared_layout=False,
+        nv_mma_shared_layout=True,
     )
     a_pipe = tle.pipe(capacity=STAGES, name="runtime_a", a=a_smem)
     b_pipe = tle.pipe(capacity=STAGES, name="runtime_b", b=b_smem)
@@ -211,12 +211,12 @@ def _ws_pipe_mm_kernel(
     a_smem = tle.gpu.alloc(
         (STAGES, BLOCK_M, BLOCK_K),
         dtype=tl.float16,
-        nv_mma_shared_layout=False,
+        nv_mma_shared_layout=True,
     )
     b_smem = tle.gpu.alloc(
         (STAGES, BLOCK_K, BLOCK_N),
         dtype=tl.float16,
-        nv_mma_shared_layout=False,
+        nv_mma_shared_layout=True,
     )
     a_pipe = tle.pipe(capacity=STAGES, name="ws_runtime_a", a=a_smem)
     b_pipe = tle.pipe(capacity=STAGES, name="ws_runtime_b", b=b_smem)

--- a/third_party/mthreads/python/test/unit/tle/test_tle_slot.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_slot.py
@@ -1,0 +1,219 @@
+"""Compile-only coverage for mthreads TLE buffered_tensor.slot()."""
+
+import re
+
+import pytest
+import triton
+import triton.language as tl
+import triton.experimental.tle.language as tle
+from triton.compiler import ASTSource
+from triton.compiler.errors import CompilationError
+
+from test_tle_utils import musa_target, mthreads_backend, require_mthreads_libtriton
+
+require_mthreads_libtriton()
+
+
+@triton.jit
+def _slot_a_kernel(value_ptr, out_ptr, STAGES: tl.constexpr):
+    value = tl.load(value_ptr)
+    smem = tle.gpu.alloc(
+        (STAGES, 256, 64),
+        dtype=tl.float16,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    for slot_index in tl.static_range(0, STAGES):
+        slot = smem.slot(slot_index)
+        ptr = tle.gpu.local_ptr(slot, (0, 0))
+        tl.store(ptr, value)
+        tl.store(out_ptr + slot_index, tl.load(ptr))
+
+
+@triton.jit
+def _slot_b_kernel(value_ptr, out_ptr, STAGES: tl.constexpr):
+    value = tl.load(value_ptr)
+    smem = tle.gpu.alloc(
+        (STAGES, 64, 256),
+        dtype=tl.float16,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    for slot_index in tl.static_range(0, STAGES):
+        slot = smem.slot(slot_index)
+        ptr = tle.gpu.local_ptr(slot, (0, 0))
+        tl.store(ptr, value)
+        tl.store(out_ptr + slot_index, tl.load(ptr))
+
+
+@triton.jit
+def _slot_dynamic_kernel(value_ptr, out_ptr, stage):
+    value = tl.load(value_ptr)
+    smem = tle.gpu.alloc(
+        (2, 16, 16),
+        dtype=tl.float16,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    slot = smem.slot(stage)
+    ptr = tle.gpu.local_ptr(slot, (0, 0))
+    tl.store(ptr, value)
+    tl.store(out_ptr, tl.load(ptr))
+
+
+@triton.jit
+def _slot_constant_kernel(value_ptr, out_ptr, STAGES: tl.constexpr, SLOT: tl.constexpr):
+    value = tl.load(value_ptr)
+    smem = tle.gpu.alloc(
+        (STAGES, 16, 16),
+        dtype=tl.float16,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    slot = smem.slot(SLOT)
+    ptr = tle.gpu.local_ptr(slot, (0, 0))
+    tl.store(ptr, value)
+    tl.store(out_ptr, tl.load(ptr))
+
+
+def _compile_slot(fn, stages):
+    signature = {
+        "value_ptr": "*fp16",
+        "out_ptr": "*fp16",
+        "STAGES": "constexpr",
+    }
+    src = ASTSource(fn=fn, signature=signature, constexprs={"STAGES": stages})
+    return triton.compile(src, target=musa_target(), options={"num_stages": 1})
+
+
+def _compile_constant_slot(stages, slot):
+    src = ASTSource(
+        fn=_slot_constant_kernel,
+        signature={
+            "value_ptr": "*fp16",
+            "out_ptr": "*fp16",
+            "STAGES": "constexpr",
+            "SLOT": "constexpr",
+        },
+        constexprs={"STAGES": stages, "SLOT": slot},
+    )
+    return triton.compile(src, target=musa_target(), options={"num_stages": 1})
+
+
+def _memdesc_index_ops(ir_text):
+    constants = {
+        name: int(value)
+        for name, value in re.findall(
+            r"(%[-\w.]+)\s*=\s*(?:arith\.)?constant\s+(-?\d+)\s*:\s*i32",
+            ir_text,
+        )
+    }
+    ops = []
+    for line in ir_text.splitlines():
+        if "ttg.memdesc_index" not in line:
+            continue
+        match = re.search(
+            r"(?P<result>%[-\w.]+)\s*=\s*ttg\.memdesc_index\s+"
+            r"(?P<src>%[-\w.]+)\[(?P<index>%[-\w.]+)\]",
+            line,
+        )
+        assert match, line
+        index_name = match.group("index")
+        ops.append((match, constants.get(index_name), line))
+    return ops
+
+
+def _assert_slot_ir(ir_text, stages, trailing_shape):
+    ops = _memdesc_index_ops(ir_text)
+    assert len(ops) == stages, ir_text
+    assert {value for _, value, _ in ops} == set(range(stages)), ir_text
+    assert "#ttg.nvmma_shared" not in ir_text, ir_text
+    layouts = dict(re.findall(
+        r"(?m)^\s*(#[-\w.]+)\s*=\s*(#ttg\.swizzled_shared<[^\n]+>)\s*$",
+        ir_text,
+    ))
+
+    source_shape = f"!ttg.memdesc<{stages}x{trailing_shape}xf16"
+    result_shape = f"!ttg.memdesc<{trailing_shape}xf16"
+    for match, _, line in ops:
+        assert source_shape in line, line
+        assert result_shape in line, line
+        source_type, result_type = line.split(" : ", 1)[1].split(" -> ", 1)
+        source_layout = re.findall(r"#[-\w.]+", source_type)[0]
+        result_layout = re.findall(r"#[-\w.]+", result_type)[0]
+        assert source_layout in layouts, (line, layouts)
+        assert result_layout in layouts, (line, layouts)
+        assert "order = [2, 1, 0]" in layouts[source_layout], layouts[source_layout]
+        assert "order = [1, 0]" in layouts[result_layout], layouts[result_layout]
+        assert source_type.count("#smem") == 1, source_type
+        assert result_type.count("#smem") == 1, result_type
+        result = match.group("result")
+        assert re.search(
+            rf"(?:\"musa_tle\.local_pointers\"|musa_tle\.local_pointers)\s*\(\s*"
+            rf"{re.escape(result)}\b",
+            ir_text,
+        ), ir_text
+
+
+@pytest.mark.parametrize("stages", [1, 2])
+@pytest.mark.parametrize(
+    "kernel,trailing_shape",
+    [(_slot_a_kernel, "256x64"), (_slot_b_kernel, "64x256")],
+)
+def test_mthreads_tle_slot_emits_one_index_per_constant_stage(kernel, trailing_shape, stages):
+    compiled = _compile_slot(kernel, stages)
+    assert compiled.metadata.num_stages == 1
+    _assert_slot_ir(compiled.asm["ttir"], stages, trailing_shape)
+    _assert_slot_ir(compiled.asm["ttgir"], stages, trailing_shape)
+
+
+def test_mthreads_tle_slot_binding_is_backend_local():
+    _, backend = mthreads_backend()
+    from triton._C.libtriton import ir
+
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    builder = ir.builder(context)
+    assert hasattr(builder, "create_memdesc_index")
+
+
+def test_mthreads_tle_slot_preserves_dynamic_int32_stage():
+    src = ASTSource(
+        fn=_slot_dynamic_kernel,
+        signature={"value_ptr": "*fp16", "out_ptr": "*fp16", "stage": "i32"},
+    )
+    compiled = triton.compile(src, target=musa_target(), options={"num_stages": 1})
+    assert compiled.metadata.num_stages == 1
+
+    for ir_name in ("ttir", "ttgir"):
+        ir_text = compiled.asm[ir_name]
+        ops = _memdesc_index_ops(ir_text)
+        assert len(ops) == 1, ir_text
+        match, constant_value, line = ops[0]
+        assert constant_value is None, line
+        assert match.group("index") == "%stage", line
+        assert "!ttg.memdesc<2x16x16xf16" in line, line
+        assert "!ttg.memdesc<16x16xf16" in line, line
+        result = match.group("result")
+        assert re.search(
+            rf"(?:\"musa_tle\.local_pointers\"|musa_tle\.local_pointers)\s*\(\s*"
+            rf"{re.escape(result)}\b",
+            ir_text,
+        ), ir_text
+
+
+@pytest.mark.parametrize(
+    "stages,slot",
+    [(1, -1), (1, 1), (2, -1), (2, 2)],
+)
+def test_mthreads_tle_slot_rejects_constant_out_of_bounds(stages, slot):
+    with pytest.raises(
+            CompilationError,
+            match=rf"mthreads TLE memdesc index {slot} out of bounds for leading dimension {stages}",
+    ):
+        _compile_constant_slot(stages, slot)

--- a/third_party/mthreads/python/test/unit/tle/test_tle_sqmma.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_sqmma.py
@@ -1,0 +1,478 @@
+"""Compile coverage for the initial mthreads TLE SQMMA contract."""
+
+import pytest
+import triton
+import triton.language as tl
+import triton.experimental.tle.language as tle
+from triton.compiler.errors import CompilationError
+
+from test_tle_utils import compile_musa, compile_to_ttir, require_mthreads_libtriton
+
+require_mthreads_libtriton()
+
+_SQMMA_MN_SHAPES = (
+    (16, 64),
+    (32, 32),
+    (32, 64),
+    (32, 128),
+    (64, 16),
+    (64, 32),
+    (64, 64),
+    (64, 128),
+    (128, 32),
+    (128, 64),
+    (128, 128),
+)
+_SQMMA_DTYPE_CASES = (
+    ("float16", 0, 2, "fmma", (16, 32, 64), 1.0, 1.0e-1, 5.0e-2),
+    ("bfloat16", 1, 2, "bfmma", (16, 32, 64), 1.0, 3.0e-1, 1.0e-1),
+    ("float8_e4m3fn", 2, 1, "e4m3", (32, 64, 128), 0.5, 5.0e-1, 1.5e-1),
+)
+_SQMMA_SHAPE_CASES = tuple(
+    pytest.param(
+        torch_dtype_name,
+        dtype_kind,
+        input_bytes,
+        intrinsic_tag,
+        m,
+        n,
+        k,
+        scale,
+        atol,
+        rtol,
+        id=f"{intrinsic_tag}-m{m}-n{n}-k{k}",
+    )
+    for torch_dtype_name, dtype_kind, input_bytes, intrinsic_tag, k_shapes, scale, atol, rtol in _SQMMA_DTYPE_CASES
+    for m, n in _SQMMA_MN_SHAPES
+    for k in k_shapes)
+
+
+@triton.jit
+def _tle_sqmma_kernel(out):
+    a = tle.gpu.alloc((128, 64), dtype=tl.float16, layout=None, nv_mma_shared_layout=False)
+    b = tle.gpu.alloc((64, 128), dtype=tl.float16, layout=None, nv_mma_shared_layout=False)
+    acc = tl.zeros((128, 128), dtype=tl.float32)
+    acc = tle.gpu.wgmma(a, b, acc)
+    acc = tle.gpu.wgmma_wait(0, acc)
+    offsets = tl.arange(0, 128)[:, None] * 128 + tl.arange(0, 128)[None, :]
+    tl.store(out + offsets, acc)
+
+
+@triton.jit
+def _tle_sqmma_nonzero_wait_kernel(out):
+    a = tle.gpu.alloc((128, 64), dtype=tl.float16, layout=None, nv_mma_shared_layout=False)
+    b = tle.gpu.alloc((64, 128), dtype=tl.float16, layout=None, nv_mma_shared_layout=False)
+    acc = tle.gpu.wgmma(a, b, tl.zeros((128, 128), dtype=tl.float32))
+    acc = tle.gpu.wgmma_wait(1, acc)
+    offsets = tl.arange(0, 128)[:, None] * 128 + tl.arange(0, 128)[None, :]
+    tl.store(out + offsets, acc)
+
+
+@triton.jit
+def _tle_sqmma_runtime_kernel(a_desc, b_desc, out):
+    block_m: tl.constexpr = 128
+    block_n: tl.constexpr = 128
+    block_k: tl.constexpr = 64
+    a = tle.gpu.alloc(
+        (block_m, block_k),
+        dtype=tl.float16,
+        layout=None,
+        nv_mma_shared_layout=False,
+    )
+    b = tle.gpu.alloc(
+        (block_k, block_n),
+        dtype=tl.float16,
+        layout=None,
+        nv_mma_shared_layout=False,
+    )
+    a_full = tle.gpu.alloc_barrier(expect_bytes=block_m * block_k * 2)
+    b_full = tle.gpu.alloc_barrier(expect_bytes=block_k * block_n * 2)
+
+    tle.gpu.copy(a_desc, a, (block_m, block_k), (0, 0), barrier=a_full)
+    tle.gpu.copy(b_desc, b, (block_k, block_n), (0, 0), barrier=b_full)
+    tle.gpu.barrier_wait(a_full, phaseIdx=0)
+    tle.gpu.barrier_wait(b_full, phaseIdx=0)
+
+    acc = tle.gpu.wgmma(a, b, tl.zeros((block_m, block_n), dtype=tl.float32))
+    acc = tle.gpu.wgmma_wait(0, acc)
+    offsets = tl.arange(0, block_m)[:, None] * block_n + tl.arange(0, block_n)[None, :]
+    tl.store(out + offsets, acc)
+
+
+@triton.jit
+def _tle_sqmma_for_loop_runtime_kernel(a_desc, b_desc, out, k_tiles: tl.constexpr):
+    block_m: tl.constexpr = 128
+    block_n: tl.constexpr = 128
+    block_k: tl.constexpr = 64
+    a = tle.gpu.alloc(
+        (block_m, block_k),
+        dtype=tl.float16,
+        layout=None,
+        nv_mma_shared_layout=False,
+    )
+    b = tle.gpu.alloc(
+        (block_k, block_n),
+        dtype=tl.float16,
+        layout=None,
+        nv_mma_shared_layout=False,
+    )
+    a_full = tle.gpu.alloc_barrier(expect_bytes=block_m * block_k * 2)
+    b_full = tle.gpu.alloc_barrier(expect_bytes=block_k * block_n * 2)
+
+    acc = tl.zeros((block_m, block_n), dtype=tl.float32)
+    for k_iter in range(0, k_tiles):
+        k_offset = k_iter * block_k
+        tle.gpu.copy(a_desc, a, (block_m, block_k), (0, k_offset), barrier=a_full)
+        tle.gpu.copy(b_desc, b, (block_k, block_n), (k_offset, 0), barrier=b_full)
+        tle.gpu.barrier_wait(a_full, phaseIdx=k_iter)
+        tle.gpu.barrier_wait(b_full, phaseIdx=k_iter)
+        acc = tle.gpu.wgmma(a, b, acc)
+        acc = tle.gpu.wgmma_wait(0, acc)
+
+    offsets = tl.arange(0, block_m)[:, None] * block_n + tl.arange(0, block_n)[None, :]
+    tl.store(out + offsets, acc)
+
+
+@triton.jit
+def _tle_sqmma_dtype_runtime_kernel(
+    a_desc,
+    b_desc,
+    out,
+    input_bytes: tl.constexpr,
+):
+    block_m: tl.constexpr = 128
+    block_n: tl.constexpr = 128
+    block_k: tl.constexpr = 64
+    if input_bytes == 1:
+        a = tle.gpu.alloc(
+            (block_m, block_k),
+            dtype=tl.float8e4nv,
+            layout=None,
+            nv_mma_shared_layout=False,
+        )
+        b = tle.gpu.alloc(
+            (block_k, block_n),
+            dtype=tl.float8e4nv,
+            layout=None,
+            nv_mma_shared_layout=False,
+        )
+    else:
+        a = tle.gpu.alloc(
+            (block_m, block_k),
+            dtype=tl.bfloat16,
+            layout=None,
+            nv_mma_shared_layout=False,
+        )
+        b = tle.gpu.alloc(
+            (block_k, block_n),
+            dtype=tl.bfloat16,
+            layout=None,
+            nv_mma_shared_layout=False,
+        )
+    a_full = tle.gpu.alloc_barrier(expect_bytes=block_m * block_k * input_bytes, )
+    b_full = tle.gpu.alloc_barrier(expect_bytes=block_k * block_n * input_bytes, )
+
+    tle.gpu.copy(a_desc, a, (block_m, block_k), (0, 0), barrier=a_full)
+    tle.gpu.copy(b_desc, b, (block_k, block_n), (0, 0), barrier=b_full)
+    tle.gpu.barrier_wait(a_full, phaseIdx=0)
+    tle.gpu.barrier_wait(b_full, phaseIdx=0)
+    acc = tle.gpu.wgmma(a, b, tl.zeros((block_m, block_n), dtype=tl.float32))
+    acc = tle.gpu.wgmma_wait(0, acc)
+    offsets = tl.arange(0, block_m)[:, None] * block_n + tl.arange(0, block_n)[None, :]
+    tl.store(out + offsets, acc)
+
+
+@triton.jit
+def _tle_sqmma_all_shapes_runtime_kernel(
+    a_desc,
+    b_desc,
+    out,
+    block_m: tl.constexpr,
+    block_n: tl.constexpr,
+    block_k: tl.constexpr,
+    dtype_kind: tl.constexpr,
+    input_bytes: tl.constexpr,
+):
+    if dtype_kind == 0:
+        a = tle.gpu.alloc(
+            (block_m, block_k),
+            dtype=tl.float16,
+            layout=None,
+            nv_mma_shared_layout=False,
+        )
+        b = tle.gpu.alloc(
+            (block_k, block_n),
+            dtype=tl.float16,
+            layout=None,
+            nv_mma_shared_layout=False,
+        )
+    elif dtype_kind == 1:
+        a = tle.gpu.alloc(
+            (block_m, block_k),
+            dtype=tl.bfloat16,
+            layout=None,
+            nv_mma_shared_layout=False,
+        )
+        b = tle.gpu.alloc(
+            (block_k, block_n),
+            dtype=tl.bfloat16,
+            layout=None,
+            nv_mma_shared_layout=False,
+        )
+    else:
+        a = tle.gpu.alloc(
+            (block_m, block_k),
+            dtype=tl.float8e4nv,
+            layout=None,
+            nv_mma_shared_layout=False,
+        )
+        b = tle.gpu.alloc(
+            (block_k, block_n),
+            dtype=tl.float8e4nv,
+            layout=None,
+            nv_mma_shared_layout=False,
+        )
+
+    a_full = tle.gpu.alloc_barrier(expect_bytes=block_m * block_k * input_bytes, )
+    b_full = tle.gpu.alloc_barrier(expect_bytes=block_k * block_n * input_bytes, )
+    tle.gpu.copy(a_desc, a, (block_m, block_k), (0, 0), barrier=a_full)
+    tle.gpu.copy(b_desc, b, (block_k, block_n), (0, 0), barrier=b_full)
+    tle.gpu.barrier_wait(a_full, phaseIdx=0)
+    tle.gpu.barrier_wait(b_full, phaseIdx=0)
+    acc = tle.gpu.wgmma(a, b, tl.zeros((block_m, block_n), dtype=tl.float32))
+    acc = tle.gpu.wgmma_wait(0, acc)
+    offsets = tl.arange(0, block_m)[:, None] * block_n + tl.arange(0, block_n)[None, :]
+    tl.store(out + offsets, acc)
+
+
+def test_mthreads_tle_sqmma_ttir_uses_backend_local_names():
+    ttir = compile_to_ttir(_tle_sqmma_kernel, {"out": "*fp32"})
+    assert "musa_tle.sqmma" in ttir, ttir
+    assert "musa_tle.sqmma_wait" in ttir, ttir
+    assert "musa_tle.wgmma" not in ttir, ttir
+    assert ttir.count("musa_tle.auto_shared_layout") == 2, ttir
+
+
+def test_mthreads_tle_sqmma_rejects_nonzero_pending_groups():
+    with pytest.raises(CompilationError, match="requires pendings=0"):
+        compile_to_ttir(_tle_sqmma_nonzero_wait_kernel, {"out": "*fp32"})
+
+
+def test_mthreads_tle_sqmma_lowers_to_parameterless_wait():
+    compiled = compile_musa(_tle_sqmma_kernel, {"out": "*fp32"})
+    ttgir = compiled.asm["ttgir"]
+    llir = compiled.asm["llir"]
+    assert "musa_tle.sqmma" not in ttgir, ttgir
+    assert "ttmg.squad_dot" in ttgir, ttgir
+    assert ttgir.count("ttmg.squad_dot_wait") == 1, ttgir
+    assert "ttg.local_load" not in ttgir, ttgir
+    assert "llvm.musa.sqmma" in llir, llir
+    assert "call void @llvm.musa.sqmma.wait()" in llir, llir
+
+
+def test_mthreads_tle_sqmma_runtime_precision():
+    import torch
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        pytest.skip("MUSA device is not available")
+
+    torch.manual_seed(1234)
+    a_cpu = torch.randn((128, 64), dtype=torch.float16)
+    b_cpu = torch.randn((64, 128), dtype=torch.float16)
+    a = a_cpu.to("musa")
+    b = b_cpu.to("musa")
+    out = torch.empty((128, 128), device="musa", dtype=torch.float32)
+    a_desc = TensorDescriptor.from_tensor(a, block_shape=[128, 64])
+    b_desc = TensorDescriptor.from_tensor(b, block_shape=[64, 128])
+
+    kernel = _tle_sqmma_runtime_kernel[(1, )](a_desc, b_desc, out, num_warps=4, num_stages=1)
+    torch.musa.synchronize()
+
+    expected = torch.matmul(a_cpu.float(), b_cpu.float())
+    torch.testing.assert_close(out.cpu(), expected, atol=5e-2, rtol=5e-2)
+    assert "llvm.musa.tme.ld.tile.2d" in kernel.asm["llir"]
+    assert "llvm.musa.sqmma" in kernel.asm["llir"]
+    assert "call void @llvm.musa.sqmma.wait()" in kernel.asm["llir"]
+
+
+def test_mthreads_tle_sqmma_for_loop_runtime_precision():
+    import torch
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        pytest.skip("MUSA device is not available")
+
+    torch.manual_seed(1234)
+    a_cpu = torch.randn((128, 128), dtype=torch.float16)
+    b_cpu = torch.randn((128, 128), dtype=torch.float16)
+    a = a_cpu.to("musa")
+    b = b_cpu.to("musa")
+    out = torch.empty((128, 128), device="musa", dtype=torch.float32)
+    a_desc = TensorDescriptor.from_tensor(a, block_shape=[128, 64])
+    b_desc = TensorDescriptor.from_tensor(b, block_shape=[64, 128])
+
+    kernel = _tle_sqmma_for_loop_runtime_kernel[(1, )](
+        a_desc,
+        b_desc,
+        out,
+        2,
+        num_warps=4,
+        num_stages=1,
+    )
+    torch.musa.synchronize()
+
+    expected = torch.matmul(a_cpu.float(), b_cpu.float())
+    torch.testing.assert_close(out.cpu(), expected, atol=7e-2, rtol=5e-2)
+    assert "scf.for" in kernel.asm["ttgir"]
+    assert "llvm.musa.tme.ld.tile.2d" in kernel.asm["llir"]
+    assert "llvm.musa.sqmma" in kernel.asm["llir"]
+    assert "call void @llvm.musa.sqmma.wait()" in kernel.asm["llir"]
+
+
+@pytest.mark.parametrize(
+    "torch_dtype_name,input_bytes,intrinsic_tag,atol,rtol",
+    [
+        ("bfloat16", 2, "bfmma", 1.5e-1, 5e-2),
+        ("float8_e4m3fn", 1, "e4m3", 2.5e-1, 1e-1),
+    ],
+)
+def test_mthreads_tle_sqmma_dtype_runtime_precision(
+    torch_dtype_name,
+    input_bytes,
+    intrinsic_tag,
+    atol,
+    rtol,
+):
+    import torch
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        pytest.skip("MUSA device is not available")
+
+    torch.manual_seed(1234)
+    torch_dtype = getattr(torch, torch_dtype_name)
+    scale = 0.5 if input_bytes == 1 else 1.0
+    a_cpu = (torch.randn((128, 64), dtype=torch.float32) * scale).to(torch_dtype)
+    b_cpu = (torch.randn((64, 128), dtype=torch.float32) * scale).to(torch_dtype)
+    a = a_cpu.to("musa")
+    b = b_cpu.to("musa")
+    out = torch.empty((128, 128), device="musa", dtype=torch.float32)
+    a_desc = TensorDescriptor.from_tensor(a, block_shape=[128, 64])
+    b_desc = TensorDescriptor.from_tensor(b, block_shape=[64, 128])
+
+    kernel = _tle_sqmma_dtype_runtime_kernel[(1, )](
+        a_desc,
+        b_desc,
+        out,
+        input_bytes,
+        num_warps=4,
+        num_stages=1,
+    )
+    torch.musa.synchronize()
+
+    expected = torch.matmul(a_cpu.float(), b_cpu.float())
+    torch.testing.assert_close(out.cpu(), expected, atol=atol, rtol=rtol)
+    assert "llvm.musa.tme.ld.tile.2d" in kernel.asm["llir"]
+    assert f"llvm.musa.sqmma.{intrinsic_tag}" in kernel.asm["llir"]
+    assert "call void @llvm.musa.sqmma.wait()" in kernel.asm["llir"]
+
+
+@pytest.mark.parametrize(
+    "torch_dtype_name,dtype_kind,input_bytes,intrinsic_tag,m,n,k,scale,atol,rtol",
+    _SQMMA_SHAPE_CASES,
+)
+def test_mthreads_tle_sqmma_all_supported_shapes_runtime(
+    torch_dtype_name,
+    dtype_kind,
+    input_bytes,
+    intrinsic_tag,
+    m,
+    n,
+    k,
+    scale,
+    atol,
+    rtol,
+):
+    import torch
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        pytest.skip("MUSA device is not available")
+
+    torch.manual_seed(1234)
+    torch_dtype = getattr(torch, torch_dtype_name)
+    a_cpu = (torch.randn((m, k), dtype=torch.float32) * scale).to(torch_dtype)
+    b_cpu = (torch.randn((k, n), dtype=torch.float32) * scale).to(torch_dtype)
+    a = a_cpu.to("musa")
+    b = b_cpu.to("musa")
+    out = torch.empty((m, n), device="musa", dtype=torch.float32)
+    a_desc = TensorDescriptor.from_tensor(a, block_shape=[m, k])
+    b_desc = TensorDescriptor.from_tensor(b, block_shape=[k, n])
+
+    kernel = _tle_sqmma_all_shapes_runtime_kernel[(1, )](
+        a_desc,
+        b_desc,
+        out,
+        m,
+        n,
+        k,
+        dtype_kind,
+        input_bytes,
+        num_warps=4,
+        num_stages=1,
+    )
+    torch.musa.synchronize()
+
+    expected = torch.matmul(a_cpu.float(), b_cpu.float())
+    torch.testing.assert_close(out.cpu(), expected, atol=atol, rtol=rtol)
+    intrinsic = f"llvm.musa.sqmma.{intrinsic_tag}.m{m}n{n}k{k}.mma"
+    assert intrinsic in kernel.asm["llir"]
+    assert "call void @llvm.musa.sqmma.wait()" in kernel.asm["llir"]
+
+
+def test_mthreads_tle_sqmma_macro_tile_auto_decomposition_runtime():
+    import torch
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        pytest.skip("MUSA device is not available")
+
+    m, n, k = 256, 256, 64
+    torch.manual_seed(5256)
+    a_cpu = torch.randn((m, k), dtype=torch.float16)
+    b_cpu = torch.randn((k, n), dtype=torch.float16)
+    a = a_cpu.to("musa")
+    b = b_cpu.to("musa")
+    out = torch.empty((m, n), device="musa", dtype=torch.float32)
+    a_desc = TensorDescriptor.from_tensor(a, block_shape=[m, k])
+    b_desc = TensorDescriptor.from_tensor(b, block_shape=[k, n])
+
+    kernel = _tle_sqmma_all_shapes_runtime_kernel[(1, )](
+        a_desc,
+        b_desc,
+        out,
+        m,
+        n,
+        k,
+        0,
+        2,
+        num_warps=16,
+        num_stages=1,
+    )
+    torch.musa.synchronize()
+
+    expected = torch.matmul(a_cpu.float(), b_cpu.float())
+    torch.testing.assert_close(out.cpu(), expected, atol=1.0e-1, rtol=5.0e-2)
+
+    ttir = kernel.asm["ttir"]
+    ttgir = kernel.asm["ttgir"]
+    llir = kernel.asm["llir"]
+    assert ttir.count("musa_tle.sqmma ") == 1
+    assert ttir.count("musa_tle.sqmma_wait ") == 1
+    assert "warpsPerCTA = [8, 2]" in ttgir
+    assert "instrShape = [128, 128, 64]" in ttgir
+    assert ttgir.count("ttmg.squad_dot ") == 1
+    intrinsic = "llvm.musa.sqmma.fmma.m128n128k64.mma"
+    assert llir.count(f"@{intrinsic}(") == 2  # One call plus one declaration.
+    assert "call void @llvm.musa.sqmma.wait()" in llir

--- a/third_party/mthreads/python/test/unit/tle/test_tle_sqmma.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_sqmma.py
@@ -49,8 +49,8 @@ _SQMMA_SHAPE_CASES = tuple(
 
 @triton.jit
 def _tle_sqmma_kernel(out):
-    a = tle.gpu.alloc((128, 64), dtype=tl.float16, layout=None, nv_mma_shared_layout=False)
-    b = tle.gpu.alloc((64, 128), dtype=tl.float16, layout=None, nv_mma_shared_layout=False)
+    a = tle.gpu.alloc((128, 64), dtype=tl.float16, layout=None)
+    b = tle.gpu.alloc((64, 128), dtype=tl.float16, layout=None)
     acc = tl.zeros((128, 128), dtype=tl.float32)
     acc = tle.gpu.wgmma(a, b, acc)
     acc = tle.gpu.wgmma_wait(0, acc)
@@ -60,10 +60,20 @@ def _tle_sqmma_kernel(out):
 
 @triton.jit
 def _tle_sqmma_nonzero_wait_kernel(out):
-    a = tle.gpu.alloc((128, 64), dtype=tl.float16, layout=None, nv_mma_shared_layout=False)
-    b = tle.gpu.alloc((64, 128), dtype=tl.float16, layout=None, nv_mma_shared_layout=False)
+    a = tle.gpu.alloc((128, 64), dtype=tl.float16, layout=None)
+    b = tle.gpu.alloc((64, 128), dtype=tl.float16, layout=None)
     acc = tle.gpu.wgmma(a, b, tl.zeros((128, 128), dtype=tl.float32))
     acc = tle.gpu.wgmma_wait(1, acc)
+    offsets = tl.arange(0, 128)[:, None] * 128 + tl.arange(0, 128)[None, :]
+    tl.store(out + offsets, acc)
+
+
+@triton.jit
+def _tle_sqmma_non_auto_layout_kernel(out):
+    a = tle.gpu.alloc((128, 64), dtype=tl.float16, layout=None, nv_mma_shared_layout=False)
+    b = tle.gpu.alloc((64, 128), dtype=tl.float16, layout=None)
+    acc = tle.gpu.wgmma(a, b, tl.zeros((128, 128), dtype=tl.float32))
+    acc = tle.gpu.wgmma_wait(0, acc)
     offsets = tl.arange(0, 128)[:, None] * 128 + tl.arange(0, 128)[None, :]
     tl.store(out + offsets, acc)
 
@@ -77,13 +87,13 @@ def _tle_sqmma_runtime_kernel(a_desc, b_desc, out):
         (block_m, block_k),
         dtype=tl.float16,
         layout=None,
-        nv_mma_shared_layout=False,
+        nv_mma_shared_layout=True,
     )
     b = tle.gpu.alloc(
         (block_k, block_n),
         dtype=tl.float16,
         layout=None,
-        nv_mma_shared_layout=False,
+        nv_mma_shared_layout=True,
     )
     a_full = tle.gpu.alloc_barrier(expect_bytes=block_m * block_k * 2)
     b_full = tle.gpu.alloc_barrier(expect_bytes=block_k * block_n * 2)
@@ -108,13 +118,13 @@ def _tle_sqmma_for_loop_runtime_kernel(a_desc, b_desc, out, k_tiles: tl.constexp
         (block_m, block_k),
         dtype=tl.float16,
         layout=None,
-        nv_mma_shared_layout=False,
+        nv_mma_shared_layout=True,
     )
     b = tle.gpu.alloc(
         (block_k, block_n),
         dtype=tl.float16,
         layout=None,
-        nv_mma_shared_layout=False,
+        nv_mma_shared_layout=True,
     )
     a_full = tle.gpu.alloc_barrier(expect_bytes=block_m * block_k * 2)
     b_full = tle.gpu.alloc_barrier(expect_bytes=block_k * block_n * 2)
@@ -148,26 +158,26 @@ def _tle_sqmma_dtype_runtime_kernel(
             (block_m, block_k),
             dtype=tl.float8e4nv,
             layout=None,
-            nv_mma_shared_layout=False,
+            nv_mma_shared_layout=True,
         )
         b = tle.gpu.alloc(
             (block_k, block_n),
             dtype=tl.float8e4nv,
             layout=None,
-            nv_mma_shared_layout=False,
+            nv_mma_shared_layout=True,
         )
     else:
         a = tle.gpu.alloc(
             (block_m, block_k),
             dtype=tl.bfloat16,
             layout=None,
-            nv_mma_shared_layout=False,
+            nv_mma_shared_layout=True,
         )
         b = tle.gpu.alloc(
             (block_k, block_n),
             dtype=tl.bfloat16,
             layout=None,
-            nv_mma_shared_layout=False,
+            nv_mma_shared_layout=True,
         )
     a_full = tle.gpu.alloc_barrier(expect_bytes=block_m * block_k * input_bytes, )
     b_full = tle.gpu.alloc_barrier(expect_bytes=block_k * block_n * input_bytes, )
@@ -198,39 +208,39 @@ def _tle_sqmma_all_shapes_runtime_kernel(
             (block_m, block_k),
             dtype=tl.float16,
             layout=None,
-            nv_mma_shared_layout=False,
+            nv_mma_shared_layout=True,
         )
         b = tle.gpu.alloc(
             (block_k, block_n),
             dtype=tl.float16,
             layout=None,
-            nv_mma_shared_layout=False,
+            nv_mma_shared_layout=True,
         )
     elif dtype_kind == 1:
         a = tle.gpu.alloc(
             (block_m, block_k),
             dtype=tl.bfloat16,
             layout=None,
-            nv_mma_shared_layout=False,
+            nv_mma_shared_layout=True,
         )
         b = tle.gpu.alloc(
             (block_k, block_n),
             dtype=tl.bfloat16,
             layout=None,
-            nv_mma_shared_layout=False,
+            nv_mma_shared_layout=True,
         )
     else:
         a = tle.gpu.alloc(
             (block_m, block_k),
             dtype=tl.float8e4nv,
             layout=None,
-            nv_mma_shared_layout=False,
+            nv_mma_shared_layout=True,
         )
         b = tle.gpu.alloc(
             (block_k, block_n),
             dtype=tl.float8e4nv,
             layout=None,
-            nv_mma_shared_layout=False,
+            nv_mma_shared_layout=True,
         )
 
     a_full = tle.gpu.alloc_barrier(expect_bytes=block_m * block_k * input_bytes, )
@@ -256,6 +266,13 @@ def test_mthreads_tle_sqmma_ttir_uses_backend_local_names():
 def test_mthreads_tle_sqmma_rejects_nonzero_pending_groups():
     with pytest.raises(CompilationError, match="requires pendings=0"):
         compile_to_ttir(_tle_sqmma_nonzero_wait_kernel, {"out": "*fp32"})
+
+
+def test_mthreads_tle_sqmma_requires_auto_shared_layout(capfd):
+    with pytest.raises(RuntimeError, match="PassManager::run failed"):
+        compile_musa(_tle_sqmma_non_auto_layout_kernel, {"out": "*fp32"})
+    captured = capfd.readouterr()
+    assert "requires layout=None and nv_mma_shared_layout=True" in captured.err
 
 
 def test_mthreads_tle_sqmma_lowers_to_parameterless_wait():

--- a/third_party/mthreads/python/test/unit/tle/test_tle_tme_transactions.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_tme_transactions.py
@@ -1,0 +1,190 @@
+"""Compile-only coverage for mthreads TLE TME completion transactions."""
+
+import re
+
+import pytest
+import triton
+import triton.language as tl
+import triton.experimental.tle.language as tle
+from triton._C import libtriton
+from triton._C.libtriton import ir, passes
+from triton.backends.compiler import Language
+from triton.compiler import ASTSource
+
+from test_tle_utils import mthreads_backend, require_mthreads_libtriton
+
+require_mthreads_libtriton()
+
+
+@triton.jit
+def _completion_transaction_kernel(
+    desc,
+    dynamic_k,
+    STAGES: tl.constexpr,
+    SLOT: tl.constexpr,
+):
+    smem = tle.gpu.alloc(
+        (STAGES, 256, 64),
+        dtype=tl.float16,
+        nv_mma_shared_layout=False,
+    )
+    full = tle.gpu.alloc_barriers(STAGES, expect_bytes=32768)
+    tle.gpu.copy(
+        desc,
+        smem.slot(SLOT),
+        (256, 64),
+        (0, dynamic_k),
+        barrier=full[SLOT],
+    )
+
+
+def _compile_transaction_module(stages=1, slot=0):
+    target, backend = mthreads_backend()
+    options = backend.parse_options({"num_warps": 4, "num_stages": 1})
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+
+    src = ASTSource(
+        fn=_completion_transaction_kernel,
+        signature={
+            "desc": "tensordesc<fp16[256, 64]>",
+            "dynamic_k": "i32",
+            "STAGES": "constexpr",
+            "SLOT": "constexpr",
+        },
+        constexprs={"STAGES": stages, "SLOT": slot},
+    )
+    module = src.make_ir(
+        target,
+        options,
+        backend.get_codegen_implementation(options),
+        backend.get_module_map(),
+        context,
+    )
+    compiler_stages = {}
+    backend.add_stages(compiler_stages, options, Language.TRITON)
+    metadata = {}
+    module = compiler_stages["ttir"](module, metadata)
+    module = compiler_stages["ttgir"](module, metadata)
+    return backend, context, module
+
+
+def _lower_to_llvm_dialect(module, context):
+    pm = ir.pass_manager(context)
+    passes.convert.add_scf_to_cf(pm)
+    passes.convert.add_index_to_llvmir(pm)
+    libtriton.mthreads.passes.ttgpuir.add_allocate_shared_memory(pm, 31)
+    libtriton.mthreads.passes.ttgpuir.add_mtgpu_to_llvm(pm, 31)
+    libtriton.mthreads.passes.ttgpuir.add_to_llvmir(pm, 31)
+    passes.common.add_canonicalizer(pm)
+    passes.common.add_cse(pm)
+    passes.convert.add_cf_to_llvmir(pm)
+    passes.convert.add_arith_to_llvmir(pm)
+    passes.common.add_canonicalizer(pm)
+    passes.common.add_cse(pm)
+    pm.run(module, "lower_tle_tme_transaction_to_llvm")
+    return module.str_nodebug()
+
+
+@pytest.mark.parametrize("stages,slot", [(1, 0), (2, 0), (2, 1)])
+def test_mthreads_tle_completion_transaction_is_single_and_idempotent(stages, slot):
+    _, context, module = _compile_transaction_module(stages, slot)
+    ttgir = module.str_nodebug()
+
+    assert ttgir.count("ttmg.barrier_add_trans") == 1, ttgir
+    assert ttgir.count("ttmg.async_tme_copy_global_to_local") == 1, ttgir
+    assert ttgir.count("ttmg.arrive_barrier_noret") == 1, ttgir
+    assert ttgir.count("musa.tme.explicit_completion") == 3, ttgir
+    assert ttgir.count("musa.tme.issue_thread = 0 : i32") == 3, ttgir
+    assert "musa_tle.expect_bytes" not in ttgir, ttgir
+    assert "ttmg.wait_barrier" not in ttgir, ttgir
+
+    add_pos = ttgir.index("ttmg.barrier_add_trans")
+    copy_pos = ttgir.index("ttmg.async_tme_copy_global_to_local")
+    arrive_pos = ttgir.index("ttmg.arrive_barrier_noret")
+    assert add_pos < copy_pos < arrive_pos, ttgir
+    add_barrier, byte_value = re.search(r"ttmg\.barrier_add_trans\s+(%[-\w.]+),\s*(%[-\w.]+)", ttgir).groups()
+    copy_barrier = re.search(r"ttmg\.async_tme_copy_global_to_local\s+[^\n]*\],\s*(%[-\w.]+)", ttgir).group(1)
+    arrive_barrier = re.search(r"ttmg\.arrive_barrier_noret\s+(%[-\w.]+)", ttgir).group(1)
+    constants = {
+        name: int(value)
+        for name, value in re.findall(r"(%[-\w.]+)\s*=\s*arith\.constant\s+(-?\d+)\s*:\s*i32", ttgir)
+    }
+    assert add_barrier == copy_barrier == arrive_barrier, ttgir
+    assert constants[byte_value] == 32768, ttgir
+
+    pm = ir.pass_manager(context)
+    libtriton.mthreads.passes.ttgpuir.add_tle_lower_tme_transactions(pm)
+    pm.run(module, "rerun_tle_tme_transaction_lowering")
+    rerun = module.str_nodebug()
+    assert rerun.count("ttmg.barrier_add_trans") == 1, rerun
+    assert rerun.count("ttmg.arrive_barrier_noret") == 1, rerun
+
+
+def test_mthreads_tle_explicit_completion_uses_raw_issue_thread_without_barrier0(tmp_path):
+    backend, _, module = _compile_transaction_module()
+    fixture = module.str_nodebug().replace(
+        "musa.tme.issue_thread = 0 : i32",
+        "musa.tme.issue_thread = 512 : i32",
+    )
+    fixture_path = tmp_path / "raw_issue_thread_512.ttgir"
+    fixture_path.write_text(fixture)
+
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    reparsed = ir.parse_mlir_module(str(fixture_path), context)
+    llir = _lower_to_llvm_dialect(reparsed, context)
+
+    assert "llvm.musa.barrier0" not in llir, llir
+    assert llir.count('llvm.call_intrinsic "llvm.musa.async.add.trans"') == 1, llir
+    assert llir.count('llvm.call_intrinsic "llvm.musa.tme.ld.tile.2d"') == 1, llir
+    assert llir.count('llvm.call_intrinsic "llvm.musa.async.arrive.none.phaseid"') == 1, llir
+    issue_constant = re.search(r"(%\d+) = llvm\.mlir\.constant\(512 : i32\) : i32", llir).group(1)
+    assert len(re.findall(rf'llvm\.icmp "eq" %\d+, {re.escape(issue_constant)} : i32', llir)) == 3, llir
+    assert (llir.index("llvm.musa.async.add.trans") < llir.index("llvm.musa.tme.ld.tile.2d") <
+            llir.index("llvm.musa.async.arrive.none.phaseid")), llir
+
+
+def test_mthreads_tle_completion_copy_rejects_consumer_partition(tmp_path, capfd):
+    fixture = """#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 16 : i32,
+    ttg.target = "musa:ph1", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @copy_in_consumer(%desc: !tt.tensordesc<tensor<256x64xf16, #shared>>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    %smem = ttg.local_alloc : () -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+    ttg.warp_specialize() attributes {requestedRegisters = array<i32: 24>}
+    default {
+      ttmg.async_tme_copy_global_to_local %desc[%c0, %c0], %c1, %smem, %true {
+        blockShape = array<i32: 256, 64>, cachePolicy = 0 : i32,
+        innerPersistence = 2 : i32, musa_tle.expect_bytes = 32768 : i32,
+        outerPersistence = 2 : i32, prefetchSize = 0 : i32,
+        swizzleGranularity = 0 : i32, swizzleLine = 1 : i32,
+        swizzleStride = 3 : i32
+      } : !tt.tensordesc<tensor<256x64xf16, #shared>>, !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}
+"""
+    fixture_path = tmp_path / "completion_copy_in_consumer.ttgir"
+    fixture_path.write_text(fixture)
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    module = ir.parse_mlir_module(str(fixture_path), context)
+    pm = ir.pass_manager(context)
+    libtriton.mthreads.passes.ttgpuir.add_tle_lower_tme_transactions(pm)
+    with pytest.raises(RuntimeError, match="PassManager::run failed"):
+        pm.run(module, "reject_completion_copy_in_consumer")
+    assert ("mthreads TLE completion TME copy must be in the producer partition" in capfd.readouterr().err)

--- a/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize.py
@@ -1,8 +1,9 @@
-"""Compile-only coverage for the mthreads TLE warp-specialize container."""
+"""Compile and runtime coverage for the mthreads TLE warp-specialize container."""
 
 import re
 
 import pytest
+import torch
 import triton
 import triton.language as tl
 import triton.experimental.tle.language as tle
@@ -56,6 +57,15 @@ def _ws_simple_default(out):
 @triton.jit
 def _ws_simple_worker(out):
     tl.store(out + 1, 2)
+
+
+@triton.jit
+def _ws_simple_kernel(out):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), (_ws_simple_worker, (out, ))],
+        worker_num_warps=[4],
+        worker_num_regs=[24],
+    )
 
 
 @triton.jit
@@ -131,6 +141,25 @@ def _ws_non_power_of_two_warps_kernel(out):
 
 
 @triton.jit
+def _ws_two_producer_warps_kernel(out):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), (_ws_simple_worker, (out, ))],
+        worker_num_warps=[2],
+        worker_num_regs=[24],
+    )
+
+
+@triton.jit
+def _ws_non_terminal_kernel(out):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), (_ws_simple_worker, (out, ))],
+        worker_num_warps=[4],
+        worker_num_regs=[24],
+    )
+    tl.store(out + 2, 3)
+
+
+@triton.jit
 def _ws_warp_count_mismatch_kernel(out):
     tle.gpu.warp_specialize(
         [(_ws_simple_default, (out, )), (_ws_simple_worker, (out, ))],
@@ -189,9 +218,15 @@ def _ws_constexpr_tuple_config_kernel(out, WORKER_WARPS: tl.constexpr, WORKER_RE
     )
 
 
-def _compile_ws_ir(fn=_ws_container_kernel, signature=None, constexprs=None):
+def _compile_ws_ir(
+    fn=_ws_container_kernel,
+    signature=None,
+    constexprs=None,
+    consumer_warps=16,
+    include_late=False,
+):
     target, backend = mthreads_backend()
-    options = backend.parse_options({"num_warps": 16, "num_stages": 1})
+    options = backend.parse_options({"num_warps": consumer_warps, "num_stages": 1})
     context = ir.context()
     ir.load_dialects(context)
     backend.load_dialects(context)
@@ -215,6 +250,16 @@ def _compile_ws_ir(fn=_ws_container_kernel, signature=None, constexprs=None):
     ttir = module.str_nodebug()
     module = stages["ttgir"](module, metadata)
     ttgir = module.str_nodebug()
+    if include_late:
+        pm = ir.pass_manager(context)
+        libtriton.passes.convert.add_scf_to_cf(pm)
+        libtriton.passes.convert.add_index_to_llvmir(pm)
+        libtriton.mthreads.passes.ttgpuir.add_allocate_shared_memory(pm, 31)
+        libtriton.mthreads.passes.ttgpuir.add_mtgpu_to_llvm(pm, 31)
+        libtriton.mthreads.passes.ttgpuir.add_to_llvmir(pm, 31)
+        libtriton.mthreads.passes.ttgpuir.add_tle_lower_warp_specialize(pm)
+        pm.run(module, "lower_static_ws_to_llvm_cfg")
+        return ttir, ttgir, module.str_nodebug()
     return ttir, ttgir
 
 
@@ -238,13 +283,13 @@ def _split_top_level(text):
     return values
 
 
-def _assert_ws_container(ir_text):
+def _assert_ws_container(ir_text, producer_warps=4):
     assert ir_text.count("ttg.warp_specialize") == 1, ir_text
     assert ir_text.count("ttg.warp_yield") == 1, ir_text
     assert ir_text.count("ttg.warp_return") == 1, ir_text
     assert "partition0" in ir_text, ir_text
     assert "partition1" not in ir_text, ir_text
-    assert "num_warps(4)" in ir_text, ir_text
+    assert f"num_warps({producer_warps})" in ir_text, ir_text
     assert re.search(r"requestedRegisters\s*=\s*array<i32:\s*24>", ir_text), ir_text
     assert "actualRegisters" not in ir_text, ir_text
     assert "ttg.maxnreg" not in ir_text, ir_text
@@ -253,7 +298,7 @@ def _assert_ws_container(ir_text):
 
     ws_match = re.search(
         r"ttg\.warp_specialize\((?P<captures>[^)]*)\).*?"
-        r"partition0\((?P<args>[^)]*)\)\s*num_warps\(4\).*?"
+        rf"partition0\((?P<args>[^)]*)\)\s*num_warps\({producer_warps}\).*?"
         r":\s*\((?P<types>[^)]*)\)\s*->\s*\(\)",
         ir_text,
         re.DOTALL,
@@ -281,10 +326,88 @@ def _assert_ws_container(ir_text):
     assert re.search(r"\)\s*->\s*\(\)\s*\n\s*tt\.return", ir_text), ir_text
 
 
+def _assert_prepared_ws_ttgir(ir_text, consumer_warps=16, producer_warps=4):
+    total_warps = consumer_warps + producer_warps
+    assert f'"ttg.total-num-warps" = {total_warps} : i32' in ir_text, ir_text
+    assert f"warpGroupStartIds = array<i32: {consumer_warps}>" in ir_text, ir_text
+    assert ir_text.count("ttg.warp_specialize") == 1, ir_text
+    assert ir_text.count("ttg.warp_yield") == 1, ir_text
+    assert ir_text.count("ttg.warp_return") == 1, ir_text
+    assert "musa_tle.static_warp_specialize" in ir_text, ir_text
+    assert "gpu.thread_id" not in ir_text, ir_text
+    assert "musa_tle.static_ws.split" not in ir_text, ir_text
+    assert "musa_tle.static_ws.role" not in ir_text, ir_text
+    assert "musa_tle.static_ws.num_warps" not in ir_text, ir_text
+    assert "musa_tle.static_ws.thread_offset" not in ir_text, ir_text
+    assert "musa_tle.static_ws.split_candidate" not in ir_text, ir_text
+
+
+def _assert_static_ws_late_ir(ir_text, consumer_warps=16, producer_warps=4):
+    producer_begin = consumer_warps * 32
+    assert "ttg.warp_specialize" not in ir_text, ir_text
+    assert "ttg.warp_yield" not in ir_text, ir_text
+    assert "ttg.warp_return" not in ir_text, ir_text
+    assert "musa_tle.static_warp_specialize" not in ir_text, ir_text
+    dispatch = re.search(
+        rf'(?P<tid>%[-\w.]+) = llvm\.call_intrinsic '
+        rf'"llvm\.musa\.read\.ptx\.sreg\.tid\.x"\(\).*?'
+        rf'arith\.constant {producer_begin} : i32.*?'
+        rf'arith\.cmpi uge, (?P=tid),',
+        ir_text,
+        re.DOTALL,
+    )
+    assert dispatch, ir_text
+    assert re.search(rf"arith\.cmpi ult, {re.escape(dispatch.group('tid'))},", ir_text), ir_text
+    assert ir_text.count("arith.cmpi uge") == 1, ir_text
+    assert ir_text.count("arith.cmpi ult") == 1, ir_text
+    assert ir_text.count("cf.cond_br") == 2, ir_text
+    assert re.search(rf"arith\.constant {producer_begin} : i32", ir_text), ir_text
+    assert ir_text.index("arith.cmpi uge") < ir_text.index("arith.cmpi ult"), ir_text
+    assert "llvm.switch" not in ir_text, ir_text
+    assert "musa_tle.static_ws." not in ir_text, ir_text
+    assert "builtin.unrealized_conversion_cast" not in ir_text, ir_text
+
+
 def test_tle_warp_specialize_mthreads_container_contract():
-    ttir, ttgir = _compile_ws_ir()
+    ttir, ttgir, late_ir = _compile_ws_ir(include_late=True)
     _assert_ws_container(ttir)
+    assert "musa_tle.static_warp_specialize" in ttir, ttir
     _assert_ws_container(ttgir)
+    _assert_prepared_ws_ttgir(ttgir)
+    _assert_static_ws_late_ir(late_ir)
+
+
+@pytest.mark.parametrize(
+    "consumer_warps,producer_warps",
+    [(4, 4), (16, 1), (16, 2), (16, 4), (16, 8)],
+    ids=["equal_4_4", "producer_1", "producer_2", "producer_4", "producer_8"],
+)
+def test_tle_warp_specialize_static_two_branch_runtime(consumer_warps, producer_warps):
+    out = torch.zeros((2, ), dtype=torch.int32, device="musa")
+    compiled = _ws_constexpr_tuple_config_kernel.warmup(
+        out,
+        WORKER_WARPS=producer_warps,
+        WORKER_REGS=24,
+        grid=(1, ),
+        num_warps=consumer_warps,
+        num_stages=1,
+    )
+    assert compiled.metadata.num_warps == consumer_warps + producer_warps
+    _assert_prepared_ws_ttgir(compiled.asm["ttgir"], consumer_warps, producer_warps)
+    assert "ttg.warp_specialize" not in compiled.asm["llir"]
+    assert f'!"maxntidx", i32 {(consumer_warps + producer_warps) * 32}' in compiled.asm["llir"]
+
+    for _ in range(2):
+        out.zero_()
+        _ws_constexpr_tuple_config_kernel[(1, )](
+            out,
+            WORKER_WARPS=producer_warps,
+            WORKER_REGS=24,
+            num_warps=consumer_warps,
+            num_stages=1,
+        )
+        torch.musa.synchronize()
+        torch.testing.assert_close(out.cpu(), torch.tensor([1, 2], dtype=torch.int32))
 
 
 def test_tle_warp_specialize_builder_bindings_are_available():
@@ -299,15 +422,33 @@ def test_tle_warp_specialize_builder_bindings_are_available():
     assert hasattr(libtriton.mthreads.ir, "WarpSpecializeOp")
 
 
-def test_tle_warp_specialize_accepts_constexpr_tuple_configuration():
-    ttir, ttgir = _compile_ws_ir(
+@pytest.mark.parametrize("producer_warps", [1, 2, 4, 8])
+def test_tle_warp_specialize_accepts_constexpr_tuple_configuration(producer_warps):
+    ttir, ttgir, late_ir = _compile_ws_ir(
         _ws_constexpr_tuple_config_kernel,
         {"out": "*i32", "WORKER_WARPS": "constexpr", "WORKER_REGS": "constexpr"},
-        {"WORKER_WARPS": 4, "WORKER_REGS": 24},
+        {"WORKER_WARPS": producer_warps, "WORKER_REGS": 24},
+        include_late=True,
     )
-    for ir_text in (ttir, ttgir):
-        assert "num_warps(4)" in ir_text, ir_text
-        assert re.search(r"requestedRegisters\s*=\s*array<i32:\s*24>", ir_text), ir_text
+    assert f"num_warps({producer_warps})" in ttir, ttir
+    assert re.search(r"requestedRegisters\s*=\s*array<i32:\s*24>", ttir), ttir
+    _assert_prepared_ws_ttgir(ttgir, producer_warps=producer_warps)
+    _assert_static_ws_late_ir(late_ir, producer_warps=producer_warps)
+
+
+@pytest.mark.parametrize(
+    "kernel,diagnostic",
+    [
+        (
+            _ws_non_terminal_kernel,
+            "mthreads TLE static warp_specialize must be the final operation before tt.return",
+        ),
+    ],
+)
+def test_tle_warp_specialize_lowering_rejects_unsupported_contract(capfd, kernel, diagnostic):
+    with pytest.raises(RuntimeError, match="PassManager::run failed"):
+        _compile_ws_ir(kernel, {"out": "*i32"}, constexprs={})
+    assert diagnostic in capfd.readouterr().err
 
 
 @pytest.mark.parametrize(

--- a/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize.py
@@ -2,6 +2,7 @@
 
 import re
 
+import pytest
 import triton
 import triton.language as tl
 import triton.experimental.tle.language as tle
@@ -9,6 +10,7 @@ from triton._C import libtriton
 from triton._C.libtriton import ir
 from triton.backends.compiler import Language
 from triton.compiler import ASTSource
+from triton.compiler.errors import CompilationError
 
 from test_tle_utils import mthreads_backend, require_mthreads_libtriton
 
@@ -46,7 +48,148 @@ def _ws_container_kernel(out, value, BIAS: tl.constexpr):
     )
 
 
-def _compile_ws_ir():
+@triton.jit
+def _ws_simple_default(out):
+    tl.store(out, 1)
+
+
+@triton.jit
+def _ws_simple_worker(out):
+    tl.store(out + 1, 2)
+
+
+@triton.jit
+def _ws_dynamic_warps_kernel(out, worker_warps):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), (_ws_simple_worker, (out, ))],
+        worker_num_warps=[worker_warps],
+        worker_num_regs=[24],
+    )
+
+
+@triton.jit
+def _ws_dynamic_regs_kernel(out, worker_regs):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), (_ws_simple_worker, (out, ))],
+        worker_num_warps=[4],
+        worker_num_regs=[worker_regs],
+    )
+
+
+@triton.jit
+def _ws_non_sequence_warps_kernel(out):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), (_ws_simple_worker, (out, ))],
+        worker_num_warps=4,
+        worker_num_regs=[24],
+    )
+
+
+@triton.jit
+def _ws_non_sequence_regs_kernel(out):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), (_ws_simple_worker, (out, ))],
+        worker_num_warps=[4],
+        worker_num_regs=24,
+    )
+
+
+@triton.jit
+def _ws_float_warps_kernel(out):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), (_ws_simple_worker, (out, ))],
+        worker_num_warps=[4.0],
+        worker_num_regs=[24],
+    )
+
+
+@triton.jit
+def _ws_float_regs_kernel(out):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), (_ws_simple_worker, (out, ))],
+        worker_num_warps=[4],
+        worker_num_regs=[24.0],
+    )
+
+
+@triton.jit
+def _ws_zero_warps_kernel(out):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), (_ws_simple_worker, (out, ))],
+        worker_num_warps=[0],
+        worker_num_regs=[24],
+    )
+
+
+@triton.jit
+def _ws_non_power_of_two_warps_kernel(out):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), (_ws_simple_worker, (out, ))],
+        worker_num_warps=[3],
+        worker_num_regs=[24],
+    )
+
+
+@triton.jit
+def _ws_warp_count_mismatch_kernel(out):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), (_ws_simple_worker, (out, ))],
+        worker_num_warps=[],
+        worker_num_regs=[24],
+    )
+
+
+@triton.jit
+def _ws_register_count_mismatch_kernel(out):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), (_ws_simple_worker, (out, ))],
+        worker_num_warps=[4],
+        worker_num_regs=[],
+    )
+
+
+@triton.jit
+def _ws_empty_functions_kernel(out):
+    tle.gpu.warp_specialize([], worker_num_warps=[], worker_num_regs=[])
+
+
+@triton.jit
+def _ws_invalid_entry_kernel(out):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), _ws_simple_worker],
+        worker_num_warps=[4],
+        worker_num_regs=[24],
+    )
+
+
+@triton.jit
+def _ws_invalid_args_kernel(out):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), (_ws_simple_worker, out)],
+        worker_num_warps=[4],
+        worker_num_regs=[24],
+    )
+
+
+@triton.jit
+def _ws_bool_warps_kernel(out):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), (_ws_simple_worker, (out, ))],
+        worker_num_warps=[True],
+        worker_num_regs=[24],
+    )
+
+
+@triton.jit
+def _ws_constexpr_tuple_config_kernel(out, WORKER_WARPS: tl.constexpr, WORKER_REGS: tl.constexpr):
+    tle.gpu.warp_specialize(
+        [(_ws_simple_default, (out, )), (_ws_simple_worker, (out, ))],
+        worker_num_warps=(WORKER_WARPS, ),
+        worker_num_regs=(WORKER_REGS, ),
+    )
+
+
+def _compile_ws_ir(fn=_ws_container_kernel, signature=None, constexprs=None):
     target, backend = mthreads_backend()
     options = backend.parse_options({"num_warps": 16, "num_stages": 1})
     context = ir.context()
@@ -54,9 +197,9 @@ def _compile_ws_ir():
     backend.load_dialects(context)
 
     src = ASTSource(
-        fn=_ws_container_kernel,
-        signature={"out": "*i32", "value": "i32"},
-        constexprs={"BIAS": 7},
+        fn=fn,
+        signature=signature or {"out": "*i32", "value": "i32"},
+        constexprs={"BIAS": 7} if constexprs is None else constexprs,
     )
     module = src.make_ir(
         target,
@@ -154,3 +297,164 @@ def test_tle_warp_specialize_builder_bindings_are_available():
     ):
         assert hasattr(builder, method)
     assert hasattr(libtriton.mthreads.ir, "WarpSpecializeOp")
+
+
+def test_tle_warp_specialize_accepts_constexpr_tuple_configuration():
+    ttir, ttgir = _compile_ws_ir(
+        _ws_constexpr_tuple_config_kernel,
+        {"out": "*i32", "WORKER_WARPS": "constexpr", "WORKER_REGS": "constexpr"},
+        {"WORKER_WARPS": 4, "WORKER_REGS": 24},
+    )
+    for ir_text in (ttir, ttgir):
+        assert "num_warps(4)" in ir_text, ir_text
+        assert re.search(r"requestedRegisters\s*=\s*array<i32:\s*24>", ir_text), ir_text
+
+
+@pytest.mark.parametrize(
+    "kernel,signature,diagnostic",
+    [
+        (
+            _ws_dynamic_warps_kernel,
+            {"out": "*i32", "worker_warps": "i32"},
+            r"mthreads TLE warp_specialize worker_num_warps\[0\] must be a compile-time integer",
+        ),
+        (
+            _ws_dynamic_regs_kernel,
+            {"out": "*i32", "worker_regs": "i32"},
+            r"mthreads TLE warp_specialize worker_num_regs\[0\] must be a compile-time integer",
+        ),
+        (
+            _ws_non_sequence_warps_kernel,
+            {"out": "*i32"},
+            "mthreads TLE warp_specialize worker_num_warps must be a static sequence",
+        ),
+        (
+            _ws_non_sequence_regs_kernel,
+            {"out": "*i32"},
+            "mthreads TLE warp_specialize worker_num_regs must be a static sequence",
+        ),
+        (
+            _ws_float_warps_kernel,
+            {"out": "*i32"},
+            r"mthreads TLE warp_specialize worker_num_warps\[0\] must be a compile-time integer",
+        ),
+        (
+            _ws_float_regs_kernel,
+            {"out": "*i32"},
+            r"mthreads TLE warp_specialize worker_num_regs\[0\] must be a compile-time integer",
+        ),
+        (
+            _ws_zero_warps_kernel,
+            {"out": "*i32"},
+            r"mthreads TLE warp_specialize worker_num_warps\[0\] must be positive",
+        ),
+        (
+            _ws_bool_warps_kernel,
+            {"out": "*i32"},
+            r"mthreads TLE warp_specialize worker_num_warps\[0\] must be a compile-time integer",
+        ),
+        (
+            _ws_warp_count_mismatch_kernel,
+            {"out": "*i32"},
+            "warp_specialize got 1 worker functions but 0 warp counts",
+        ),
+        (
+            _ws_register_count_mismatch_kernel,
+            {"out": "*i32"},
+            "warp_specialize got 1 worker functions but 0 register counts",
+        ),
+        (
+            _ws_empty_functions_kernel,
+            {"out": "*i32"},
+            "warp_specialize requires at least a default partition function",
+        ),
+        (
+            _ws_invalid_entry_kernel,
+            {"out": "*i32"},
+            "warp_specialize entry 1 must be a tuple",
+        ),
+        (
+            _ws_invalid_args_kernel,
+            {"out": "*i32"},
+            "warp_specialize entry 1 args must be a tuple",
+        ),
+    ],
+)
+def test_tle_warp_specialize_frontend_rejects_invalid_static_configuration(kernel, signature, diagnostic):
+    with pytest.raises(CompilationError, match=diagnostic):
+        _compile_ws_ir(kernel, signature, constexprs={})
+
+
+def test_tle_warp_specialize_dialect_rejects_non_power_of_two_warps(capfd):
+    with pytest.raises(RuntimeError, match="error encountered during parsing"):
+        _compile_ws_ir(_ws_non_power_of_two_warps_kernel, {"out": "*i32"}, constexprs={})
+    diagnostic = "'ttg.warp_specialize' op partition #0 number of warps (3) must be a power of 2"
+    assert diagnostic in capfd.readouterr().err
+
+
+_WS_INVALID_DIALECT_FIXTURES = [
+    (
+        """
+module attributes {"ttg.num-warps" = 16 : i32} {
+  tt.func @bad_partition_count() {
+    "ttg.warp_specialize"() ({
+      "ttg.warp_yield"() : () -> ()
+    }, {
+      "ttg.warp_specialize.partitions"() : () -> ()
+    }) {partitionNumWarps = array<i32: 4>} : () -> ()
+    tt.return
+  }
+}
+""",
+        "'ttg.warp_specialize' op has 0 partitions but `partitionNumWarps` has 1 elements",
+    ),
+    (
+        """
+module attributes {"ttg.num-warps" = 16 : i32} {
+  tt.func @bad_capture_count(%arg0: i32) {
+    ttg.warp_specialize(%arg0)
+    default {
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttg.warp_return
+    } : (i32) -> ()
+    tt.return
+  }
+}
+""",
+        "'ttg.warp_specialize.partitions' op partition region #0 has 0 arguments but expected 1",
+    ),
+    (
+        """
+module attributes {"ttg.num-warps" = 16 : i32} {
+  tt.func @bad_capture_type(%arg0: i32) {
+    ttg.warp_specialize(%arg0)
+    default {
+      ttg.warp_yield
+    }
+    partition0(%arg1: i64) num_warps(4) {
+      ttg.warp_return
+    } : (i32) -> ()
+    tt.return
+  }
+}
+""",
+        "'ttg.warp_specialize.partitions' op partition region #0 argument #0 has type 'i64' "
+        "but corresponding capture has type 'i32'",
+    ),
+]
+
+
+@pytest.mark.parametrize("fixture,diagnostic", _WS_INVALID_DIALECT_FIXTURES)
+def test_tle_warp_specialize_dialect_rejects_invalid_structure(tmp_path, capfd, fixture, diagnostic):
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    fixture_path = tmp_path / "invalid_ws_capture.mlir"
+    fixture_path.write_text(fixture)
+
+    with pytest.raises(RuntimeError):
+        ir.parse_mlir_module(str(fixture_path), context)
+    assert diagnostic in capfd.readouterr().err

--- a/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize.py
@@ -1,0 +1,156 @@
+"""Compile-only coverage for the mthreads TLE warp-specialize container."""
+
+import re
+
+import triton
+import triton.language as tl
+import triton.experimental.tle.language as tle
+from triton._C import libtriton
+from triton._C.libtriton import ir
+from triton.backends.compiler import Language
+from triton.compiler import ASTSource
+
+from test_tle_utils import mthreads_backend, require_mthreads_libtriton
+
+require_mthreads_libtriton()
+
+
+@triton.jit
+def _ws_default(out, value):
+    tl.store(out, value + 1)
+
+
+@triton.jit
+def _ws_worker(out, value, smem, duplicate_out, BIAS: tl.constexpr):
+    local = tle.gpu.local_ptr(smem, (0, ))
+    tl.store(local, value)
+    loaded = tl.load(local)
+    tl.store(out + 1, loaded + BIAS)
+    tl.store(duplicate_out + 2, loaded + BIAS + 1)
+
+
+@triton.jit
+def _ws_container_kernel(out, value, BIAS: tl.constexpr):
+    smem = tle.gpu.alloc(
+        (1, ),
+        dtype=tl.int32,
+        nv_mma_shared_layout=False,
+    )
+    tle.gpu.warp_specialize(
+        [
+            (_ws_default, (out, value)),
+            (_ws_worker, (out, value, smem, out, BIAS)),
+        ],
+        worker_num_warps=[4],
+        worker_num_regs=[24],
+    )
+
+
+def _compile_ws_ir():
+    target, backend = mthreads_backend()
+    options = backend.parse_options({"num_warps": 16, "num_stages": 1})
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+
+    src = ASTSource(
+        fn=_ws_container_kernel,
+        signature={"out": "*i32", "value": "i32"},
+        constexprs={"BIAS": 7},
+    )
+    module = src.make_ir(
+        target,
+        options,
+        backend.get_codegen_implementation(options),
+        backend.get_module_map(),
+        context,
+    )
+    stages = {}
+    backend.add_stages(stages, options, Language.TRITON)
+    metadata = {}
+    module = stages["ttir"](module, metadata)
+    ttir = module.str_nodebug()
+    module = stages["ttgir"](module, metadata)
+    ttgir = module.str_nodebug()
+    return ttir, ttgir
+
+
+def _split_top_level(text):
+    values = []
+    start = 0
+    depth = 0
+    pairs = {"<": ">", "[": "]", "{": "}"}
+    closing = set(pairs.values())
+    for index, char in enumerate(text):
+        if char in pairs:
+            depth += 1
+        elif char in closing:
+            depth -= 1
+        elif char == "," and depth == 0:
+            values.append(text[start:index].strip())
+            start = index + 1
+    tail = text[start:].strip()
+    if tail:
+        values.append(tail)
+    return values
+
+
+def _assert_ws_container(ir_text):
+    assert ir_text.count("ttg.warp_specialize") == 1, ir_text
+    assert ir_text.count("ttg.warp_yield") == 1, ir_text
+    assert ir_text.count("ttg.warp_return") == 1, ir_text
+    assert "partition0" in ir_text, ir_text
+    assert "partition1" not in ir_text, ir_text
+    assert "num_warps(4)" in ir_text, ir_text
+    assert re.search(r"requestedRegisters\s*=\s*array<i32:\s*24>", ir_text), ir_text
+    assert "actualRegisters" not in ir_text, ir_text
+    assert "ttg.maxnreg" not in ir_text, ir_text
+    assert "tle.wgmma_pipeline_mode" not in ir_text, ir_text
+    assert "tt.call" not in ir_text, ir_text
+
+    ws_match = re.search(
+        r"ttg\.warp_specialize\((?P<captures>[^)]*)\).*?"
+        r"partition0\((?P<args>[^)]*)\)\s*num_warps\(4\).*?"
+        r":\s*\((?P<types>[^)]*)\)\s*->\s*\(\)",
+        ir_text,
+        re.DOTALL,
+    )
+    assert ws_match, ir_text
+    captures = _split_top_level(ws_match.group("captures"))
+    args = _split_top_level(ws_match.group("args"))
+    types = _split_top_level(ws_match.group("types"))
+
+    # Five Python worker arguments flatten to three unique SSA captures:
+    # pointer, dynamic i32, and shared memdesc.  The repeated pointer is
+    # remapped to the first block argument and constexpr BIAS consumes no SSA.
+    assert len(captures) == 3, ir_text
+    assert len(args) == 3, ir_text
+    assert len(types) == 3, ir_text
+    assert sum("ptr" in ty for ty in types) == 1, ir_text
+    assert sum(ty == "i32" for ty in types) == 1, ir_text
+    assert sum("memdesc" in ty for ty in types) == 1, ir_text
+    assert any(re.search(r"\bi32\b", arg) for arg in args), ir_text
+    assert any("memdesc" in arg for arg in args), ir_text
+
+    assert re.search(r"(?:arith\.)?constant\s+7\s*:\s*i32", ir_text), ir_text
+    assert re.search(r"ttg\.warp_yield\s*(?:\n|\})", ir_text), ir_text
+    assert re.search(r"ttg\.warp_return\s*(?:\n|\})", ir_text), ir_text
+    assert re.search(r"\)\s*->\s*\(\)\s*\n\s*tt\.return", ir_text), ir_text
+
+
+def test_tle_warp_specialize_mthreads_container_contract():
+    ttir, ttgir = _compile_ws_ir()
+    _assert_ws_container(ttir)
+    _assert_ws_container(ttgir)
+
+
+def test_tle_warp_specialize_builder_bindings_are_available():
+    builder = libtriton.ir.builder
+    for method in (
+            "create_warp_specialize",
+            "create_warp_specialize_partitions",
+            "create_warp_yield",
+            "create_warp_return",
+    ):
+        assert hasattr(builder, method)
+    assert hasattr(libtriton.mthreads.ir, "WarpSpecializeOp")

--- a/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize_integration.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize_integration.py
@@ -557,6 +557,12 @@ def _assert_common_ws_ir(ir_text, stages, k_tiles, barriers_lowered=False):
         assert f"musa.max_bar_id = {4 * stages}" in ir_text, ir_text
         assert "musa.next_bar_id" not in ir_text, ir_text
         assert "ttmg.bar_record" in ir_text, ir_text
+        assert ir_text.count("ttg.barrier local") == 1, ir_text
+        init_positions = [match.start() for match in re.finditer("ttmg.init_arrival", ir_text)]
+        rendezvous = ir_text.index("ttg.barrier local")
+        warp_specialize = ir_text.index("ttg.warp_specialize(")
+        assert ir_text.index("ttmg.bar_record") < min(init_positions), ir_text
+        assert max(init_positions) < rendezvous < warp_specialize, ir_text
     else:
         assert sum("arrive_count = 1" in line and "expect_bytes = 32768" in line and "init_polarity = 0" in line
                    for line in alloc_lines) == 2, ir_text
@@ -572,6 +578,8 @@ def _assert_common_ws_ir(ir_text, stages, k_tiles, barriers_lowered=False):
     assert "#smem, mutable>" in ir_text, ir_text
 
     ws_match, default_region, partition_match = _extract_ws_regions(ir_text)
+    assert "ttg.barrier local" not in default_region, default_region
+    assert "ttg.barrier local" not in partition_match.group("body"), partition_match.group("body")
     captures = _split_top_level(ws_match.group("captures"))
     partition_args = _split_top_level(partition_match.group("args"))
     assert len(captures) == 10, (captures, ir_text)

--- a/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize_integration.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize_integration.py
@@ -731,12 +731,13 @@ def _assert_ttgir_copy_association(ttgir, stages, k_tiles):
     assert all(_depends_on(value, loop_induction, definitions) for value in dynamic_offsets[:period_offset_count])
     assert all(not _depends_on(value, loop_induction, definitions) for value in dynamic_offsets[period_offset_count:])
     assert ttgir.count("ttmg.async_tme_copy_global_to_local") == 2 * len(emitted_tiles), ttgir
-    assert ttgir.count("musa_tle.expect_bytes = 32768 : i32") == 2 * len(emitted_tiles), ttgir
+    assert ttgir.count("musa.tme.explicit_completion") == 3 * 2 * len(emitted_tiles), ttgir
+    assert ttgir.count("musa.tme.issue_thread = 512 : i32") == 3 * 2 * len(emitted_tiles), ttgir
     assert ttgir.count("blockShape = array<i32: 256, 64>") == len(emitted_tiles), ttgir
     assert ttgir.count("blockShape = array<i32: 64, 256>") == len(emitted_tiles), ttgir
     assert ttgir.count("ttmg.init_arrival") == 4 * stages, ttgir
-    assert "ttmg.barrier_add_trans" not in ttgir, ttgir
-    assert "ttmg.arrive_barrier" not in ttgir, ttgir
+    assert ttgir.count("ttmg.barrier_add_trans") == 2 * len(emitted_tiles), ttgir
+    assert ttgir.count("ttmg.arrive_barrier_noret") == 2 * len(emitted_tiles), ttgir
     assert "ttmg.wait_barrier" not in ttgir, ttgir
 
 

--- a/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize_integration.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize_integration.py
@@ -399,7 +399,17 @@ def _compile_ws_dot_integration(stages):
     pm = ir.pass_manager(context)
     libtriton.mthreads.passes.ttgpuir.add_allocate_shared_memory(pm, 31)
     pm.run(module, "allocate_ws_dot_integration_shared_memory")
-    return ttir, ttgir, module.str_nodebug()
+    allocated = module.str_nodebug()
+
+    pm = ir.pass_manager(context)
+    libtriton.passes.convert.add_scf_to_cf(pm)
+    libtriton.passes.convert.add_index_to_llvmir(pm)
+    libtriton.mthreads.passes.ttgpuir.add_mtgpu_to_llvm(pm, 31)
+    libtriton.mthreads.passes.ttgpuir.add_to_llvmir(pm, 31)
+    libtriton.mthreads.passes.ttgpuir.add_tle_lower_warp_specialize(pm)
+    libtriton.passes.convert.add_scf_to_cf(pm)
+    pm.run(module, "lower_ws_dot_integration_to_llvm_cfg")
+    return ttir, ttgir, allocated, module.str_nodebug()
 
 
 def _split_top_level(text):
@@ -424,7 +434,8 @@ def _constants(region):
     return {
         name: int(value)
         for name, value in re.findall(
-            r"(%[-\w.]+)\s*=\s*(?:arith\.)?constant\s+(-?\d+)\s*:\s*i32",
+            r"(%[-\w.]+)\s*=\s*(?:arith\.)?constant"
+            r"(?:\s+\{[^}\n]*\})?\s+(-?\d+)\s*:\s*i32",
             region,
         )
     }
@@ -501,7 +512,8 @@ def _physical_barrier_defs(region, base_args):
     constants = _constants(region)
     definitions = {}
     for result, base, slot in re.findall(
-            r"(%[-\w.]+)\s*=\s*arith\.addi\s+(%[-\w.]+),\s*(%[-\w.]+)\s*:\s*i32",
+            r"(%[-\w.]+)\s*=\s*arith\.addi\s+(%[-\w.]+),\s*(%[-\w.]+)"
+            r"\s*(?:\{[^}\n]*\}\s*)?:\s*i32",
             region,
     ):
         if base in base_args and slot in constants:
@@ -535,9 +547,25 @@ def _assert_single_compiler_stage(ir_text):
 def _assert_common_ws_ir(ir_text, stages, k_tiles, barriers_lowered=False):
     emitted_tiles = _emitted_static_tiles(stages, k_tiles)
     _assert_single_compiler_stage(ir_text)
-    assert ir_text.count("ttg.warp_specialize") == 1, ir_text
-    assert ir_text.count("ttg.warp_yield") == 1, ir_text
-    assert ir_text.count("ttg.warp_return") == 1, ir_text
+    if barriers_lowered:
+        assert ir_text.count("ttg.warp_specialize") == 1, ir_text
+        assert ir_text.count("ttg.warp_yield") == 1, ir_text
+        assert ir_text.count("ttg.warp_return") == 1, ir_text
+        assert "musa_tle.static_warp_specialize" in ir_text, ir_text
+        assert "warpGroupStartIds = array<i32: 16>" in ir_text, ir_text
+        assert '"ttg.total-num-warps" = 20 : i32' in ir_text, ir_text
+        assert "gpu.thread_id" not in ir_text, ir_text
+        assert "musa_tle.static_ws.split" not in ir_text, ir_text
+        assert "musa_tle.static_ws.role" not in ir_text, ir_text
+        assert "musa_tle.static_ws.num_warps" not in ir_text, ir_text
+        assert "musa_tle.static_ws.thread_offset" not in ir_text, ir_text
+        assert "musa_tle.static_ws.split_candidate" not in ir_text, ir_text
+        assert "builtin.unrealized_conversion_cast" not in ir_text, ir_text
+    else:
+        assert ir_text.count("ttg.warp_specialize") == 1, ir_text
+        assert ir_text.count("ttg.warp_yield") == 1, ir_text
+        assert ir_text.count("ttg.warp_return") == 1, ir_text
+        assert "musa_tle.static_warp_specialize" in ir_text, ir_text
     assert ir_text.count("scf.for") == 2, ir_text
     assert ir_text.count("musa_tle.barrier.alloc") == (0 if barriers_lowered else 4), ir_text
     wait_op = "ttmg.wait_barrier" if barriers_lowered else "musa_tle.barrier.wait"
@@ -565,7 +593,7 @@ def _assert_common_ws_ir(ir_text, stages, k_tiles, barriers_lowered=False):
         assert ir_text.count("ttg.barrier local") == 1, ir_text
         init_positions = [match.start() for match in re.finditer("ttmg.init_arrival", ir_text)]
         rendezvous = ir_text.index("ttg.barrier local")
-        warp_specialize = ir_text.index("ttg.warp_specialize(")
+        warp_specialize = ir_text.index("ttg.warp_specialize")
         assert ir_text.index("ttmg.bar_record") < min(init_positions), ir_text
         assert max(init_positions) < rendezvous < warp_specialize, ir_text
     else:
@@ -583,20 +611,23 @@ def _assert_common_ws_ir(ir_text, stages, k_tiles, barriers_lowered=False):
     assert "#smem, mutable>" in ir_text, ir_text
 
     ws_match, default_region, partition_match = _extract_ws_regions(ir_text)
+    producer_region = partition_match.group("body")
+    if barriers_lowered:
+        partition_args = []
+    else:
+        captures = _split_top_level(ws_match.group("captures"))
+        partition_args = _split_top_level(partition_match.group("args"))
+        assert len(captures) == 10, (captures, ir_text)
+        assert len(set(captures)) == 10, (captures, ir_text)
+        assert len(partition_args) == 10, (partition_args, ir_text)
+        assert sum("tensordesc" in arg for arg in partition_args) == 2, partition_args
+        assert sum("memdesc" in arg for arg in partition_args) == 2, partition_args
+        assert sum(": i32" in arg for arg in partition_args) == 5, partition_args
+        assert sum("ptr<f16>" in arg for arg in partition_args) == 1, partition_args
+        assert "requestedRegisters = array<i32: 24>" in ws_match.group("attrs"), ir_text
+        assert re.search(r"\)\s*->\s*\(\)\s*\n\s*tt\.return", ir_text), ir_text
     assert "ttg.barrier local" not in default_region, default_region
-    assert "ttg.barrier local" not in partition_match.group("body"), partition_match.group("body")
-    captures = _split_top_level(ws_match.group("captures"))
-    partition_args = _split_top_level(partition_match.group("args"))
-    expected_captures = 6 if barriers_lowered else 10
-    assert len(captures) == expected_captures, (captures, ir_text)
-    assert len(set(captures)) == expected_captures, (captures, ir_text)
-    assert len(partition_args) == expected_captures, (partition_args, ir_text)
-    assert sum("tensordesc" in arg for arg in partition_args) == 2, partition_args
-    assert sum("memdesc" in arg for arg in partition_args) == 2, partition_args
-    assert sum(": i32" in arg for arg in partition_args) == (1 if barriers_lowered else 5), partition_args
-    assert sum("ptr<f16>" in arg for arg in partition_args) == 1, partition_args
-    assert "requestedRegisters = array<i32: 24>" in ws_match.group("attrs"), ir_text
-    assert re.search(r"\)\s*->\s*\(\)\s*\n\s*tt\.return", ir_text), ir_text
+    assert "ttg.barrier local" not in producer_region, producer_region
 
     enclosing_constants = _constants(ir_text)
     assert default_region.count("scf.for") == 1, default_region
@@ -642,7 +673,6 @@ def _assert_common_ws_ir(ir_text, stages, k_tiles, barriers_lowered=False):
             enclosing_constants,
         ) == expected_ready, default_region
 
-    producer_region = partition_match.group("body")
     assert producer_region.count("scf.for") == 1, producer_region
     assert not re.search(r"arith\.(?:rem|div)", producer_region), producer_region
     producer_arg_names = [arg.split(":", 1)[0].strip() for arg in partition_args]
@@ -769,13 +799,11 @@ def _assert_explicit_shared_allocations(allocated, stages):
     assert f"!ttg.memdesc<{stages}x64x256xf16" in local_allocs[1], local_allocs
     assert "allocation.offset = 0 : i32" in local_allocs[0], local_allocs
     assert f"allocation.offset = {stages * 32768} : i32" in local_allocs[1], local_allocs
-    ws_line = next(line for line in allocated.splitlines() if "ttg.warp_specialize(" in line)
-    assert f"allocation.offset = {explicit_bytes} : i32" in ws_line, ws_line
+    assert allocated.count("ttg.warp_specialize") == 1, allocated
+    ws_line = next(line for line in allocated.splitlines() if "ttg.warp_specialize" in line)
+    assert "allocation.offset" not in ws_line, ws_line
     shared_bytes = int(re.search(r"ttg\.shared = (\d+) : i32", allocated).group(1))
-    # Descriptor, memdesc, pointer, and scalar captures occupy 68 bytes rounded
-    # to the generic WS mailbox's 8-byte alignment. The four hardware barrier
-    # base IDs are rematerialized constants and therefore add zero SMEM.
-    assert shared_bytes == explicit_bytes + 72, allocated
+    assert shared_bytes == explicit_bytes, allocated
 
 
 def _assert_dot_pipeline_resources(ttir, ttgir, allocated, stages):
@@ -828,21 +856,69 @@ def _assert_dot_pipeline_resources(ttir, ttgir, allocated, stages):
     explicit_offsets = [int(re.search(r"allocation\.offset = (\d+)", line).group(1)) for line in explicit_allocs]
     assert explicit_offsets == [131072, 131072 + stages * 32768], explicit_allocs
     sqmma_offsets = [int(re.search(r"allocation\.offset = (\d+)", line).group(1)) for line in sqmma_allocs]
-    sqmma_base = 131072 + stages * 65536
-    assert sqmma_offsets == [sqmma_base + index * 32768 for index in range(4 * stages)], sqmma_allocs
+    explicit_end = 131072 + stages * 65536
+    expected_sqmma_offsets = [index * 32768 for index in range(4)]
+    expected_sqmma_offsets += [explicit_end + index * 32768 for index in range(4 * (stages - 1))]
+    assert sqmma_offsets == expected_sqmma_offsets, sqmma_allocs
 
     output_conversion = next(
         line for line in allocated_lines
         if "ttg.convert_layout" in line and "tensor<256x256xf16" in line and "allocation.offset" in line)
     assert "allocation.offset = 0 : i32" in output_conversion, output_conversion
-    ws_line = next(line for line in allocated_lines if "ttg.warp_specialize(" in line)
-    assert "allocation.offset = 0 : i32" in ws_line, ws_line
+    assert allocated.count("ttg.warp_specialize") == 1, allocated
+    ws_line = next(line for line in allocated.splitlines() if "ttg.warp_specialize" in line)
+    assert "allocation.offset" not in ws_line, ws_line
 
-    expected_scratch_end = sqmma_base + 4 * stages * 32768
     func_line = next(line for line in allocated_lines if "tt.func public @_ws_dot_integration_kernel" in line)
-    assert f"allocation.offset = {expected_scratch_end} : i32" in func_line, func_line
+    assert "allocation.offset" not in func_line, func_line
     shared_bytes = int(re.search(r"ttg\.shared = (\d+) : i32", allocated).group(1))
-    assert shared_bytes == expected_scratch_end + 4, allocated
+    expected_shared = max(
+        explicit_end,
+        max(offset + 32768 for offset in expected_sqmma_offsets),
+        131072,
+    )
+    assert shared_bytes == expected_shared, allocated
+
+
+def _assert_late_ws_dot_cfg(late, stages):
+    assert "ttg.warp_specialize" not in late, late
+    assert "ttg.warp_yield" not in late, late
+    assert "ttg.warp_return" not in late, late
+    assert "musa_tle.static_warp_specialize" not in late, late
+    assert "musa_tle.static_ws." not in late, late
+    assert "cf.switch" not in late, late
+
+    comparisons = re.findall(
+        r"(%[-\w.]+)\s*=\s*arith\.cmpi\s+(uge|ult),\s*"
+        r"(%[-\w.]+),\s*(%[-\w.]+)",
+        late,
+    )
+    producer = [comparison for comparison in comparisons if comparison[1] == "uge"]
+    consumer = [comparison for comparison in comparisons if comparison[1] == "ult"]
+    assert len(producer) == 1, late
+    assert len(consumer) == 1, late
+    assert producer[0][2:] == consumer[0][2:], (producer, consumer, late)
+    constants = _constants(late)
+    assert constants[producer[0][3]] == 16 * 32, (producer, constants, late)
+    assert late.index(producer[0][0]) < late.index(consumer[0][0]), late
+    assert re.search(rf"cf\.cond_br\s+{re.escape(producer[0][0])},", late), late
+    assert re.search(rf"cf\.cond_br\s+{re.escape(consumer[0][0])},", late), late
+    # Two partition dispatches plus the thread-0-only barrier initializer.
+    assert late.count("cf.cond_br") == 3, late
+
+    # The pre-existing post-initialization CTA rendezvous is reused.  The
+    # static dispatch and partition barriers must not allocate control SMEM.
+    assert late.count('"llvm.musa.syncthreads.lm"') == 1, late
+    initialized_barriers = late.count('"llvm.musa.async.init.arrival"')
+    record = re.search(
+        r'llvm\.call_intrinsic\s+"llvm\.musa\.async\.bar\.record"'
+        r'\((%[-\w.]+)\)',
+        late,
+    )
+    assert record, late
+    recorded_barriers = constants[record.group(1)]
+    assert recorded_barriers == initialized_barriers, (record.group(1), constants, late)
+    assert recorded_barriers > 4 * stages, (recorded_barriers, stages, late)
 
 
 @pytest.mark.parametrize("stages,k_tiles", [(1, 16), (2, 16), (2, 10)])
@@ -855,8 +931,9 @@ def test_mthreads_tle_warp_specialize_integration_contract(stages, k_tiles):
 
 @pytest.mark.parametrize("stages", [1, 2])
 def test_mthreads_tle_warp_specialize_dot_pipeline_resources(stages):
-    ttir, ttgir, allocated = _compile_ws_dot_integration(stages)
+    ttir, ttgir, allocated, late = _compile_ws_dot_integration(stages)
     _assert_dot_pipeline_resources(ttir, ttgir, allocated, stages)
+    _assert_late_ws_dot_cfg(late, stages)
 
 
 def test_mthreads_tle_warp_specialize_stage_three_remains_deferred():

--- a/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize_integration.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize_integration.py
@@ -587,12 +587,13 @@ def _assert_common_ws_ir(ir_text, stages, k_tiles, barriers_lowered=False):
     assert "ttg.barrier local" not in partition_match.group("body"), partition_match.group("body")
     captures = _split_top_level(ws_match.group("captures"))
     partition_args = _split_top_level(partition_match.group("args"))
-    assert len(captures) == 10, (captures, ir_text)
-    assert len(set(captures)) == 10, (captures, ir_text)
-    assert len(partition_args) == 10, (partition_args, ir_text)
+    expected_captures = 6 if barriers_lowered else 10
+    assert len(captures) == expected_captures, (captures, ir_text)
+    assert len(set(captures)) == expected_captures, (captures, ir_text)
+    assert len(partition_args) == expected_captures, (partition_args, ir_text)
     assert sum("tensordesc" in arg for arg in partition_args) == 2, partition_args
     assert sum("memdesc" in arg for arg in partition_args) == 2, partition_args
-    assert sum(": i32" in arg for arg in partition_args) == 5, partition_args
+    assert sum(": i32" in arg for arg in partition_args) == (1 if barriers_lowered else 5), partition_args
     assert sum("ptr<f16>" in arg for arg in partition_args) == 1, partition_args
     assert "requestedRegisters = array<i32: 24>" in ws_match.group("attrs"), ir_text
     assert re.search(r"\)\s*->\s*\(\)\s*\n\s*tt\.return", ir_text), ir_text
@@ -645,10 +646,21 @@ def _assert_common_ws_ir(ir_text, stages, k_tiles, barriers_lowered=False):
     assert producer_region.count("scf.for") == 1, producer_region
     assert not re.search(r"arith\.(?:rem|div)", producer_region), producer_region
     producer_arg_names = [arg.split(":", 1)[0].strip() for arg in partition_args]
-    producer_full = set(producer_arg_names[4:6])
-    producer_empty = set(producer_arg_names[6:8])
-    producer_barriers = (_physical_barrier_defs(producer_region, producer_full | producer_empty)
-                         if barriers_lowered else _index_defs(producer_region, "musa_tle.barrier.index"))
+    if barriers_lowered:
+        # Hardware barrier bases are constants, rematerialized directly in the
+        # isolated producer. They must not consume WS capture-mailbox SMEM.
+        producer_constants = _constants(producer_region)
+        producer_full = {name for name, value in producer_constants.items() if value in {1, 1 + stages}}
+        producer_empty = {
+            name
+            for name, value in producer_constants.items()
+            if value in {1 + 2 * stages, 1 + 3 * stages}
+        }
+        producer_barriers = _physical_barrier_defs(producer_region, producer_full | producer_empty)
+    else:
+        producer_full = set(producer_arg_names[4:6])
+        producer_empty = set(producer_arg_names[6:8])
+        producer_barriers = _index_defs(producer_region, "musa_tle.barrier.index")
     assert _barrier_phases(
         producer_region,
         "ttmg.wait_barrier" if barriers_lowered else "musa_tle.barrier.wait",
@@ -760,12 +772,10 @@ def _assert_explicit_shared_allocations(allocated, stages):
     ws_line = next(line for line in allocated.splitlines() if "ttg.warp_specialize(" in line)
     assert f"allocation.offset = {explicit_bytes} : i32" in ws_line, ws_line
     shared_bytes = int(re.search(r"ttg\.shared = (\d+) : i32", allocated).group(1))
-    # The generic ttg.warp_specialize allocation currently serializes this
-    # probe's ten explicit captures into an 88-byte scratch area.  Keep this
-    # temporary equality strict so no other implicit shared allocation can be
-    # introduced unnoticed.  Static mthreads WS lowering must replace it with
-    # shared_bytes == explicit_bytes once captures are remapped directly.
-    assert shared_bytes == explicit_bytes + 88, allocated
+    # Descriptor, memdesc, pointer, and scalar captures occupy 68 bytes rounded
+    # to the generic WS mailbox's 8-byte alignment. The four hardware barrier
+    # base IDs are rematerialized constants and therefore add zero SMEM.
+    assert shared_bytes == explicit_bytes + 72, allocated
 
 
 def _assert_dot_pipeline_resources(ttir, ttgir, allocated, stages):

--- a/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize_integration.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize_integration.py
@@ -1,0 +1,554 @@
+"""Compile-only integration coverage for mthreads explicit TLE warp specialization."""
+
+import re
+
+import pytest
+import triton
+import triton.language as tl
+import triton.experimental.tle.language as tle
+from triton._C import libtriton
+from triton._C.libtriton import ir
+from triton.backends.compiler import Language
+from triton.compiler import ASTSource
+
+from test_tle_utils import mthreads_backend, require_mthreads_libtriton
+
+require_mthreads_libtriton()
+
+
+@triton.jit
+def _ws_consumer(
+    a_smem,
+    b_smem,
+    full_a,
+    full_b,
+    empty_a,
+    empty_b,
+    out,
+    K_TILES: tl.constexpr,
+    STAGES: tl.constexpr,
+    BIAS: tl.constexpr,
+):
+    PERIOD: tl.constexpr = 2 * STAGES
+    FULL_PERIODS: tl.constexpr = K_TILES // PERIOD
+    TAIL_TILES: tl.constexpr = K_TILES % PERIOD
+
+    for period_idx in tl.range(0, FULL_PERIODS, num_stages=1):
+        for u in tl.static_range(0, PERIOD):
+            k_iter = period_idx * PERIOD + u
+            tle.gpu.barrier_wait(full_a[u % STAGES], phaseIdx=u // STAGES)
+            tle.gpu.barrier_wait(full_b[u % STAGES], phaseIdx=u // STAGES)
+
+            a = tl.load(tle.gpu.local_ptr(a_smem.slot(u % STAGES), (0, 0)))
+            b = tl.load(tle.gpu.local_ptr(b_smem.slot(u % STAGES), (0, 0)))
+            tl.store(out + 2 * k_iter, a + BIAS)
+            tl.store(out + 2 * k_iter + 1, b + BIAS)
+
+            tle.gpu.barrier_arrive(empty_a[u % STAGES], phaseIdx=u // STAGES)
+            tle.gpu.barrier_arrive(empty_b[u % STAGES], phaseIdx=u // STAGES)
+
+    for u in tl.static_range(0, TAIL_TILES):
+        k_iter = FULL_PERIODS * PERIOD + u
+        tle.gpu.barrier_wait(full_a[u % STAGES], phaseIdx=u // STAGES)
+        tle.gpu.barrier_wait(full_b[u % STAGES], phaseIdx=u // STAGES)
+
+        a = tl.load(tle.gpu.local_ptr(a_smem.slot(u % STAGES), (0, 0)))
+        b = tl.load(tle.gpu.local_ptr(b_smem.slot(u % STAGES), (0, 0)))
+        tl.store(out + 2 * k_iter, a + BIAS)
+        tl.store(out + 2 * k_iter + 1, b + BIAS)
+
+        tle.gpu.barrier_arrive(empty_a[u % STAGES], phaseIdx=u // STAGES)
+        tle.gpu.barrier_arrive(empty_b[u % STAGES], phaseIdx=u // STAGES)
+
+
+@triton.jit
+def _ws_producer(
+    a_desc,
+    b_desc,
+    a_smem,
+    b_smem,
+    full_a,
+    full_b,
+    empty_a,
+    empty_b,
+    out,
+    duplicate_out,
+    dynamic_k,
+    K_TILES: tl.constexpr,
+    STAGES: tl.constexpr,
+    BIAS: tl.constexpr,
+):
+    # out, duplicate_out and BIAS intentionally exercise capture reconstruction.
+    tl.store(duplicate_out, tl.load(out))
+    PERIOD: tl.constexpr = 2 * STAGES
+    FULL_PERIODS: tl.constexpr = K_TILES // PERIOD
+    TAIL_TILES: tl.constexpr = K_TILES % PERIOD
+
+    for period_idx in tl.range(0, FULL_PERIODS, num_stages=1):
+        period_base = period_idx * PERIOD
+        for u in tl.static_range(0, PERIOD):
+            k_offset = dynamic_k + period_base + u
+            tle.gpu.barrier_wait(empty_a[u % STAGES], phaseIdx=u // STAGES)
+            tle.gpu.barrier_wait(empty_b[u % STAGES], phaseIdx=u // STAGES)
+            tle.gpu.copy(
+                a_desc,
+                a_smem.slot(u % STAGES),
+                (256, 64),
+                (0, k_offset),
+                barrier=full_a[u % STAGES],
+            )
+            tle.gpu.copy(
+                b_desc,
+                b_smem.slot(u % STAGES),
+                (64, 256),
+                (k_offset, 0),
+                barrier=full_b[u % STAGES],
+            )
+
+    for u in tl.static_range(0, TAIL_TILES):
+        k_offset = dynamic_k + FULL_PERIODS * PERIOD + u
+        tle.gpu.barrier_wait(empty_a[u % STAGES], phaseIdx=u // STAGES)
+        tle.gpu.barrier_wait(empty_b[u % STAGES], phaseIdx=u // STAGES)
+        tle.gpu.copy(
+            a_desc,
+            a_smem.slot(u % STAGES),
+            (256, 64),
+            (0, k_offset),
+            barrier=full_a[u % STAGES],
+        )
+        tle.gpu.copy(
+            b_desc,
+            b_smem.slot(u % STAGES),
+            (64, 256),
+            (k_offset, 0),
+            barrier=full_b[u % STAGES],
+        )
+
+
+@triton.jit
+def _ws_integration_kernel(
+    a_desc,
+    b_desc,
+    out,
+    dynamic_k,
+    K_TILES: tl.constexpr,
+    STAGES: tl.constexpr,
+    BIAS: tl.constexpr,
+):
+    a_smem = tle.gpu.alloc(
+        (STAGES, 256, 64),
+        dtype=tl.float16,
+        nv_mma_shared_layout=False,
+    )
+    b_smem = tle.gpu.alloc(
+        (STAGES, 64, 256),
+        dtype=tl.float16,
+        nv_mma_shared_layout=False,
+    )
+    full_a = tle.gpu.alloc_barriers(
+        STAGES,
+        arrive_count=1,
+        init=tle.gpu.PENDING,
+        expect_bytes=32768,
+    )
+    full_b = tle.gpu.alloc_barriers(
+        STAGES,
+        arrive_count=1,
+        init=tle.gpu.PENDING,
+        expect_bytes=32768,
+    )
+    empty_a = tle.gpu.alloc_barriers(
+        STAGES,
+        arrive_count=16,
+        init=tle.gpu.READY,
+    )
+    empty_b = tle.gpu.alloc_barriers(
+        STAGES,
+        arrive_count=16,
+        init=tle.gpu.READY,
+    )
+
+    tle.gpu.warp_specialize(
+        [
+            (
+                _ws_consumer,
+                (a_smem, b_smem, full_a, full_b, empty_a, empty_b, out, K_TILES, STAGES, BIAS),
+            ),
+            (
+                _ws_producer,
+                (
+                    a_desc,
+                    b_desc,
+                    a_smem,
+                    b_smem,
+                    full_a,
+                    full_b,
+                    empty_a,
+                    empty_b,
+                    out,
+                    out,
+                    dynamic_k,
+                    K_TILES,
+                    STAGES,
+                    BIAS,
+                ),
+            ),
+        ],
+        worker_num_warps=[4],
+        worker_num_regs=[24],
+    )
+
+
+def _compile_ws_integration(stages, k_tiles):
+    target, backend = mthreads_backend()
+    options = backend.parse_options({"num_warps": 16, "num_stages": 1})
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+
+    src = ASTSource(
+        fn=_ws_integration_kernel,
+        signature={
+            "a_desc": "tensordesc<fp16[256, 64]>",
+            "b_desc": "tensordesc<fp16[64, 256]>",
+            "out": "*fp16",
+            "dynamic_k": "i32",
+            "K_TILES": "constexpr",
+            "STAGES": "constexpr",
+            "BIAS": "constexpr",
+        },
+        constexprs={"K_TILES": k_tiles, "STAGES": stages, "BIAS": 1},
+    )
+    module = src.make_ir(
+        target,
+        options,
+        backend.get_codegen_implementation(options),
+        backend.get_module_map(),
+        context,
+    )
+    compiler_stages = {}
+    backend.add_stages(compiler_stages, options, Language.TRITON)
+    metadata = {}
+    module = compiler_stages["ttir"](module, metadata)
+    ttir = module.str_nodebug()
+    module = compiler_stages["ttgir"](module, metadata)
+    ttgir = module.str_nodebug()
+
+    pm = ir.pass_manager(context)
+    libtriton.mthreads.passes.ttgpuir.add_allocate_shared_memory(pm, 31)
+    pm.run(module, "allocate_ws_integration_shared_memory")
+    return ttir, ttgir, module.str_nodebug()
+
+
+def _split_top_level(text):
+    values = []
+    start = 0
+    depth = 0
+    for index, char in enumerate(text):
+        if char in "<[{(":
+            depth += 1
+        elif char in ">]})":
+            depth -= 1
+        elif char == "," and depth == 0:
+            values.append(text[start:index].strip())
+            start = index + 1
+    tail = text[start:].strip()
+    if tail:
+        values.append(tail)
+    return values
+
+
+def _constants(region):
+    return {
+        name: int(value)
+        for name, value in re.findall(
+            r"(%[-\w.]+)\s*=\s*(?:arith\.)?constant\s+(-?\d+)\s*:\s*i32",
+            region,
+        )
+    }
+
+
+def _ssa_definitions(region):
+    definitions = {}
+    for line in region.splitlines():
+        match = re.match(r"\s*(%[-\w.]+)\s*=\s*(.*)", line)
+        if match:
+            definitions[match.group(1)] = set(re.findall(r"%[-\w.]+", match.group(2)))
+    return definitions
+
+
+def _depends_on(value, root, definitions, seen=None):
+    if value == root:
+        return True
+    seen = set() if seen is None else seen
+    if value in seen:
+        return False
+    return any(_depends_on(operand, root, definitions, seen | {value}) for operand in definitions.get(value, ()))
+
+
+def _extract_ws_regions(ir_text):
+    ws_match = re.search(
+        r"ttg\.warp_specialize\((?P<captures>[^)]*)\)\s+"
+        r"attributes\s+\{(?P<attrs>[^}]*)\}",
+        ir_text,
+    )
+    default_match = re.search(
+        r"\bdefault\s*\{(?P<body>.*?)\n\s*\}\s*\n\s*partition0\(",
+        ir_text,
+        re.DOTALL,
+    )
+    partition_match = re.search(
+        r"partition0\((?P<args>.*?)\)\s*num_warps\(4\)\s*\{"
+        r"(?P<body>.*?)\n\s*ttg\.warp_return",
+        ir_text,
+        re.DOTALL,
+    )
+    assert ws_match and default_match and partition_match, ir_text
+    return ws_match, default_match.group("body"), partition_match
+
+
+def _index_defs(region, op_name, enclosing_constants=None):
+    constants = dict(enclosing_constants or {})
+    constants.update(_constants(region))
+    definitions = {}
+    for result, source, index in re.findall(
+            rf"(%[-\w.]+)\s*=\s*{re.escape(op_name)}\s+(%[-\w.]+)\[(%[-\w.]+)\]",
+            region,
+    ):
+        assert index in constants, (op_name, index, region)
+        definitions[result] = (source, constants[index])
+    return definitions
+
+
+def _barrier_phases(region, op_name, barrier_defs, selected_sources, enclosing_constants=None):
+    constants = dict(enclosing_constants or {})
+    constants.update(_constants(region))
+    phases = []
+    for slot, phase in re.findall(
+            rf"{re.escape(op_name)}\s+(%[-\w.]+),\s*(%[-\w.]+)",
+            region,
+    ):
+        source, _ = barrier_defs[slot]
+        if source in selected_sources:
+            assert phase in constants, (op_name, phase, region)
+            phases.append(constants[phase])
+    return phases
+
+
+def _emitted_static_tiles(stages, k_tiles):
+    period = 2 * stages
+    full_periods = k_tiles // period
+    tail_tiles = k_tiles % period
+    return ([*range(period)] if full_periods else []) + [*range(tail_tiles)]
+
+
+def _assert_common_ws_ir(ir_text, stages, k_tiles):
+    emitted_tiles = _emitted_static_tiles(stages, k_tiles)
+    assert ir_text.count("ttg.warp_specialize") == 1, ir_text
+    assert ir_text.count("ttg.warp_yield") == 1, ir_text
+    assert ir_text.count("ttg.warp_return") == 1, ir_text
+    assert ir_text.count("scf.for") == 2, ir_text
+    assert ir_text.count("musa_tle.barrier.alloc") == 4, ir_text
+    assert ir_text.count("musa_tle.barrier.wait") == 4 * len(emitted_tiles), ir_text
+    assert ir_text.count("musa_tle.barrier.arrive") == 2 * len(emitted_tiles), ir_text
+    assert ir_text.count("ttg.memdesc_index") >= 4 * stages, ir_text
+    assert ir_text.count("ttg.local_alloc") == 2, ir_text
+    assert "tle.wgmma_pipeline_mode" not in ir_text, ir_text
+    assert "#ttg.nvmma_shared" not in ir_text, ir_text
+    assert "ttg.maxnreg" not in ir_text, ir_text
+    assert "actualRegisters" not in ir_text, ir_text
+    assert not re.search(r"(?<!musa_)tle\.barrier\.", ir_text), ir_text
+
+    alloc_lines = [line for line in ir_text.splitlines() if "musa_tle.barrier.alloc" in line]
+    assert sum("arrive_count = 1" in line and "expect_bytes = 32768" in line and "init_polarity = 0" in line
+               for line in alloc_lines) == 2, ir_text
+    assert sum("arrive_count = 16" in line and "expect_bytes" not in line and "init_polarity = 1" in line
+               for line in alloc_lines) == 2, ir_text
+    assert all(f"num_barriers = {stages}" in line for line in alloc_lines), ir_text
+    assert all("memdesc" not in line and "allocation.offset" not in line for line in alloc_lines), ir_text
+
+    assert f"!ttg.memdesc<{stages}x256x64xf16" in ir_text, ir_text
+    assert f"!ttg.memdesc<{stages}x64x256xf16" in ir_text, ir_text
+    assert "!ttg.memdesc<256x64xf16" in ir_text, ir_text
+    assert "!ttg.memdesc<64x256xf16" in ir_text, ir_text
+    assert "#smem, mutable>" in ir_text, ir_text
+
+    ws_match, default_region, partition_match = _extract_ws_regions(ir_text)
+    captures = _split_top_level(ws_match.group("captures"))
+    partition_args = _split_top_level(partition_match.group("args"))
+    assert len(captures) == 10, (captures, ir_text)
+    assert len(set(captures)) == 10, (captures, ir_text)
+    assert len(partition_args) == 10, (partition_args, ir_text)
+    assert sum("tensordesc" in arg for arg in partition_args) == 2, partition_args
+    assert sum("memdesc" in arg for arg in partition_args) == 2, partition_args
+    assert sum(": i32" in arg for arg in partition_args) == 5, partition_args
+    assert sum("ptr<f16>" in arg for arg in partition_args) == 1, partition_args
+    assert "requestedRegisters = array<i32: 24>" in ws_match.group("attrs"), ir_text
+    assert re.search(r"\)\s*->\s*\(\)\s*\n\s*tt\.return", ir_text), ir_text
+
+    enclosing_constants = _constants(ir_text)
+    assert default_region.count("scf.for") == 1, default_region
+    assert not re.search(r"arith\.(?:rem|div)", default_region), default_region
+    default_barriers = _index_defs(default_region, "musa_tle.barrier.index", enclosing_constants)
+    default_memdescs = _index_defs(default_region, "ttg.memdesc_index", enclosing_constants)
+    allocation_results = re.findall(
+        r"(%[-\w.]+)\s*=\s*musa_tle\.barrier\.alloc",
+        ir_text,
+    )
+    assert len(allocation_results) == 4, ir_text
+    full_sources = set(allocation_results[:2])
+    empty_sources = set(allocation_results[2:])
+    expected_logical = [u // stages for u in emitted_tiles for _ in range(2)]
+    expected_ready = [phase ^ 1 for phase in expected_logical]
+    assert _barrier_phases(
+        default_region,
+        "musa_tle.barrier.wait",
+        default_barriers,
+        full_sources,
+        enclosing_constants,
+    ) == expected_logical, default_region
+    assert _barrier_phases(
+        default_region,
+        "musa_tle.barrier.arrive",
+        default_barriers,
+        empty_sources,
+        enclosing_constants,
+    ) == expected_ready, default_region
+
+    producer_region = partition_match.group("body")
+    assert producer_region.count("scf.for") == 1, producer_region
+    assert not re.search(r"arith\.(?:rem|div)", producer_region), producer_region
+    producer_barriers = _index_defs(producer_region, "musa_tle.barrier.index")
+    producer_arg_names = [arg.split(":", 1)[0].strip() for arg in partition_args]
+    producer_full = set(producer_arg_names[4:6])
+    producer_empty = set(producer_arg_names[6:8])
+    assert _barrier_phases(
+        producer_region,
+        "musa_tle.barrier.wait",
+        producer_barriers,
+        producer_empty,
+    ) == expected_ready, producer_region
+
+    slot_values = {value for _, value in default_barriers.values()}
+    slot_values.update(value for _, value in default_memdescs.values())
+    slot_values.update(value for _, value in producer_barriers.values())
+    memdesc_defs = _index_defs(producer_region, "ttg.memdesc_index")
+    slot_values.update(value for _, value in memdesc_defs.values())
+    assert slot_values == set(range(stages)), producer_region
+    return producer_region, producer_barriers, producer_full, memdesc_defs
+
+
+def _assert_ttir_copy_association(ttir, stages, k_tiles):
+    emitted_tiles = _emitted_static_tiles(stages, k_tiles)
+    producer_region, barrier_defs, full_sources, memdesc_defs = _assert_common_ws_ir(ttir, stages, k_tiles)
+    copies = re.findall(
+        r"ttg\.tma_copy\s+(%[-\w.]+),\s*(%[-\w.]+),\s*"
+        r"\[(?P<offsets>[^]]+)\]\s+barrier\s+(%[-\w.]+)",
+        producer_region,
+    )
+    assert len(copies) == 2 * len(emitted_tiles), producer_region
+    dynamic_offsets = []
+    for copy_index, (_, destination, offsets, barrier) in enumerate(copies):
+        barrier_source, barrier_slot = barrier_defs[barrier]
+        _, destination_slot = memdesc_defs[destination]
+        assert barrier_source in full_sources, (barrier, producer_region)
+        assert barrier_slot == destination_slot, (barrier, destination, producer_region)
+        offset_values = [value.strip() for value in offsets.split(",")]
+        assert len(offset_values) == 2, offsets
+        constants = _constants(producer_region)
+        if copy_index % 2 == 0:
+            assert constants[offset_values[0]] == 0, offsets
+            dynamic_offsets.append(offset_values[1])
+        else:
+            assert constants[offset_values[1]] == 0, offsets
+            dynamic_offsets.append(offset_values[0])
+    assert all(dynamic_offsets[index] == dynamic_offsets[index + 1]
+               for index in range(0, len(dynamic_offsets), 2)), copies
+    assert len(set(dynamic_offsets[::2])) == len(emitted_tiles), copies
+    loop_induction = re.search(r"scf\.for\s+(%[-\w.]+)\s*=", producer_region).group(1)
+    definitions = _ssa_definitions(producer_region)
+    period_offset_count = 4 * stages
+    assert all(_depends_on(value, loop_induction, definitions) for value in dynamic_offsets[:period_offset_count])
+    assert all(not _depends_on(value, loop_induction, definitions) for value in dynamic_offsets[period_offset_count:])
+    assert ttir.count("ttg.tma_copy") == 2 * len(emitted_tiles), ttir
+    assert ttir.count("expect_bytes = 32768 : i32") == 2 + 2 * len(emitted_tiles), ttir
+
+
+def _assert_ttgir_copy_association(ttgir, stages, k_tiles):
+    emitted_tiles = _emitted_static_tiles(stages, k_tiles)
+    producer_region, barrier_defs, full_sources, memdesc_defs = _assert_common_ws_ir(ttgir, stages, k_tiles)
+    copies = re.findall(
+        r"ttmg\.async_tme_copy_global_to_local\s+(%[-\w.]+)"
+        r"\[(?P<offsets>[^]]+)\],\s*(%[-\w.]+),\s*(%[-\w.]+),",
+        producer_region,
+    )
+    assert len(copies) == 2 * len(emitted_tiles), producer_region
+    dynamic_offsets = []
+    constants = _constants(producer_region)
+    for copy_index, (_, offsets, barrier, destination) in enumerate(copies):
+        barrier_source, barrier_slot = barrier_defs[barrier]
+        _, destination_slot = memdesc_defs[destination]
+        assert barrier_source in full_sources, (barrier, producer_region)
+        assert barrier_slot == destination_slot, (barrier, destination, producer_region)
+        offset_values = [value.strip() for value in offsets.split(",")]
+        assert len(offset_values) == 2, offsets
+        if copy_index % 2 == 0:
+            assert constants[offset_values[0]] == 0, offsets
+            dynamic_offsets.append(offset_values[1])
+        else:
+            assert constants[offset_values[1]] == 0, offsets
+            dynamic_offsets.append(offset_values[0])
+    assert all(dynamic_offsets[index] == dynamic_offsets[index + 1]
+               for index in range(0, len(dynamic_offsets), 2)), copies
+    assert len(set(dynamic_offsets[::2])) == len(emitted_tiles), copies
+    loop_induction = re.search(r"scf\.for\s+(%[-\w.]+)\s*=", producer_region).group(1)
+    definitions = _ssa_definitions(producer_region)
+    period_offset_count = 4 * stages
+    assert all(_depends_on(value, loop_induction, definitions) for value in dynamic_offsets[:period_offset_count])
+    assert all(not _depends_on(value, loop_induction, definitions) for value in dynamic_offsets[period_offset_count:])
+    assert ttgir.count("ttmg.async_tme_copy_global_to_local") == 2 * len(emitted_tiles), ttgir
+    assert ttgir.count("musa_tle.expect_bytes = 32768 : i32") == 2 * len(emitted_tiles), ttgir
+    assert ttgir.count("blockShape = array<i32: 256, 64>") == len(emitted_tiles), ttgir
+    assert ttgir.count("blockShape = array<i32: 64, 256>") == len(emitted_tiles), ttgir
+    assert "ttmg.init_arrival" not in ttgir, ttgir
+    assert "ttmg.barrier_add_trans" not in ttgir, ttgir
+    assert "ttmg.arrive_barrier" not in ttgir, ttgir
+    assert "ttmg.wait_barrier" not in ttgir, ttgir
+
+
+def _assert_explicit_shared_allocations(allocated, stages):
+    explicit_bytes = stages * 65536
+    local_allocs = [line for line in allocated.splitlines() if "ttg.local_alloc" in line]
+    barrier_allocs = [line for line in allocated.splitlines() if "musa_tle.barrier.alloc" in line]
+    assert len(local_allocs) == 2, allocated
+    assert len(barrier_allocs) == 4, allocated
+    assert f"!ttg.memdesc<{stages}x256x64xf16" in local_allocs[0], local_allocs
+    assert f"!ttg.memdesc<{stages}x64x256xf16" in local_allocs[1], local_allocs
+    assert all("allocation.offset" not in line for line in barrier_allocs), barrier_allocs
+    assert all("memdesc" not in line for line in barrier_allocs), barrier_allocs
+    barrier_counts = [int(re.search(r"num_barriers = (\d+) : i32", line).group(1)) for line in barrier_allocs]
+    assert barrier_counts == [stages] * 4, barrier_allocs
+    assert sum(barrier_counts) == 4 * stages, barrier_allocs
+    assert all("arrive_count = 1" in line and "expect_bytes = 32768" in line and "init_polarity = 0" in line
+               for line in barrier_allocs[:2]), barrier_allocs
+    assert all("arrive_count = 16" in line and "expect_bytes" not in line and "init_polarity = 1" in line
+               for line in barrier_allocs[2:]), barrier_allocs
+    assert "allocation.offset = 0 : i32" in local_allocs[0], local_allocs
+    assert f"allocation.offset = {stages * 32768} : i32" in local_allocs[1], local_allocs
+    ws_line = next(line for line in allocated.splitlines() if "ttg.warp_specialize(" in line)
+    assert f"allocation.offset = {explicit_bytes} : i32" in ws_line, ws_line
+    shared_bytes = int(re.search(r"ttg\.shared = (\d+) : i32", allocated).group(1))
+    # The generic ttg.warp_specialize allocation currently serializes this
+    # probe's ten explicit captures into an 88-byte scratch area.  Keep this
+    # temporary equality strict so no other implicit shared allocation can be
+    # introduced unnoticed.  Static mthreads WS lowering must replace it with
+    # shared_bytes == explicit_bytes once captures are remapped directly.
+    assert shared_bytes == explicit_bytes + 88, allocated
+
+
+@pytest.mark.parametrize("stages,k_tiles", [(1, 16), (2, 16), (2, 10)])
+def test_mthreads_tle_warp_specialize_integration_contract(stages, k_tiles):
+    ttir, ttgir, allocated = _compile_ws_integration(stages, k_tiles)
+    _assert_ttir_copy_association(ttir, stages, k_tiles)
+    _assert_ttgir_copy_association(ttgir, stages, k_tiles)
+    _assert_explicit_shared_allocations(allocated, stages)

--- a/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize_integration.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize_integration.py
@@ -10,6 +10,7 @@ from triton._C import libtriton
 from triton._C.libtriton import ir
 from triton.backends.compiler import Language
 from triton.compiler import ASTSource
+from triton.compiler.errors import CompilationError
 
 from test_tle_utils import mthreads_backend, require_mthreads_libtriton
 
@@ -126,6 +127,50 @@ def _ws_producer(
 
 
 @triton.jit
+def _ws_dot_consumer(
+    a_smem,
+    b_smem,
+    full_a,
+    full_b,
+    empty_a,
+    empty_b,
+    out,
+    K_TILES: tl.constexpr,
+    STAGES: tl.constexpr,
+):
+    PERIOD: tl.constexpr = 2 * STAGES
+    FULL_PERIODS: tl.constexpr = K_TILES // PERIOD
+    TAIL_TILES: tl.constexpr = K_TILES % PERIOD
+
+    acc = tl.zeros((256, 256), dtype=tl.float32)
+    for _period_idx in tl.range(0, FULL_PERIODS, num_stages=1):
+        for u in tl.static_range(0, PERIOD):
+            tle.gpu.barrier_wait(full_a[u % STAGES], phaseIdx=u // STAGES)
+            tle.gpu.barrier_wait(full_b[u % STAGES], phaseIdx=u // STAGES)
+
+            a = tl.load(tle.gpu.local_ptr(a_smem.slot(u % STAGES)))
+            b = tl.load(tle.gpu.local_ptr(b_smem.slot(u % STAGES)))
+            acc = tl.dot(a, b, acc=acc)
+
+            tle.gpu.barrier_arrive(empty_a[u % STAGES], phaseIdx=u // STAGES)
+            tle.gpu.barrier_arrive(empty_b[u % STAGES], phaseIdx=u // STAGES)
+
+    for u in tl.static_range(0, TAIL_TILES):
+        tle.gpu.barrier_wait(full_a[u % STAGES], phaseIdx=u // STAGES)
+        tle.gpu.barrier_wait(full_b[u % STAGES], phaseIdx=u // STAGES)
+
+        a = tl.load(tle.gpu.local_ptr(a_smem.slot(u % STAGES)))
+        b = tl.load(tle.gpu.local_ptr(b_smem.slot(u % STAGES)))
+        acc = tl.dot(a, b, acc=acc)
+
+        tle.gpu.barrier_arrive(empty_a[u % STAGES], phaseIdx=u // STAGES)
+        tle.gpu.barrier_arrive(empty_b[u % STAGES], phaseIdx=u // STAGES)
+
+    offsets = tl.arange(0, 256)[:, None] * 256 + tl.arange(0, 256)[None, :]
+    tl.store(out + offsets, acc.to(tl.float16))
+
+
+@triton.jit
 def _ws_integration_kernel(
     a_desc,
     b_desc,
@@ -199,9 +244,84 @@ def _ws_integration_kernel(
     )
 
 
+@triton.jit
+def _ws_dot_integration_kernel(
+    a_desc,
+    b_desc,
+    out,
+    dynamic_k,
+    K_TILES: tl.constexpr,
+    STAGES: tl.constexpr,
+):
+    a_smem = tle.gpu.alloc(
+        (STAGES, 256, 64),
+        dtype=tl.float16,
+        nv_mma_shared_layout=False,
+    )
+    b_smem = tle.gpu.alloc(
+        (STAGES, 64, 256),
+        dtype=tl.float16,
+        nv_mma_shared_layout=False,
+    )
+    full_a = tle.gpu.alloc_barriers(
+        STAGES,
+        arrive_count=1,
+        init=tle.gpu.PENDING,
+        expect_bytes=32768,
+    )
+    full_b = tle.gpu.alloc_barriers(
+        STAGES,
+        arrive_count=1,
+        init=tle.gpu.PENDING,
+        expect_bytes=32768,
+    )
+    empty_a = tle.gpu.alloc_barriers(
+        STAGES,
+        arrive_count=16,
+        init=tle.gpu.READY,
+    )
+    empty_b = tle.gpu.alloc_barriers(
+        STAGES,
+        arrive_count=16,
+        init=tle.gpu.READY,
+    )
+
+    tle.gpu.warp_specialize(
+        [
+            (
+                _ws_dot_consumer,
+                (a_smem, b_smem, full_a, full_b, empty_a, empty_b, out, K_TILES, STAGES),
+            ),
+            (
+                _ws_producer,
+                (
+                    a_desc,
+                    b_desc,
+                    a_smem,
+                    b_smem,
+                    full_a,
+                    full_b,
+                    empty_a,
+                    empty_b,
+                    out,
+                    out,
+                    dynamic_k,
+                    K_TILES,
+                    STAGES,
+                    1,
+                ),
+            ),
+        ],
+        worker_num_warps=[4],
+        worker_num_regs=[24],
+    )
+
+
 def _compile_ws_integration(stages, k_tiles):
     target, backend = mthreads_backend()
     options = backend.parse_options({"num_warps": 16, "num_stages": 1})
+    assert options.num_warps == 16
+    assert options.num_stages == 1
     context = ir.context()
     ir.load_dialects(context)
     backend.load_dialects(context)
@@ -237,6 +357,48 @@ def _compile_ws_integration(stages, k_tiles):
     pm = ir.pass_manager(context)
     libtriton.mthreads.passes.ttgpuir.add_allocate_shared_memory(pm, 31)
     pm.run(module, "allocate_ws_integration_shared_memory")
+    return ttir, ttgir, module.str_nodebug()
+
+
+def _compile_ws_dot_integration(stages):
+    target, backend = mthreads_backend()
+    options = backend.parse_options({"num_warps": 16, "num_stages": 1})
+    assert options.num_warps == 16
+    assert options.num_stages == 1
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+
+    src = ASTSource(
+        fn=_ws_dot_integration_kernel,
+        signature={
+            "a_desc": "tensordesc<fp16[256, 64]>",
+            "b_desc": "tensordesc<fp16[64, 256]>",
+            "out": "*fp16",
+            "dynamic_k": "i32",
+            "K_TILES": "constexpr",
+            "STAGES": "constexpr",
+        },
+        constexprs={"K_TILES": 16, "STAGES": stages},
+    )
+    module = src.make_ir(
+        target,
+        options,
+        backend.get_codegen_implementation(options),
+        backend.get_module_map(),
+        context,
+    )
+    compiler_stages = {}
+    backend.add_stages(compiler_stages, options, Language.TRITON)
+    metadata = {}
+    module = compiler_stages["ttir"](module, metadata)
+    ttir = module.str_nodebug()
+    module = compiler_stages["ttgir"](module, metadata)
+    ttgir = module.str_nodebug()
+
+    pm = ir.pass_manager(context)
+    libtriton.mthreads.passes.ttgpuir.add_allocate_shared_memory(pm, 31)
+    pm.run(module, "allocate_ws_dot_integration_shared_memory")
     return ttir, ttgir, module.str_nodebug()
 
 
@@ -335,6 +497,30 @@ def _barrier_phases(region, op_name, barrier_defs, selected_sources, enclosing_c
     return phases
 
 
+def _physical_barrier_defs(region, base_args):
+    constants = _constants(region)
+    definitions = {}
+    for result, base, slot in re.findall(
+            r"(%[-\w.]+)\s*=\s*arith\.addi\s+(%[-\w.]+),\s*(%[-\w.]+)\s*:\s*i32",
+            region,
+    ):
+        if base in base_args and slot in constants:
+            definitions[result] = (base, constants[slot])
+    return definitions
+
+
+def _physical_barrier_uses(region, op_name, enclosing_constants):
+    constants = dict(enclosing_constants)
+    constants.update(_constants(region))
+    uses = []
+    for bar_id, phase in re.findall(
+            rf"{re.escape(op_name)}\s+(%[-\w.]+),\s*(%[-\w.]+)",
+            region,
+    ):
+        uses.append((constants[bar_id], constants[phase]))
+    return uses
+
+
 def _emitted_static_tiles(stages, k_tiles):
     period = 2 * stages
     full_periods = k_tiles // period
@@ -342,13 +528,18 @@ def _emitted_static_tiles(stages, k_tiles):
     return ([*range(period)] if full_periods else []) + [*range(tail_tiles)]
 
 
-def _assert_common_ws_ir(ir_text, stages, k_tiles):
+def _assert_single_compiler_stage(ir_text):
+    assert re.findall(r"tt\.num_stages = (\d+) : i32", ir_text) == ["1", "1"], ir_text
+
+
+def _assert_common_ws_ir(ir_text, stages, k_tiles, barriers_lowered=False):
     emitted_tiles = _emitted_static_tiles(stages, k_tiles)
+    _assert_single_compiler_stage(ir_text)
     assert ir_text.count("ttg.warp_specialize") == 1, ir_text
     assert ir_text.count("ttg.warp_yield") == 1, ir_text
     assert ir_text.count("ttg.warp_return") == 1, ir_text
     assert ir_text.count("scf.for") == 2, ir_text
-    assert ir_text.count("musa_tle.barrier.alloc") == 4, ir_text
+    assert ir_text.count("musa_tle.barrier.alloc") == (0 if barriers_lowered else 4), ir_text
     assert ir_text.count("musa_tle.barrier.wait") == 4 * len(emitted_tiles), ir_text
     assert ir_text.count("musa_tle.barrier.arrive") == 2 * len(emitted_tiles), ir_text
     assert ir_text.count("ttg.memdesc_index") >= 4 * stages, ir_text
@@ -360,12 +551,19 @@ def _assert_common_ws_ir(ir_text, stages, k_tiles):
     assert not re.search(r"(?<!musa_)tle\.barrier\.", ir_text), ir_text
 
     alloc_lines = [line for line in ir_text.splitlines() if "musa_tle.barrier.alloc" in line]
-    assert sum("arrive_count = 1" in line and "expect_bytes = 32768" in line and "init_polarity = 0" in line
-               for line in alloc_lines) == 2, ir_text
-    assert sum("arrive_count = 16" in line and "expect_bytes" not in line and "init_polarity = 1" in line
-               for line in alloc_lines) == 2, ir_text
-    assert all(f"num_barriers = {stages}" in line for line in alloc_lines), ir_text
-    assert all("memdesc" not in line and "allocation.offset" not in line for line in alloc_lines), ir_text
+    if barriers_lowered:
+        assert "musa_tle.barrier.index" not in ir_text, ir_text
+        assert ir_text.count("ttmg.init_arrival") == 4 * stages, ir_text
+        assert f"musa.max_bar_id = {4 * stages}" in ir_text, ir_text
+        assert "musa.next_bar_id" not in ir_text, ir_text
+        assert "ttmg.bar_record" in ir_text, ir_text
+    else:
+        assert sum("arrive_count = 1" in line and "expect_bytes = 32768" in line and "init_polarity = 0" in line
+                   for line in alloc_lines) == 2, ir_text
+        assert sum("arrive_count = 16" in line and "expect_bytes" not in line and "init_polarity = 1" in line
+                   for line in alloc_lines) == 2, ir_text
+        assert all(f"num_barriers = {stages}" in line for line in alloc_lines), ir_text
+        assert all("memdesc" not in line and "allocation.offset" not in line for line in alloc_lines), ir_text
 
     assert f"!ttg.memdesc<{stages}x256x64xf16" in ir_text, ir_text
     assert f"!ttg.memdesc<{stages}x64x256xf16" in ir_text, ir_text
@@ -389,39 +587,55 @@ def _assert_common_ws_ir(ir_text, stages, k_tiles):
     enclosing_constants = _constants(ir_text)
     assert default_region.count("scf.for") == 1, default_region
     assert not re.search(r"arith\.(?:rem|div)", default_region), default_region
-    default_barriers = _index_defs(default_region, "musa_tle.barrier.index", enclosing_constants)
     default_memdescs = _index_defs(default_region, "ttg.memdesc_index", enclosing_constants)
-    allocation_results = re.findall(
-        r"(%[-\w.]+)\s*=\s*musa_tle\.barrier\.alloc",
-        ir_text,
-    )
-    assert len(allocation_results) == 4, ir_text
-    full_sources = set(allocation_results[:2])
-    empty_sources = set(allocation_results[2:])
     expected_logical = [u // stages for u in emitted_tiles for _ in range(2)]
     expected_ready = [phase ^ 1 for phase in expected_logical]
-    assert _barrier_phases(
-        default_region,
-        "musa_tle.barrier.wait",
-        default_barriers,
-        full_sources,
-        enclosing_constants,
-    ) == expected_logical, default_region
-    assert _barrier_phases(
-        default_region,
-        "musa_tle.barrier.arrive",
-        default_barriers,
-        empty_sources,
-        enclosing_constants,
-    ) == expected_ready, default_region
+    if barriers_lowered:
+        expected_slots = [u % stages for u in emitted_tiles]
+        expected_waits = [
+            item for slot, phase in zip(expected_slots, expected_logical[::2])
+            for item in ((1 + slot, phase), (1 + stages + slot, phase))
+        ]
+        expected_arrives = [
+            item for slot, phase in zip(expected_slots, expected_ready[::2])
+            for item in ((1 + 2 * stages + slot, phase), (1 + 3 * stages + slot, phase))
+        ]
+        assert _physical_barrier_uses(default_region, "musa_tle.barrier.wait",
+                                      enclosing_constants) == expected_waits, default_region
+        assert _physical_barrier_uses(default_region, "musa_tle.barrier.arrive",
+                                      enclosing_constants) == expected_arrives, default_region
+    else:
+        default_barriers = _index_defs(default_region, "musa_tle.barrier.index", enclosing_constants)
+        allocation_results = re.findall(
+            r"(%[-\w.]+)\s*=\s*musa_tle\.barrier\.alloc",
+            ir_text,
+        )
+        assert len(allocation_results) == 4, ir_text
+        full_sources = set(allocation_results[:2])
+        empty_sources = set(allocation_results[2:])
+        assert _barrier_phases(
+            default_region,
+            "musa_tle.barrier.wait",
+            default_barriers,
+            full_sources,
+            enclosing_constants,
+        ) == expected_logical, default_region
+        assert _barrier_phases(
+            default_region,
+            "musa_tle.barrier.arrive",
+            default_barriers,
+            empty_sources,
+            enclosing_constants,
+        ) == expected_ready, default_region
 
     producer_region = partition_match.group("body")
     assert producer_region.count("scf.for") == 1, producer_region
     assert not re.search(r"arith\.(?:rem|div)", producer_region), producer_region
-    producer_barriers = _index_defs(producer_region, "musa_tle.barrier.index")
     producer_arg_names = [arg.split(":", 1)[0].strip() for arg in partition_args]
     producer_full = set(producer_arg_names[4:6])
     producer_empty = set(producer_arg_names[6:8])
+    producer_barriers = (_physical_barrier_defs(producer_region, producer_full | producer_empty)
+                         if barriers_lowered else _index_defs(producer_region, "musa_tle.barrier.index"))
     assert _barrier_phases(
         producer_region,
         "musa_tle.barrier.wait",
@@ -429,8 +643,9 @@ def _assert_common_ws_ir(ir_text, stages, k_tiles):
         producer_empty,
     ) == expected_ready, producer_region
 
-    slot_values = {value for _, value in default_barriers.values()}
-    slot_values.update(value for _, value in default_memdescs.values())
+    slot_values = {value for _, value in default_memdescs.values()}
+    if not barriers_lowered:
+        slot_values.update(value for _, value in default_barriers.values())
     slot_values.update(value for _, value in producer_barriers.values())
     memdesc_defs = _index_defs(producer_region, "ttg.memdesc_index")
     slot_values.update(value for _, value in memdesc_defs.values())
@@ -476,7 +691,8 @@ def _assert_ttir_copy_association(ttir, stages, k_tiles):
 
 def _assert_ttgir_copy_association(ttgir, stages, k_tiles):
     emitted_tiles = _emitted_static_tiles(stages, k_tiles)
-    producer_region, barrier_defs, full_sources, memdesc_defs = _assert_common_ws_ir(ttgir, stages, k_tiles)
+    producer_region, barrier_defs, full_sources, memdesc_defs = _assert_common_ws_ir(
+        ttgir, stages, k_tiles, barriers_lowered=True)
     copies = re.findall(
         r"ttmg\.async_tme_copy_global_to_local\s+(%[-\w.]+)"
         r"\[(?P<offsets>[^]]+)\],\s*(%[-\w.]+),\s*(%[-\w.]+),",
@@ -510,7 +726,7 @@ def _assert_ttgir_copy_association(ttgir, stages, k_tiles):
     assert ttgir.count("musa_tle.expect_bytes = 32768 : i32") == 2 * len(emitted_tiles), ttgir
     assert ttgir.count("blockShape = array<i32: 256, 64>") == len(emitted_tiles), ttgir
     assert ttgir.count("blockShape = array<i32: 64, 256>") == len(emitted_tiles), ttgir
-    assert "ttmg.init_arrival" not in ttgir, ttgir
+    assert ttgir.count("ttmg.init_arrival") == 4 * stages, ttgir
     assert "ttmg.barrier_add_trans" not in ttgir, ttgir
     assert "ttmg.arrive_barrier" not in ttgir, ttgir
     assert "ttmg.wait_barrier" not in ttgir, ttgir
@@ -519,20 +735,13 @@ def _assert_ttgir_copy_association(ttgir, stages, k_tiles):
 def _assert_explicit_shared_allocations(allocated, stages):
     explicit_bytes = stages * 65536
     local_allocs = [line for line in allocated.splitlines() if "ttg.local_alloc" in line]
-    barrier_allocs = [line for line in allocated.splitlines() if "musa_tle.barrier.alloc" in line]
     assert len(local_allocs) == 2, allocated
-    assert len(barrier_allocs) == 4, allocated
+    assert "musa_tle.barrier.alloc" not in allocated, allocated
+    assert "musa_tle.barrier.index" not in allocated, allocated
+    assert allocated.count("ttmg.init_arrival") == 4 * stages, allocated
+    assert f"musa.max_bar_id = {4 * stages}" in allocated, allocated
     assert f"!ttg.memdesc<{stages}x256x64xf16" in local_allocs[0], local_allocs
     assert f"!ttg.memdesc<{stages}x64x256xf16" in local_allocs[1], local_allocs
-    assert all("allocation.offset" not in line for line in barrier_allocs), barrier_allocs
-    assert all("memdesc" not in line for line in barrier_allocs), barrier_allocs
-    barrier_counts = [int(re.search(r"num_barriers = (\d+) : i32", line).group(1)) for line in barrier_allocs]
-    assert barrier_counts == [stages] * 4, barrier_allocs
-    assert sum(barrier_counts) == 4 * stages, barrier_allocs
-    assert all("arrive_count = 1" in line and "expect_bytes = 32768" in line and "init_polarity = 0" in line
-               for line in barrier_allocs[:2]), barrier_allocs
-    assert all("arrive_count = 16" in line and "expect_bytes" not in line and "init_polarity = 1" in line
-               for line in barrier_allocs[2:]), barrier_allocs
     assert "allocation.offset = 0 : i32" in local_allocs[0], local_allocs
     assert f"allocation.offset = {stages * 32768} : i32" in local_allocs[1], local_allocs
     ws_line = next(line for line in allocated.splitlines() if "ttg.warp_specialize(" in line)
@@ -546,9 +755,76 @@ def _assert_explicit_shared_allocations(allocated, stages):
     assert shared_bytes == explicit_bytes + 88, allocated
 
 
+def _assert_dot_pipeline_resources(ttir, ttgir, allocated, stages):
+    _assert_single_compiler_stage(ttir)
+    _assert_single_compiler_stage(ttgir)
+    assert "#ttg.swizzled_shared" in ttir, ttir
+    assert "#ttg.swizzled_shared" in ttgir, ttgir
+    assert "#ttg.nvmma_shared" not in ttir, ttir
+    assert "#ttg.nvmma_shared" not in ttgir, ttgir
+
+    assert ttir.count("ttg.local_alloc") == 2, ttir
+    assert f"!ttg.memdesc<{stages}x256x64xf16" in ttir, ttir
+    assert f"!ttg.memdesc<{stages}x64x256xf16" in ttir, ttir
+
+    ttgir_allocs = [line for line in ttgir.splitlines() if "ttg.local_alloc" in line]
+    explicit_ttgir_allocs = [line for line in ttgir_allocs if "sqmma.op_idx" not in line]
+    sqmma_ttgir_allocs = [line for line in ttgir_allocs if "sqmma.op_idx" in line]
+    assert len(explicit_ttgir_allocs) == 2, ttgir
+    assert len(sqmma_ttgir_allocs) == 4 * stages, ttgir
+    assert f"!ttg.memdesc<{stages}x256x64xf16" in explicit_ttgir_allocs[0], explicit_ttgir_allocs
+    assert f"!ttg.memdesc<{stages}x64x256xf16" in explicit_ttgir_allocs[1], explicit_ttgir_allocs
+    assert sum("sqmma.op_idx = 0" in line for line in sqmma_ttgir_allocs) == 2 * stages, sqmma_ttgir_allocs
+    assert sum("sqmma.op_idx = 1" in line for line in sqmma_ttgir_allocs) == 2 * stages, sqmma_ttgir_allocs
+    assert all("sqmma.elem_bytes = 2" in line for line in sqmma_ttgir_allocs), sqmma_ttgir_allocs
+    assert sum("!ttg.memdesc<256x64xf16" in line for line in sqmma_ttgir_allocs) == 2 * stages
+    assert sum("!ttg.memdesc<64x256xf16" in line for line in sqmma_ttgir_allocs) == 2 * stages
+
+    allocated_lines = allocated.splitlines()
+    allocated_local = [line for line in allocated_lines if "ttg.local_alloc" in line]
+    explicit_allocs = [line for line in allocated_local if "sqmma.op_idx" not in line]
+    sqmma_allocs = [line for line in allocated_local if "sqmma.op_idx" in line]
+    assert len(explicit_allocs) == 2, allocated
+    assert len(sqmma_allocs) == 4 * stages, allocated
+    assert "musa_tle.barrier.alloc" not in allocated, allocated
+    assert "musa_tle.barrier.index" not in allocated, allocated
+    assert allocated.count("ttmg.init_arrival") == 4 * stages, allocated
+    assert f"musa.max_bar_id = {4 * stages}" in allocated, allocated
+
+    explicit_offsets = [int(re.search(r"allocation\.offset = (\d+)", line).group(1)) for line in explicit_allocs]
+    assert explicit_offsets == [131072, 131072 + stages * 32768], explicit_allocs
+    sqmma_offsets = [int(re.search(r"allocation\.offset = (\d+)", line).group(1)) for line in sqmma_allocs]
+    sqmma_base = 131072 + stages * 65536
+    assert sqmma_offsets == [sqmma_base + index * 32768 for index in range(4 * stages)], sqmma_allocs
+
+    output_conversion = next(
+        line for line in allocated_lines
+        if "ttg.convert_layout" in line and "tensor<256x256xf16" in line and "allocation.offset" in line)
+    assert "allocation.offset = 0 : i32" in output_conversion, output_conversion
+    ws_line = next(line for line in allocated_lines if "ttg.warp_specialize(" in line)
+    assert "allocation.offset = 0 : i32" in ws_line, ws_line
+
+    expected_scratch_end = sqmma_base + 4 * stages * 32768
+    func_line = next(line for line in allocated_lines if "tt.func public @_ws_dot_integration_kernel" in line)
+    assert f"allocation.offset = {expected_scratch_end} : i32" in func_line, func_line
+    shared_bytes = int(re.search(r"ttg\.shared = (\d+) : i32", allocated).group(1))
+    assert shared_bytes == expected_scratch_end + 4, allocated
+
+
 @pytest.mark.parametrize("stages,k_tiles", [(1, 16), (2, 16), (2, 10)])
 def test_mthreads_tle_warp_specialize_integration_contract(stages, k_tiles):
     ttir, ttgir, allocated = _compile_ws_integration(stages, k_tiles)
     _assert_ttir_copy_association(ttir, stages, k_tiles)
     _assert_ttgir_copy_association(ttgir, stages, k_tiles)
     _assert_explicit_shared_allocations(allocated, stages)
+
+
+@pytest.mark.parametrize("stages", [1, 2])
+def test_mthreads_tle_warp_specialize_dot_pipeline_resources(stages):
+    ttir, ttgir, allocated = _compile_ws_dot_integration(stages)
+    _assert_dot_pipeline_resources(ttir, ttgir, allocated, stages)
+
+
+def test_mthreads_tle_warp_specialize_stage_three_remains_deferred():
+    with pytest.raises(CompilationError, match="Shape element 0 must be a power of 2"):
+        _compile_ws_integration(3, 16)

--- a/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize_integration.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_warp_specialize_integration.py
@@ -540,8 +540,13 @@ def _assert_common_ws_ir(ir_text, stages, k_tiles, barriers_lowered=False):
     assert ir_text.count("ttg.warp_return") == 1, ir_text
     assert ir_text.count("scf.for") == 2, ir_text
     assert ir_text.count("musa_tle.barrier.alloc") == (0 if barriers_lowered else 4), ir_text
-    assert ir_text.count("musa_tle.barrier.wait") == 4 * len(emitted_tiles), ir_text
-    assert ir_text.count("musa_tle.barrier.arrive") == 2 * len(emitted_tiles), ir_text
+    wait_op = "ttmg.wait_barrier" if barriers_lowered else "musa_tle.barrier.wait"
+    arrive_op = "ttmg.warp_arrive_barrier" if barriers_lowered else "musa_tle.barrier.arrive"
+    assert ir_text.count(wait_op) == 4 * len(emitted_tiles), ir_text
+    assert ir_text.count(arrive_op) == 2 * len(emitted_tiles), ir_text
+    if barriers_lowered:
+        assert "musa_tle.barrier.wait" not in ir_text, ir_text
+        assert "musa_tle.barrier.arrive" not in ir_text, ir_text
     assert ir_text.count("ttg.memdesc_index") >= 4 * stages, ir_text
     assert ir_text.count("ttg.local_alloc") == 2, ir_text
     assert "tle.wgmma_pipeline_mode" not in ir_text, ir_text
@@ -608,9 +613,9 @@ def _assert_common_ws_ir(ir_text, stages, k_tiles, barriers_lowered=False):
             item for slot, phase in zip(expected_slots, expected_ready[::2])
             for item in ((1 + 2 * stages + slot, phase), (1 + 3 * stages + slot, phase))
         ]
-        assert _physical_barrier_uses(default_region, "musa_tle.barrier.wait",
+        assert _physical_barrier_uses(default_region, "ttmg.wait_barrier",
                                       enclosing_constants) == expected_waits, default_region
-        assert _physical_barrier_uses(default_region, "musa_tle.barrier.arrive",
+        assert _physical_barrier_uses(default_region, "ttmg.warp_arrive_barrier",
                                       enclosing_constants) == expected_arrives, default_region
     else:
         default_barriers = _index_defs(default_region, "musa_tle.barrier.index", enclosing_constants)
@@ -646,7 +651,7 @@ def _assert_common_ws_ir(ir_text, stages, k_tiles, barriers_lowered=False):
                          if barriers_lowered else _index_defs(producer_region, "musa_tle.barrier.index"))
     assert _barrier_phases(
         producer_region,
-        "musa_tle.barrier.wait",
+        "ttmg.wait_barrier" if barriers_lowered else "musa_tle.barrier.wait",
         producer_barriers,
         producer_empty,
     ) == expected_ready, producer_region
@@ -738,7 +743,6 @@ def _assert_ttgir_copy_association(ttgir, stages, k_tiles):
     assert ttgir.count("ttmg.init_arrival") == 4 * stages, ttgir
     assert ttgir.count("ttmg.barrier_add_trans") == 2 * len(emitted_tiles), ttgir
     assert ttgir.count("ttmg.arrive_barrier_noret") == 2 * len(emitted_tiles), ttgir
-    assert "ttmg.wait_barrier" not in ttgir, ttgir
 
 
 def _assert_explicit_shared_allocations(allocated, stages):
@@ -771,6 +775,15 @@ def _assert_dot_pipeline_resources(ttir, ttgir, allocated, stages):
     assert "#ttg.swizzled_shared" in ttgir, ttgir
     assert "#ttg.nvmma_shared" not in ttir, ttir
     assert "#ttg.nvmma_shared" not in ttgir, ttgir
+    assert "musa_tle.barrier.wait" not in ttgir, ttgir
+    assert "musa_tle.barrier.arrive" not in ttgir, ttgir
+
+    _, default_region, _ = _extract_ws_regions(ttgir)
+    wait_segments = default_region.split("ttmg.squad_dot_wait")[1:]
+    assert len(wait_segments) == 2 * stages, default_region
+    for segment in wait_segments:
+        before_next_dot = segment.split("ttmg.squad_dot", 1)[0]
+        assert before_next_dot.count("ttmg.warp_arrive_barrier") == 2, before_next_dot
 
     assert ttir.count("ttg.local_alloc") == 2, ttir
     assert f"!ttg.memdesc<{stages}x256x64xf16" in ttir, ttir
@@ -797,6 +810,8 @@ def _assert_dot_pipeline_resources(ttir, ttgir, allocated, stages):
     assert len(sqmma_allocs) == 4 * stages, allocated
     assert "musa_tle.barrier.alloc" not in allocated, allocated
     assert "musa_tle.barrier.index" not in allocated, allocated
+    assert "musa_tle.barrier.wait" not in allocated, allocated
+    assert "musa_tle.barrier.arrive" not in allocated, allocated
     assert allocated.count("ttmg.init_arrival") == 4 * stages, allocated
     assert f"musa.max_bar_id = {4 * stages}" in allocated, allocated
 

--- a/third_party/mthreads/spec/triton/compiler/code_generator.py
+++ b/third_party/mthreads/spec/triton/compiler/code_generator.py
@@ -1355,6 +1355,71 @@ class CodeGenerator(ast.NodeVisitor):
         handles = [call_op.get_result(i) for i in range(call_op.get_num_results())]
         return next(unflatten_ir_values(handles, [callee_ret_type]))
 
+    def inline_JitFunction(self, fn: JITFunction, args, kwargs, caller_context=None):
+        """Inline a JITFunction body into the current insertion block.
+
+        TLE warp-specialize partition regions are isolated from above, so their
+        worker bodies must be materialized directly in the region instead of
+        remaining behind a ``tt.call`` boundary.
+        """
+        bound_args = fn.signature.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+        ordered_args = [bound_args.arguments[name] for name in fn.arg_names]
+        for i, arg in enumerate(ordered_args):
+            if not isinstance(arg, base_value) or isinstance(arg, JITCallable):
+                ordered_args[i] = language.core.constexpr(arg)
+
+        parsed = fn.parse()
+        if isinstance(parsed, ast.Module):
+            if len(parsed.body) != 1 or not isinstance(parsed.body[0], ast.FunctionDef):
+                raise ValueError("inline_JitFunction expects a single function definition")
+            fn_def = parsed.body[0]
+        else:
+            fn_def = parsed
+        if not isinstance(fn_def, ast.FunctionDef):
+            raise ValueError("inline_JitFunction expects a function definition")
+
+        mapped_gscope = {}
+        for key, value in fn.get_capture_scope().items():
+            if isinstance(value, ModuleType):
+                mapped_gscope[key] = self.builder.module_map.get(value.__name__, value)
+                continue
+            module_name = getattr(value, "__module__", "")
+            if module_name in self.builder.module_map:
+                mapped_gscope[key] = getattr(self.builder.module_map[module_name], value.__name__)
+            else:
+                mapped_gscope[key] = value
+
+        prev_gscope = self.gscope
+        prev_lscope = self.lscope
+        prev_defs = self.local_defs
+        prev_caller_context = self.caller_context
+        try:
+            self.gscope = mapped_gscope
+            self.lscope = {}
+            self.local_defs = {}
+            self.caller_context = caller_context or self.caller_context
+            for arg_name, arg_value in zip(fn.arg_names, ordered_args):
+                self.set_value(arg_name, arg_value)
+
+            def decay_return(value):
+                if isinstance(value, language.tuple):
+                    return _apply_to_tuple_values(value, decay_return)
+                if isinstance(value, (language.constexpr, int, float)):
+                    return self.semantic.to_tensor(value)
+                return value
+
+            for stmt in fn_def.body:
+                if isinstance(stmt, ast.Return):
+                    return decay_return(self.visit(stmt.value)) if stmt.value is not None else None
+                self.visit(stmt)
+            return None
+        finally:
+            self.gscope = prev_gscope
+            self.lscope = prev_lscope
+            self.local_defs = prev_defs
+            self.caller_context = prev_caller_context
+
     def call_Function(self, node, fn, args, kws):
         if isinstance(fn, (BoundJITMethod, BoundConstexprFunction)):
             args.insert(0, fn.__self__)

--- a/third_party/mthreads/tle/dialect/include/Dialect/MUSATLE/IR/MUSATLEOps.td
+++ b/third_party/mthreads/tle/dialect/include/Dialect/MUSATLE/IR/MUSATLEOps.td
@@ -4,6 +4,7 @@
 #ifdef __TLE__
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "MUSATLEDialect.td"
+include "triton/Dialect/Triton/IR/TritonAttrDefs.td"
 include "triton/Dialect/Triton/IR/TritonInterfaces.td"
 include "triton/Dialect/Triton/IR/TritonTypes.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUTypes.td"
@@ -93,6 +94,39 @@ def MUSATLE_ExclusiveCumsumOp
   let arguments = (ins TT_Tensor:$src, I32Attr:$axis, BoolAttr:$reverse);
   let results = (outs TT_Tensor:$exclusive, TT_Type:$total);
   let assemblyFormat = "$src attr-dict `:` type($src) `->` type($exclusive) `,` type($total)";
+  let hasVerifier = 1;
+}
+
+def MUSATLE_SqmmaOp : MUSATLE_Op<"sqmma", [
+    TypesMatchWith<"result type matches accumulator type", "d", "c", "$_self">
+  ]> {
+  let summary = "MUSA TLE asynchronous SQMMA";
+  let arguments = (ins
+    TTG_MemDescType:$a,
+    TTG_MemDescType:$b,
+    TT_FpIntTensor:$c,
+    DefaultValuedAttr<TT_InputPrecisionAttr,
+                      "::mlir::triton::InputPrecision::IEEE">:$inputPrecision,
+    DefaultValuedAttr<I32Attr, "0">:$maxNumImpreciseAcc,
+    DefaultValuedAttr<BoolAttr, "true">:$isAsync
+  );
+  let results = (outs TT_FpIntTensor:$d);
+  let assemblyFormat = [{
+    $a `,` $b `,` $c attr-dict `:` qualified(type($a)) `*`
+    qualified(type($b)) `,` qualified(type($c)) `->` qualified(type($d))
+  }];
+  let hasVerifier = 1;
+}
+
+def MUSATLE_SqmmaWaitOp : MUSATLE_Op<"sqmma_wait", [
+    TypesMatchWith<"result type matches input type", "output", "input", "$_self">
+  ]> {
+  let summary = "Wait for a MUSA TLE asynchronous SQMMA";
+  let arguments = (ins TT_FpIntTensor:$input, I32Attr:$pendings);
+  let results = (outs TT_FpIntTensor:$output);
+  let assemblyFormat = [{
+    $input attr-dict `:` qualified(type($input)) `->` qualified(type($output))
+  }];
   let hasVerifier = 1;
 }
 #endif // __TLE__

--- a/third_party/mthreads/tle/dialect/include/Dialect/MUSATLE/IR/MUSATLEOps.td
+++ b/third_party/mthreads/tle/dialect/include/Dialect/MUSATLE/IR/MUSATLEOps.td
@@ -22,6 +22,45 @@ def MUSATLE_LocalPointersOp : MUSATLE_Op<"local_pointers", [Pure]> {
   let hasVerifier = 1;
 }
 
+def MUSATLE_BarrierAllocOp : MUSATLE_Op<"barrier.alloc"> {
+  let summary = "declare an mthreads hardware barrier id range";
+  let arguments = (ins
+    I32Attr:$num_barriers,
+    I32Attr:$arrive_count,
+    I32Attr:$init_polarity,
+    OptionalAttr<I32Attr>:$expect_bytes
+  );
+  let results = (outs I32:$base_id);
+  let assemblyFormat = "attr-dict";
+  let hasVerifier = 1;
+}
+
+def MUSATLE_BarrierIndexOp : MUSATLE_Op<"barrier.index", [Pure]> {
+  let summary = "select an mthreads hardware barrier id from a range";
+  let arguments = (ins I32:$base_id, I32:$index);
+  let results = (outs I32:$bar_id);
+  let assemblyFormat = "$base_id `[` $index `]` attr-dict";
+  let hasVerifier = 1;
+}
+
+def MUSATLE_BarrierWaitOp : MUSATLE_Op<"barrier.wait"> {
+  let summary = "wait on an mthreads hardware barrier id";
+  let arguments = (ins I32:$bar_id, I32:$phase);
+  let assemblyFormat = "$bar_id `,` $phase attr-dict";
+  let hasVerifier = 1;
+}
+
+def MUSATLE_BarrierArriveOp : MUSATLE_Op<"barrier.arrive"> {
+  let summary = "arrive on an mthreads hardware barrier id";
+  let arguments = (ins
+    I32:$bar_id,
+    I32:$phase,
+    I32Attr:$arrive_count
+  );
+  let assemblyFormat = "$bar_id `,` $phase attr-dict";
+  let hasVerifier = 1;
+}
+
 def MUSATLE_ExtractTileOp : MUSATLE_Op<"extract_tile", [Pure]> {
   let arguments = (ins TT_Tensor:$src, TT_IntLike:$index,
       DenseI64ArrayAttr:$tile_shape);

--- a/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
+++ b/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
@@ -125,6 +125,40 @@ def TritonMUSAGPUTLELowerPipe
   ];
 }
 
+def TritonMUSAGPUTLEPrepareWarpSpecialize
+    : Pass<"tritonmusa-tle-prepare-warp-specialize", "mlir::ModuleOp"> {
+  let summary = "Validate mthreads TLE static warp specialization";
+  let description = [{
+    Validate the restricted single-producer/single-consumer contract and
+    publish the total launch warp count while retaining ttg.warp_specialize for
+    shared-memory allocation and late LLVM lowering.
+  }];
+  let dependentDialects = [
+    "mlir::triton::TritonDialect",
+    "mlir::triton::gpu::TritonGPUDialect"
+  ];
+}
+
+def TritonMUSAGPUTLELowerWarpSpecialize
+    : Pass<"tritonmusa-tle-lower-warp-specialize", "mlir::ModuleOp"> {
+  let summary = "Late-lower mthreads TLE static warp specialization";
+  let description = [{
+    Lower warp-group barriers directly from the retained default and partition
+    regions, then replace the restricted warp-specialize operation with two
+    independent static CFG branches.  The lowering uses hardware barrier ids
+    and direct SSA captures, so it allocates no control shared memory.
+  }];
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::cf::ControlFlowDialect",
+    "mlir::LLVM::LLVMDialect",
+    "mlir::scf::SCFDialect",
+    "mlir::triton::TritonDialect",
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::musa::MUSADialect"
+  ];
+}
+
 def TritonMUSAGPUTLELowerBarrierAllocations
     : Pass<"tritonmusa-tle-lower-barrier-allocations", "mlir::ModuleOp"> {
   let summary = "Assign MUSA hardware ids to TLE barrier declarations";

--- a/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
+++ b/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
@@ -127,4 +127,20 @@ def TritonMUSAGPUTLELowerTMETransactions
   ];
 }
 
+def TritonMUSAGPUTLELowerBarrierOperations
+    : Pass<"tritonmusa-tle-lower-barrier-operations", "mlir::ModuleOp"> {
+  let summary = "Lower TLE waits and arrivals to MUSA hardware barriers";
+  let description = [{
+    Replace backend-local TLE barrier wait and arrive operations with the
+    corresponding MUSA hardware barrier operations after logical barrier
+    ranges have been assigned physical ids.  Consumer arrivals remain
+    convergent warp-level operations and are deliberately kept separate from
+    the single-issuer TME transaction arrival path.
+  }];
+  let dependentDialects = [
+    "mlir::triton::musa::MUSADialect",
+    "mlir::triton::musa_tle::MUSATLEDialect"
+  ];
+}
+
 #endif // MUSA_TLE_TRANSFORMS_PASSES

--- a/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
+++ b/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
@@ -89,6 +89,24 @@ def TritonMUSAGPUTLELowerExclusiveCumsum
   ];
 }
 
+def TritonMUSAGPUTLELowerSqmma
+    : Pass<"tritonmusa-tle-lower-sqmma", "mlir::ModuleOp"> {
+  let summary = "Lower backend-local MUSA TLE SQMMA operations";
+  let description = [{
+    Infer the PH1 SQMMA accumulator and shared-memory operand layouts, preserve
+    explicit wait boundaries, and lower musa_tle.sqmma/sqmma_wait to the MUSA
+    squad-dot dialect.
+  }];
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::scf::SCFDialect",
+    "mlir::triton::TritonDialect",
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::musa::MUSADialect",
+    "mlir::triton::musa_tle::MUSATLEDialect"
+  ];
+}
+
 def TritonMUSAGPUTLELowerBarrierAllocations
     : Pass<"tritonmusa-tle-lower-barrier-allocations", "mlir::ModuleOp"> {
   let summary = "Assign MUSA hardware ids to TLE barrier declarations";

--- a/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
+++ b/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
@@ -109,4 +109,22 @@ def TritonMUSAGPUTLELowerBarrierAllocations
   ];
 }
 
+def TritonMUSAGPUTLELowerTMETransactions
+    : Pass<"tritonmusa-tle-lower-tme-transactions", "mlir::ModuleOp"> {
+  let summary = "Materialize explicit MUSA TME completion transactions";
+  let description = [{
+    Replace the temporary transaction-byte marker on each explicit TLE
+    completion copy with one barrier add-transaction before the copy and one
+    issuer arrival after it.  Mark all three issue operations with the same raw
+    CTA issuer thread and suppress the legacy CTA-wide synchronization inside
+    explicit-completion TME lowering.
+  }];
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::triton::TritonDialect",
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::musa::MUSADialect"
+  ];
+}
+
 #endif // MUSA_TLE_TRANSFORMS_PASSES

--- a/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
+++ b/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
@@ -95,11 +95,15 @@ def TritonMUSAGPUTLELowerBarrierAllocations
   let description = [{
     Reserve one contiguous MUSA async-barrier range per function, materialize
     hardware initialization records for every declared TLE barrier, and replace
-    logical barrier allocations and indices with i32 hardware ids.
+    logical barrier allocations and indices with i32 hardware ids.  Insert one
+    CTA rendezvous after all initialization records and before every barrier
+    use; for explicit warp specialization this also precedes the first
+    top-level partition split.
   }];
   let dependentDialects = [
     "mlir::arith::ArithDialect",
     "mlir::triton::TritonDialect",
+    "mlir::triton::gpu::TritonGPUDialect",
     "mlir::triton::musa::MUSADialect",
     "mlir::triton::musa_tle::MUSATLEDialect"
   ];

--- a/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
+++ b/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
@@ -89,4 +89,20 @@ def TritonMUSAGPUTLELowerExclusiveCumsum
   ];
 }
 
+def TritonMUSAGPUTLELowerBarrierAllocations
+    : Pass<"tritonmusa-tle-lower-barrier-allocations", "mlir::ModuleOp"> {
+  let summary = "Assign MUSA hardware ids to TLE barrier declarations";
+  let description = [{
+    Reserve one contiguous MUSA async-barrier range per function, materialize
+    hardware initialization records for every declared TLE barrier, and replace
+    logical barrier allocations and indices with i32 hardware ids.
+  }];
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::triton::TritonDialect",
+    "mlir::triton::musa::MUSADialect",
+    "mlir::triton::musa_tle::MUSATLEDialect"
+  ];
+}
+
 #endif // MUSA_TLE_TRANSFORMS_PASSES

--- a/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
+++ b/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
@@ -107,6 +107,24 @@ def TritonMUSAGPUTLELowerSqmma
   ];
 }
 
+def TritonMUSAGPUTLELowerPipe
+    : Pass<"tritonmusa-tle-lower-pipe", "mlir::ModuleOp"> {
+  let summary = "Lower single-field TME SPSC pipes to MUSA barriers";
+  let description = [{
+    Lower the initial mthreads tle.pipe contract: one CTA-scoped cyclic SPSC
+    field produced by one descriptor-to-shared TME transaction.  Materialize
+    independent full and empty hardware-barrier rings, bind TME completion to
+    the full barrier, and reject all unsupported pipe forms before rewriting.
+  }];
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::triton::TritonDialect",
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::musa_tle::MUSATLEDialect",
+    "mlir::triton::tle::TleDialect"
+  ];
+}
+
 def TritonMUSAGPUTLELowerBarrierAllocations
     : Pass<"tritonmusa-tle-lower-barrier-allocations", "mlir::ModuleOp"> {
   let summary = "Assign MUSA hardware ids to TLE barrier declarations";

--- a/third_party/mthreads/tle/dialect/lib/IR/Dialect.cpp
+++ b/third_party/mthreads/tle/dialect/lib/IR/Dialect.cpp
@@ -360,6 +360,52 @@ LogicalResult ExclusiveCumsumOp::verify() {
   return success();
 }
 
+LogicalResult SqmmaOp::verify() {
+  auto aTy = dyn_cast<ttg::MemDescType>(getA().getType());
+  auto bTy = dyn_cast<ttg::MemDescType>(getB().getType());
+  auto cTy = dyn_cast<RankedTensorType>(getC().getType());
+  auto dTy = dyn_cast<RankedTensorType>(getD().getType());
+  if (!aTy || !bTy || !cTy || !dTy)
+    return emitOpError("expects memdesc A/B and ranked tensor accumulator");
+  if (aTy.getRank() != 2 || bTy.getRank() != 2 || cTy.getRank() != 2)
+    return emitOpError("expects rank-2 A, B, and accumulator operands");
+  if (!isa<ttg::SharedMemorySpaceAttr>(aTy.getMemorySpace()) ||
+      !isa<ttg::SharedMemorySpaceAttr>(bTy.getMemorySpace()))
+    return emitOpError("expects A and B in shared memory");
+  Type aElemTy = aTy.getElementType();
+  Type bElemTy = bTy.getElementType();
+  bool supportedInput =
+      aElemTy.isF16() || aElemTy.isBF16() || isa<Float8E4M3FNType>(aElemTy);
+  if (!supportedInput || aElemTy != bElemTy)
+    return emitOpError(
+        "mthreads TLE SQMMA requires matching f16, bf16, or fp8e4nv A/B");
+  if (!cTy.getElementType().isF32() || !dTy.getElementType().isF32())
+    return emitOpError(
+        "initial mthreads TLE SQMMA requires an f32 accumulator/result");
+
+  ArrayRef<int64_t> aShape = aTy.getShape();
+  ArrayRef<int64_t> bShape = bTy.getShape();
+  ArrayRef<int64_t> cShape = cTy.getShape();
+  if (aShape[1] != bShape[0] || cShape[0] != aShape[0] ||
+      cShape[1] != bShape[1])
+    return emitOpError("expects A[M,K] * B[K,N] and accumulator[M,N]");
+  if (!getIsAsync())
+    return emitOpError("requires isAsync=true");
+  if (getMaxNumImpreciseAcc() != 0)
+    return emitOpError(
+        "initial mthreads TLE SQMMA requires maxNumImpreciseAcc=0");
+  return success();
+}
+
+LogicalResult SqmmaWaitOp::verify() {
+  auto pendings = getOperation()->getAttrOfType<IntegerAttr>("pendings");
+  if (!pendings || pendings.getInt() != 0)
+    return emitOpError(
+        "mthreads TLE wgmma_wait currently requires pendings=0; non-zero "
+        "pending groups are not supported");
+  return success();
+}
+
 } // namespace mlir::triton::musa_tle
 
 #endif // __TLE__

--- a/third_party/mthreads/tle/dialect/lib/IR/Dialect.cpp
+++ b/third_party/mthreads/tle/dialect/lib/IR/Dialect.cpp
@@ -281,6 +281,50 @@ LogicalResult LocalPointersOp::verify() {
   return success();
 }
 
+LogicalResult BarrierAllocOp::verify() {
+  if (getNumBarriers() <= 0)
+    return emitOpError("num_barriers must be positive");
+  if (getNumBarriers() > 63)
+    return emitOpError("num_barriers exceeds the 63 mthreads hardware "
+                       "barrier id limit");
+  if (getArriveCount() <= 0)
+    return emitOpError("arrive_count must be positive");
+  if (getInitPolarity() != 0 && getInitPolarity() != 1)
+    return emitOpError("init_polarity must be 0 or 1");
+  if (auto expectBytes =
+          getOperation()->getAttrOfType<IntegerAttr>("expect_bytes")) {
+    if (expectBytes.getInt() <= 0)
+      return emitOpError("expect_bytes must be positive when present");
+  }
+  return success();
+}
+
+LogicalResult BarrierIndexOp::verify() {
+  APInt constantIndex;
+  if (!matchPattern(getIndex(), m_ConstantInt(&constantIndex)))
+    return success();
+
+  int64_t index = constantIndex.getSExtValue();
+  if (index < 0)
+    return emitOpError("barrier index must be non-negative when constant");
+
+  if (auto alloc = getBaseId().getDefiningOp<BarrierAllocOp>()) {
+    if (index >= alloc.getNumBarriers())
+      return emitOpError("barrier index ")
+             << index << " out of bounds for " << alloc.getNumBarriers()
+             << " barriers";
+  }
+  return success();
+}
+
+LogicalResult BarrierWaitOp::verify() { return success(); }
+
+LogicalResult BarrierArriveOp::verify() {
+  if (getArriveCount() <= 0)
+    return emitOpError("arrive_count must be positive");
+  return success();
+}
+
 LogicalResult ExclusiveCumsumOp::verify() {
   auto srcTy = dyn_cast<RankedTensorType>(getSrc().getType());
   if (!srcTy)

--- a/third_party/mthreads/tle/dialect/lib/IR/Dialect.cpp
+++ b/third_party/mthreads/tle/dialect/lib/IR/Dialect.cpp
@@ -320,8 +320,9 @@ LogicalResult BarrierIndexOp::verify() {
 LogicalResult BarrierWaitOp::verify() { return success(); }
 
 LogicalResult BarrierArriveOp::verify() {
-  if (getArriveCount() <= 0)
-    return emitOpError("arrive_count must be positive");
+  if (getArriveCount() != 1)
+    return emitOpError(
+        "mthreads hardware barrier arrive requires arrive_count = 1");
   return success();
 }
 

--- a/third_party/mthreads/tle/dialect/lib/Transforms/CMakeLists.txt
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(MUSATLETransforms
   LowerBarrierAllocations.cpp
   LowerBarrierOperations.cpp
   LowerExclusiveCumsum.cpp
+  LowerPipe.cpp
   LowerSqmma.cpp
   LowerTMETransactions.cpp
   OptimizeLocalPointerAsyncStores.cpp
@@ -17,6 +18,7 @@ add_triton_library(MUSATLETransforms
   LINK_LIBS PUBLIC
   MUSATLEIR
   MUSAIR
+  TleIR
   TritonIR
   TritonGPUIR
   TritonGPUTransforms

--- a/third_party/mthreads/tle/dialect/lib/Transforms/CMakeLists.txt
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_triton_library(MUSATLETransforms
   InsertLocalPointerBarriers.cpp
+  LowerBarrierAllocations.cpp
   LowerExclusiveCumsum.cpp
   OptimizeLocalPointerAsyncStores.cpp
   OptimizeLocalPointerLoads.cpp
@@ -12,6 +13,7 @@ add_triton_library(MUSATLETransforms
 
   LINK_LIBS PUBLIC
   MUSATLEIR
+  MUSAIR
   TritonIR
   TritonGPUIR
   TritonGPUTransforms

--- a/third_party/mthreads/tle/dialect/lib/Transforms/CMakeLists.txt
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(MUSATLETransforms
   LowerBarrierAllocations.cpp
   LowerBarrierOperations.cpp
   LowerExclusiveCumsum.cpp
+  LowerSqmma.cpp
   LowerTMETransactions.cpp
   OptimizeLocalPointerAsyncStores.cpp
   OptimizeLocalPointerLoads.cpp

--- a/third_party/mthreads/tle/dialect/lib/Transforms/CMakeLists.txt
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_triton_library(MUSATLETransforms
   InsertLocalPointerBarriers.cpp
   LowerBarrierAllocations.cpp
+  LowerBarrierOperations.cpp
   LowerExclusiveCumsum.cpp
   LowerTMETransactions.cpp
   OptimizeLocalPointerAsyncStores.cpp

--- a/third_party/mthreads/tle/dialect/lib/Transforms/CMakeLists.txt
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/CMakeLists.txt
@@ -6,6 +6,8 @@ add_triton_library(MUSATLETransforms
   LowerPipe.cpp
   LowerSqmma.cpp
   LowerTMETransactions.cpp
+  LowerWarpSpecialize.cpp
+  LowerWarpSpecializeToLLVM.cpp
   OptimizeLocalPointerAsyncStores.cpp
   OptimizeLocalPointerLoads.cpp
   OptimizeLocalPointerStores.cpp

--- a/third_party/mthreads/tle/dialect/lib/Transforms/CMakeLists.txt
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_triton_library(MUSATLETransforms
   InsertLocalPointerBarriers.cpp
   LowerBarrierAllocations.cpp
   LowerExclusiveCumsum.cpp
+  LowerTMETransactions.cpp
   OptimizeLocalPointerAsyncStores.cpp
   OptimizeLocalPointerLoads.cpp
   OptimizeLocalPointerStores.cpp

--- a/third_party/mthreads/tle/dialect/lib/Transforms/LowerBarrierAllocations.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/LowerBarrierAllocations.cpp
@@ -1,0 +1,125 @@
+#ifdef __TLE__
+
+#include "Dialect/MUSA/IR/Dialect.h"
+#include "Dialect/MUSATLE/IR/Dialect.h"
+#include "TritonMUSACommon/BarrierUtils.h"
+#include "TritonMUSAGPUTransforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include <cstdint>
+#include <limits>
+
+namespace mlir {
+
+#define GEN_PASS_DEF_TRITONMUSAGPUTLELOWERBARRIERALLOCATIONS
+#include "TritonMUSAGPUTransforms/Passes.h.inc"
+
+namespace {
+
+using triton::musa_tle::BarrierAllocOp;
+using triton::musa_tle::BarrierIndexOp;
+
+static constexpr StringLiteral kExhaustedDiagnostic =
+    "mthreads TLE barrier allocation exhausted hardware barrier ids";
+
+class LowerBarrierAllocationsPass
+    : public impl::TritonMUSAGPUTLELowerBarrierAllocationsBase<
+          LowerBarrierAllocationsPass> {
+  LogicalResult lowerFunction(triton::FuncOp func, IRRewriter &rewriter) {
+    SmallVector<BarrierAllocOp> allocs;
+    func.walk([&](BarrierAllocOp op) { allocs.push_back(op); });
+    if (allocs.empty())
+      return success();
+
+    int64_t totalBarriers = 0;
+    for (BarrierAllocOp alloc : allocs) {
+      totalBarriers += alloc.getNumBarriers();
+      if (totalBarriers > std::numeric_limits<int32_t>::max())
+        break;
+    }
+
+    if (totalBarriers <= 0 ||
+        totalBarriers > std::numeric_limits<int32_t>::max()) {
+      allocs.front().emitOpError()
+          << kExhaustedDiagnostic << ": cannot reserve " << totalBarriers
+          << " additional ids in [1, " << triton::musa::kMaxBarrierId << "]";
+      return failure();
+    }
+
+    auto reserved = triton::musa::reserveBarrierIdRange(
+        allocs.front(), static_cast<int32_t>(totalBarriers));
+    if (failed(reserved)) {
+      allocs.front().emitOpError()
+          << kExhaustedDiagnostic << ": cannot reserve " << totalBarriers
+          << " additional ids in [1, " << triton::musa::kMaxBarrierId << "]";
+      return failure();
+    }
+
+    SmallVector<BarrierIndexOp> indices;
+    func.walk([&](BarrierIndexOp op) { indices.push_back(op); });
+
+    int32_t nextBase = *reserved;
+    for (BarrierAllocOp alloc : allocs) {
+      Location loc = alloc.getLoc();
+      rewriter.setInsertionPoint(alloc);
+      Value base = arith::ConstantIntOp::create(rewriter, loc, nextBase, 32);
+      Value arriveCount = arith::ConstantIntOp::create(
+          rewriter, loc, alloc.getArriveCount(), 32);
+      Value initPolarity = arith::ConstantIntOp::create(
+          rewriter, loc, alloc.getInitPolarity(), 32);
+
+      for (int32_t slot = 0; slot < alloc.getNumBarriers(); ++slot) {
+        Value barId =
+            arith::ConstantIntOp::create(rewriter, loc, nextBase + slot, 32);
+        triton::musa::InitArrivalOp::create(rewriter, loc, barId, arriveCount,
+                                            initPolarity);
+      }
+
+      rewriter.replaceAllUsesWith(alloc.getBaseId(), base);
+      rewriter.eraseOp(alloc);
+      nextBase += alloc.getNumBarriers();
+    }
+
+    for (BarrierIndexOp index : indices) {
+      if (!index)
+        continue;
+      rewriter.setInsertionPoint(index);
+      APInt baseValue;
+      APInt indexValue;
+      Value physicalId;
+      if (matchPattern(index.getBaseId(), m_ConstantInt(&baseValue)) &&
+          matchPattern(index.getIndex(), m_ConstantInt(&indexValue))) {
+        physicalId = arith::ConstantIntOp::create(
+            rewriter, index.getLoc(),
+            baseValue.getSExtValue() + indexValue.getSExtValue(), 32);
+      } else {
+        physicalId = arith::AddIOp::create(rewriter, index.getLoc(),
+                                           index.getBaseId(), index.getIndex());
+      }
+      rewriter.replaceOp(index, physicalId);
+    }
+
+    return success();
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    IRRewriter rewriter(&getContext());
+    for (triton::FuncOp func : module.getOps<triton::FuncOp>()) {
+      if (failed(lowerFunction(func, rewriter))) {
+        signalPassFailure();
+        return;
+      }
+    }
+  }
+};
+
+} // namespace
+} // namespace mlir
+
+#endif // __TLE__

--- a/third_party/mthreads/tle/dialect/lib/Transforms/LowerBarrierAllocations.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/LowerBarrierAllocations.cpp
@@ -129,8 +129,7 @@ class LowerBarrierAllocationsPass
       Value base = arith::ConstantIntOp::create(rewriter, loc, nextBase, 32);
       Value arriveCount = arith::ConstantIntOp::create(
           rewriter, loc, alloc.getArriveCount(), 32);
-      Value initPolarity = arith::ConstantIntOp::create(
-          rewriter, loc, alloc.getInitPolarity(), 32);
+      Value initPolarity = arith::ConstantIntOp::create(rewriter, loc, 0, 32);
 
       for (int32_t slot = 0; slot < alloc.getNumBarriers(); ++slot) {
         Value barId =

--- a/third_party/mthreads/tle/dialect/lib/Transforms/LowerBarrierAllocations.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/LowerBarrierAllocations.cpp
@@ -7,8 +7,10 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Dominance.h"
 #include "mlir/IR/PatternMatch.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 #include "llvm/ADT/SmallVector.h"
 #include <cstdint>
@@ -23,6 +25,7 @@ namespace {
 
 using triton::musa_tle::BarrierAllocOp;
 using triton::musa_tle::BarrierIndexOp;
+namespace ttg = triton::gpu;
 
 static constexpr StringLiteral kExhaustedDiagnostic =
     "mthreads TLE barrier allocation exhausted hardware barrier ids";
@@ -35,6 +38,61 @@ class LowerBarrierAllocationsPass
     func.walk([&](BarrierAllocOp op) { allocs.push_back(op); });
     if (allocs.empty())
       return success();
+
+    Block &entry = func.getBody().front();
+    SmallVector<BarrierAllocOp> entryAllocs;
+    for (Operation &op : entry) {
+      if (auto alloc = dyn_cast<BarrierAllocOp>(op))
+        entryAllocs.push_back(alloc);
+    }
+    if (entryAllocs.size() != allocs.size()) {
+      auto nested = llvm::find_if(allocs, [&](BarrierAllocOp alloc) {
+        return alloc->getBlock() != &entry;
+      });
+      return nested->emitOpError(
+          "mthreads TLE barrier initialization requires allocations in the "
+          "function entry block");
+    }
+    allocs = std::move(entryAllocs);
+
+    ttg::WarpSpecializeOp warpSpecialize;
+    bool hasWarpSpecialize = false;
+    func.walk([&](ttg::WarpSpecializeOp) { hasWarpSpecialize = true; });
+    for (Operation &op : entry) {
+      if (auto ws = dyn_cast<ttg::WarpSpecializeOp>(op)) {
+        warpSpecialize = ws;
+        break;
+      }
+    }
+
+    if (hasWarpSpecialize) {
+      if (!warpSpecialize) {
+        return allocs.front().emitOpError(
+            "mthreads TLE barrier initialization for warp_specialize requires "
+            "a top-level warp_specialize in the function entry block");
+      }
+      for (BarrierAllocOp alloc : allocs) {
+        if (alloc->getBlock() != &entry ||
+            !alloc->isBeforeInBlock(warpSpecialize)) {
+          return alloc.emitOpError(
+              "mthreads TLE barrier initialization for warp_specialize "
+              "requires barrier allocations in the function entry block "
+              "before the first top-level warp_specialize");
+        }
+      }
+    }
+
+    BarrierAllocOp lastAlloc = allocs.back();
+    DominanceInfo dominance(func);
+    for (BarrierAllocOp alloc : allocs) {
+      for (Operation *user : alloc.getBaseId().getUsers()) {
+        if (!dominance.dominates(lastAlloc.getOperation(), user)) {
+          return alloc.emitOpError(
+              "mthreads TLE barrier initialization requires all allocations "
+              "before the first barrier use");
+        }
+      }
+    }
 
     int64_t totalBarriers = 0;
     for (BarrierAllocOp alloc : allocs) {
@@ -63,6 +121,7 @@ class LowerBarrierAllocationsPass
     SmallVector<BarrierIndexOp> indices;
     func.walk([&](BarrierIndexOp op) { indices.push_back(op); });
 
+    Operation *lastInitArrival = nullptr;
     int32_t nextBase = *reserved;
     for (BarrierAllocOp alloc : allocs) {
       Location loc = alloc.getLoc();
@@ -76,14 +135,19 @@ class LowerBarrierAllocationsPass
       for (int32_t slot = 0; slot < alloc.getNumBarriers(); ++slot) {
         Value barId =
             arith::ConstantIntOp::create(rewriter, loc, nextBase + slot, 32);
-        triton::musa::InitArrivalOp::create(rewriter, loc, barId, arriveCount,
-                                            initPolarity);
+        lastInitArrival = triton::musa::InitArrivalOp::create(
+            rewriter, loc, barId, arriveCount, initPolarity);
       }
 
       rewriter.replaceAllUsesWith(alloc.getBaseId(), base);
       rewriter.eraseOp(alloc);
       nextBase += alloc.getNumBarriers();
     }
+
+    assert(lastInitArrival && "positive barrier allocations must initialize");
+    rewriter.setInsertionPointAfter(lastInitArrival);
+    ttg::BarrierOp::create(rewriter, lastInitArrival->getLoc(),
+                           ttg::AddrSpace::Local);
 
     for (BarrierIndexOp index : indices) {
       if (!index)

--- a/third_party/mthreads/tle/dialect/lib/Transforms/LowerBarrierAllocations.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/LowerBarrierAllocations.cpp
@@ -8,10 +8,13 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Dominance.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/IR/PatternMatch.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
+#include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include <cstdint>
 #include <limits>
@@ -123,10 +126,12 @@ class LowerBarrierAllocationsPass
 
     Operation *lastInitArrival = nullptr;
     int32_t nextBase = *reserved;
+    SmallVector<Value> loweredBases;
     for (BarrierAllocOp alloc : allocs) {
       Location loc = alloc.getLoc();
       rewriter.setInsertionPoint(alloc);
       Value base = arith::ConstantIntOp::create(rewriter, loc, nextBase, 32);
+      loweredBases.push_back(base);
       Value arriveCount = arith::ConstantIntOp::create(
           rewriter, loc, alloc.getArriveCount(), 32);
       Value initPolarity = arith::ConstantIntOp::create(rewriter, loc, 0, 32);
@@ -165,6 +170,40 @@ class LowerBarrierAllocationsPass
                                            index.getBaseId(), index.getIndex());
       }
       rewriter.replaceOp(index, physicalId);
+    }
+
+    // A hardware barrier is identified by an i32 resource ID and does not
+    // require shared-memory storage. Pipe lowering may need to carry the base
+    // ID into an isolated warp-specialize producer region before IDs are
+    // assigned. Once allocation has resolved the base to an arith.constant,
+    // rematerialize that constant in each partition and remove only those
+    // barrier-ID captures. This prevents the generic WS capture mailbox from
+    // charging shared memory for hardware barrier IDs.
+    SmallVector<ttg::WarpSpecializePartitionsOp> partitionContainers;
+    func.walk([&](ttg::WarpSpecializePartitionsOp partitions) {
+      partitionContainers.push_back(partitions);
+    });
+    for (ttg::WarpSpecializePartitionsOp partitions : partitionContainers) {
+      llvm::BitVector eraseCaptures(partitions.getNumOperands());
+      for (auto [index, capture] :
+           llvm::enumerate(partitions.getExplicitCaptures())) {
+        if (!llvm::is_contained(loweredBases, capture))
+          continue;
+        Operation *constant = capture.getDefiningOp();
+        assert(isa_and_nonnull<arith::ConstantIntOp>(constant));
+        for (Region &partition : partitions.getPartitionRegions()) {
+          rewriter.setInsertionPointToStart(&partition.front());
+          IRMapping mapping;
+          Operation *clone = rewriter.clone(*constant, mapping);
+          partition.getArgument(index).replaceAllUsesWith(clone->getResult(0));
+        }
+        eraseCaptures.set(index);
+      }
+      if (eraseCaptures.none())
+        continue;
+      for (Region &partition : partitions.getPartitionRegions())
+        partition.front().eraseArguments(eraseCaptures);
+      partitions->eraseOperands(eraseCaptures);
     }
 
     return success();

--- a/third_party/mthreads/tle/dialect/lib/Transforms/LowerBarrierOperations.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/LowerBarrierOperations.cpp
@@ -1,0 +1,60 @@
+#ifdef __TLE__
+
+#include "Dialect/MUSA/IR/Dialect.h"
+#include "Dialect/MUSATLE/IR/Dialect.h"
+#include "TritonMUSAGPUTransforms/Passes.h"
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir {
+
+#define GEN_PASS_DEF_TRITONMUSAGPUTLELOWERBARRIEROPERATIONS
+#include "TritonMUSAGPUTransforms/Passes.h.inc"
+
+namespace {
+
+namespace ttmg = triton::musa;
+namespace musa_tle = triton::musa_tle;
+
+class LowerBarrierOperationsPass
+    : public impl::TritonMUSAGPUTLELowerBarrierOperationsBase<
+          LowerBarrierOperationsPass> {
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    IRRewriter rewriter(&getContext());
+
+    SmallVector<musa_tle::BarrierWaitOp> waits;
+    SmallVector<musa_tle::BarrierArriveOp> arrivals;
+    module.walk([&](musa_tle::BarrierWaitOp op) { waits.push_back(op); });
+    module.walk([&](musa_tle::BarrierArriveOp op) { arrivals.push_back(op); });
+
+    for (musa_tle::BarrierWaitOp wait : waits) {
+      rewriter.setInsertionPoint(wait);
+      auto lowered = ttmg::WaitBarrierOp::create(
+          rewriter, wait.getLoc(), wait.getBarId(), wait.getPhase());
+      lowered->setDiscardableAttrs(wait->getDiscardableAttrDictionary());
+      rewriter.eraseOp(wait);
+    }
+
+    for (musa_tle::BarrierArriveOp arrive : arrivals) {
+      if (arrive.getArriveCount() != 1) {
+        arrive.emitOpError(
+            "mthreads hardware barrier arrive requires arrive_count = 1");
+        signalPassFailure();
+        return;
+      }
+
+      rewriter.setInsertionPoint(arrive);
+      auto lowered = ttmg::WarpArriveBarrierOp::create(
+          rewriter, arrive.getLoc(), arrive.getBarId(), arrive.getPhase());
+      lowered->setDiscardableAttrs(arrive->getDiscardableAttrDictionary());
+      rewriter.eraseOp(arrive);
+    }
+  }
+};
+
+} // namespace
+} // namespace mlir
+
+#endif // __TLE__

--- a/third_party/mthreads/tle/dialect/lib/Transforms/LowerPipe.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/LowerPipe.cpp
@@ -1,0 +1,562 @@
+#ifdef __TLE__
+
+#include "Dialect/MUSATLE/IR/Dialect.h"
+#include "TritonMUSAGPUTransforms/Passes.h"
+#include "tle/dialect/include/IR/Dialect.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <optional>
+#include <string>
+
+namespace mlir {
+
+#define GEN_PASS_DEF_TRITONMUSAGPUTLELOWERPIPE
+#include "TritonMUSAGPUTransforms/Passes.h.inc"
+
+namespace {
+
+namespace tt = triton;
+namespace ttg = triton::gpu;
+namespace tle = triton::tle;
+namespace musa_tle = triton::musa_tle;
+
+static int64_t getCapacity(Operation *op) {
+  return op->getAttrOfType<IntegerAttr>("capacity").getInt();
+}
+
+static OperandRange getFields(Operation *op) {
+  if (auto pipe = dyn_cast<tle::PipeCreateOp>(op))
+    return pipe.getFields();
+  if (auto pipe = dyn_cast<tle::PipeWriterAcquireOp>(op))
+    return pipe.getFields();
+  if (auto pipe = dyn_cast<tle::PipeWriterCommitOp>(op))
+    return pipe.getFields();
+  if (auto pipe = dyn_cast<tle::PipeWriterCloseOp>(op))
+    return pipe.getFields();
+  if (auto pipe = dyn_cast<tle::PipeReaderWaitOp>(op))
+    return pipe.getFields();
+  return cast<tle::PipeReaderReleaseOp>(op).getFields();
+}
+
+static bool isPipeOp(Operation *op) {
+  return isa<tle::PipeCreateOp, tle::PipeWriterAcquireOp,
+             tle::PipeWriterCommitOp, tle::PipeWriterCloseOp,
+             tle::PipeReaderWaitOp, tle::PipeReaderReleaseOp>(op);
+}
+
+static Value canonicalizePipeField(Value field) {
+  while (auto blockArg = dyn_cast<BlockArgument>(field)) {
+    Block *block = blockArg.getOwner();
+    auto partitions =
+        dyn_cast_or_null<ttg::WarpSpecializePartitionsOp>(block->getParentOp());
+    if (!partitions)
+      break;
+    auto ws = dyn_cast<ttg::WarpSpecializeOp>(partitions->getParentOp());
+    if (!ws ||
+        blockArg.getArgNumber() >= partitions.getExplicitCaptures().size())
+      break;
+    field = partitions.getExplicitCaptures()[blockArg.getArgNumber()];
+  }
+  return field;
+}
+
+static Value getMemDescRoot(Value value) {
+  Value current = canonicalizePipeField(value);
+  while (true) {
+    if (auto index = current.getDefiningOp<ttg::MemDescIndexOp>()) {
+      current = canonicalizePipeField(index.getSrc());
+      continue;
+    }
+    if (auto subslice = current.getDefiningOp<ttg::MemDescSubsliceOp>()) {
+      current = canonicalizePipeField(subslice.getSrc());
+      continue;
+    }
+    return current;
+  }
+}
+
+static std::string getPipeKey(Operation *op) {
+  std::string key;
+  llvm::raw_string_ostream os(key);
+  os << getCapacity(op) << "|";
+  op->getAttr("scope").print(os);
+  os << "|";
+  if (Attribute name = op->getAttr("pipe_name"))
+    name.print(os);
+  os << "|";
+  op->getAttr("field_names").print(os);
+  os << "|";
+  for (Value field : getFields(op))
+    os << getMemDescRoot(field).getAsOpaquePointer() << ",";
+  return key;
+}
+
+static bool sameIndex(Value lhs, Value rhs) {
+  if (lhs == rhs)
+    return true;
+  APInt lhsValue;
+  APInt rhsValue;
+  return matchPattern(lhs, m_ConstantInt(&lhsValue)) &&
+         matchPattern(rhs, m_ConstantInt(&rhsValue)) && lhsValue == rhsValue;
+}
+
+enum class PipeRole { None, DefaultConsumer, Producer, OtherPartition };
+
+static PipeRole getPipeRole(Operation *op) {
+  for (Region *region = op->getParentRegion(); region;) {
+    Operation *parent = region->getParentOp();
+    if (!parent)
+      break;
+    if (auto ws = dyn_cast<ttg::WarpSpecializeOp>(parent)) {
+      if (region == &ws.getDefaultRegion())
+        return PipeRole::DefaultConsumer;
+    }
+    if (auto partitions = dyn_cast<ttg::WarpSpecializePartitionsOp>(parent)) {
+      for (auto [index, partition] : llvm::enumerate(partitions.getRegions())) {
+        if (region == partition)
+          return index == 0 ? PipeRole::Producer : PipeRole::OtherPartition;
+      }
+    }
+    region = parent->getParentRegion();
+  }
+  return PipeRole::None;
+}
+
+static std::optional<std::pair<ttg::WarpSpecializeOp, Region *>>
+getEnclosingPartition(Operation *op) {
+  for (Region *region = op->getParentRegion(); region;) {
+    Operation *parent = region->getParentOp();
+    if (!parent)
+      break;
+    if (auto partitions = dyn_cast<ttg::WarpSpecializePartitionsOp>(parent))
+      return std::make_pair(
+          cast<ttg::WarpSpecializeOp>(partitions->getParentOp()), region);
+    region = parent->getParentRegion();
+  }
+  return std::nullopt;
+}
+
+static bool isDefinedInside(Value value, Region *region) {
+  if (auto blockArg = dyn_cast<BlockArgument>(value))
+    return region->isAncestor(blockArg.getOwner()->getParent());
+  Operation *def = value.getDefiningOp();
+  return def && region->isAncestor(def->getParentRegion());
+}
+
+static Value captureForUse(Operation *use, Value value) {
+  auto partition = getEnclosingPartition(use);
+  if (!partition || isDefinedInside(value, partition->second))
+    return value;
+
+  ttg::WarpSpecializeOp ws = partition->first;
+  ttg::WarpSpecializePartitionsOp partitions = ws.getPartitionOp();
+  Region *region = partition->second;
+  for (auto [index, capture] :
+       llvm::enumerate(partitions.getExplicitCaptures())) {
+    if (capture == value)
+      return region->getArgument(index);
+  }
+
+  partitions->insertOperands(partitions->getNumOperands(), value);
+  unsigned captureIndex = partitions->getNumOperands() - 1;
+  for (Region *partitionRegion : ws.getPartitionRegions())
+    partitionRegion->addArgument(value.getType(), value.getLoc());
+  return region->getArgument(captureIndex);
+}
+
+static LogicalResult verifyCommonContract(Operation *op) {
+  if (getCapacity(op) <= 0)
+    return op->emitOpError("requires positive capacity");
+  auto scope = op->getAttrOfType<StringAttr>("scope");
+  if (!scope || scope.getValue() != "cta")
+    return op->emitOpError(
+        "initial mthreads tle.pipe supports only scope='cta'");
+  if (getFields(op).size() != 1)
+    return op->emitOpError(
+        "initial mthreads tle.pipe requires exactly one payload field");
+  auto fieldNames = op->getAttrOfType<ArrayAttr>("field_names");
+  if (!fieldNames || fieldNames.size() != 1)
+    return op->emitOpError(
+        "initial mthreads tle.pipe requires exactly one field name");
+  if (op->getAttr("reader_name"))
+    return op->emitOpError(
+        "initial mthreads tle.pipe supports only the default SPSC reader");
+  return success();
+}
+
+static FailureOr<int32_t> getConsumerWarps(Operation *op) {
+  int warps = ttg::lookupNumWarps(op);
+  if (warps <= 0 || warps > std::numeric_limits<int32_t>::max()) {
+    op->emitOpError("requires a positive consumer warp count");
+    return failure();
+  }
+  return static_cast<int32_t>(warps);
+}
+
+static FailureOr<int32_t> getTransactionBytes(ttg::TMACopyOp copy) {
+  auto descTy = dyn_cast<tt::TensorDescType>(copy.getSrc().getType());
+  auto memDescTy = dyn_cast<ttg::MemDescType>(copy.getDst().getType());
+  if (!descTy || !memDescTy) {
+    copy.emitOpError("initial mthreads tle.pipe requires a tensor-descriptor "
+                     "to shared-memory TME copy");
+    return failure();
+  }
+  auto blockTy = descTy.getSignlessBlockType();
+  if (blockTy.getShape() != memDescTy.getShape() ||
+      blockTy.getElementType() != memDescTy.getElementType()) {
+    copy.emitOpError("pipe TME descriptor block must match the destination "
+                     "slot shape and element type");
+    return failure();
+  }
+
+  int64_t elements = 1;
+  for (int64_t dim : blockTy.getShape()) {
+    if (dim <= 0 || elements > std::numeric_limits<int64_t>::max() / dim) {
+      copy.emitOpError("cannot infer a positive static TME transaction size");
+      return failure();
+    }
+    elements *= dim;
+  }
+  unsigned bitWidth = blockTy.getElementType().getIntOrFloatBitWidth();
+  if (bitWidth == 0 ||
+      elements > std::numeric_limits<int64_t>::max() / bitWidth ||
+      (elements * bitWidth) % 8 != 0) {
+    copy.emitOpError("TME transaction size must be a whole number of bytes");
+    return failure();
+  }
+  int64_t bytes = elements * bitWidth / 8;
+  if (bytes <= 0 || bytes > std::numeric_limits<int32_t>::max()) {
+    copy.emitOpError("TME transaction bytes exceed the positive i32 range");
+    return failure();
+  }
+  return static_cast<int32_t>(bytes);
+}
+
+static bool isExactSlot(Value destination, Value fieldRoot, Value stage) {
+  auto index = destination.getDefiningOp<ttg::MemDescIndexOp>();
+  return index && getMemDescRoot(index.getSrc()) == fieldRoot &&
+         sameIndex(index.getIndex(), stage);
+}
+
+struct PipeState {
+  tle::PipeCreateOp create;
+  Value fieldRoot;
+  int32_t capacity = 0;
+  int32_t transactionBytes = -1;
+  int32_t consumerWarps = -1;
+  std::optional<bool> warpSpecialized;
+  Value fullBase;
+  Value emptyBase;
+  SmallVector<tle::PipeWriterAcquireOp> acquires;
+  SmallVector<tle::PipeWriterCommitOp> commits;
+  SmallVector<tle::PipeReaderWaitOp> waits;
+  SmallVector<tle::PipeReaderReleaseOp> releases;
+};
+
+static LogicalResult recordExecutionMode(PipeState &state, Operation *op,
+                                         PipeRole actualRole,
+                                         PipeRole warpSpecializedRole,
+                                         StringRef endpoint) {
+  if (actualRole != PipeRole::None && actualRole != warpSpecializedRole)
+    return op->emitOpError()
+           << "requires " << endpoint
+           << " operations either outside warp_specialize or in the "
+           << (warpSpecializedRole == PipeRole::Producer ? "worker partition 0"
+                                                         : "default partition");
+
+  bool usesWarpSpecialize = actualRole == warpSpecializedRole;
+  if (state.warpSpecialized && *state.warpSpecialized != usesWarpSpecialize)
+    return op->emitOpError(
+        "cannot mix warp-specialized and non-warp-specialized endpoints on "
+        "one pipe");
+  state.warpSpecialized = usesWarpSpecialize;
+  return success();
+}
+
+class LowerPipePass
+    : public impl::TritonMUSAGPUTLELowerPipeBase<LowerPipePass> {
+  LogicalResult analyze(ModuleOp module,
+                        std::map<std::string, PipeState> &pipes,
+                        DenseMap<Operation *, ttg::TMACopyOp> &commitCopies) {
+    SmallVector<Operation *> pipeOps;
+    module.walk([&](Operation *op) {
+      if (isPipeOp(op))
+        pipeOps.push_back(op);
+    });
+
+    for (Operation *op : pipeOps) {
+      if (failed(verifyCommonContract(op)))
+        return failure();
+      std::string key = getPipeKey(op);
+
+      if (auto create = dyn_cast<tle::PipeCreateOp>(op)) {
+        if (create->getAttrOfType<ArrayAttr>("readers"))
+          return create.emitOpError(
+              "initial mthreads tle.pipe does not support named readers");
+        if (auto oneShot = create->getAttrOfType<BoolAttr>("one_shot");
+            oneShot && oneShot.getValue())
+          return create.emitOpError(
+              "initial mthreads tle.pipe does not support one_shot=True");
+        if (!create->getParentOfType<tt::FuncOp>() ||
+            create->getParentOfType<ttg::WarpSpecializeOp>())
+          return create.emitOpError(
+              "requires pipe.create outside warp_specialize");
+        if (pipes.find(key) != pipes.end())
+          return create.emitOpError("duplicates an existing pipe identity");
+        pipes.emplace(key,
+                      PipeState{create, getMemDescRoot(create.getFields()[0]),
+                                static_cast<int32_t>(getCapacity(op))});
+        continue;
+      }
+
+      auto it = pipes.find(key);
+      if (it == pipes.end())
+        return op->emitOpError("requires a preceding matching pipe.create");
+      PipeState &state = it->second;
+
+      if (auto close = dyn_cast<tle::PipeWriterCloseOp>(op))
+        return close.emitOpError(
+            "initial mthreads tle.pipe does not support writer.close");
+      if (auto acquire = dyn_cast<tle::PipeWriterAcquireOp>(op)) {
+        if (failed(recordExecutionMode(state, op, getPipeRole(op),
+                                       PipeRole::Producer, "writer")))
+          return failure();
+        state.acquires.push_back(acquire);
+        continue;
+      }
+      if (auto commit = dyn_cast<tle::PipeWriterCommitOp>(op)) {
+        if (failed(recordExecutionMode(state, op, getPipeRole(op),
+                                       PipeRole::Producer, "writer")))
+          return failure();
+
+        tle::PipeWriterAcquireOp matchingAcquire;
+        SmallVector<ttg::TMACopyOp> matchingCopies;
+        for (Operation *previous = commit->getPrevNode(); previous;
+             previous = previous->getPrevNode()) {
+          if (auto acquire = dyn_cast<tle::PipeWriterAcquireOp>(previous)) {
+            if (getPipeKey(previous) == key &&
+                sameIndex(acquire.getStage(), commit.getStage())) {
+              matchingAcquire = acquire;
+              break;
+            }
+            continue;
+          }
+          if (auto copy = dyn_cast<ttg::TMACopyOp>(previous)) {
+            if (isExactSlot(copy.getDst(), state.fieldRoot, commit.getStage()))
+              matchingCopies.push_back(copy);
+          }
+        }
+        if (!matchingAcquire)
+          return commit.emitOpError(
+              "requires a same-block, same-stage matching writer.acquire");
+        if (matchingCopies.size() != 1)
+          return commit.emitOpError(
+                     "initial mthreads tle.pipe requires exactly one TME copy "
+                     "between acquire and commit; found ")
+                 << matchingCopies.size();
+
+        ttg::TMACopyOp copy = matchingCopies.front();
+        if (copy.getCompletionBarrier())
+          return copy.emitOpError(
+              "pipe-managed TME copy must not provide an explicit barrier");
+        FailureOr<int32_t> bytes = getTransactionBytes(copy);
+        if (failed(bytes))
+          return failure();
+        if (state.transactionBytes >= 0 && state.transactionBytes != *bytes)
+          return commit.emitOpError(
+              "all commits on one pipe must use identical transaction bytes");
+        state.transactionBytes = *bytes;
+        state.commits.push_back(commit);
+        commitCopies[commit.getOperation()] = copy;
+        continue;
+      }
+      if (auto wait = dyn_cast<tle::PipeReaderWaitOp>(op)) {
+        if (failed(recordExecutionMode(state, op, getPipeRole(op),
+                                       PipeRole::DefaultConsumer, "reader")))
+          return failure();
+        FailureOr<int32_t> warps = getConsumerWarps(op);
+        if (failed(warps))
+          return failure();
+        if (state.consumerWarps >= 0 && state.consumerWarps != *warps)
+          return wait.emitOpError(
+              "all reader operations must use one consumer warp count");
+        state.consumerWarps = *warps;
+        state.waits.push_back(wait);
+        continue;
+      }
+
+      auto release = cast<tle::PipeReaderReleaseOp>(op);
+      if (failed(recordExecutionMode(state, op, getPipeRole(op),
+                                     PipeRole::DefaultConsumer, "reader")))
+        return failure();
+      bool matchingWait = false;
+      for (Operation *previous = release->getPrevNode(); previous;
+           previous = previous->getPrevNode()) {
+        if (auto wait = dyn_cast<tle::PipeReaderWaitOp>(previous)) {
+          if (getPipeKey(previous) == key &&
+              sameIndex(wait.getStage(), release.getStage())) {
+            matchingWait = true;
+            break;
+          }
+        }
+      }
+      if (!matchingWait)
+        return release.emitOpError(
+            "requires a same-block, same-stage matching reader.wait");
+      FailureOr<int32_t> warps = getConsumerWarps(op);
+      if (failed(warps))
+        return failure();
+      if (state.consumerWarps >= 0 && state.consumerWarps != *warps)
+        return release.emitOpError(
+            "all reader operations must use one consumer warp count");
+      state.consumerWarps = *warps;
+      state.releases.push_back(release);
+    }
+
+    for (auto &[key, state] : pipes) {
+      if (state.acquires.empty() || state.commits.empty())
+        return state.create.emitOpError(
+            "requires at least one writer acquire/commit pair");
+      if (state.waits.empty() || state.releases.empty())
+        return state.create.emitOpError(
+            "requires at least one reader wait/release pair");
+      if (state.transactionBytes <= 0 || state.consumerWarps <= 0)
+        return state.create.emitOpError(
+            "could not infer transaction bytes or consumer warp count");
+    }
+    return success();
+  }
+
+  static Value toI32Phase(OpBuilder &builder, Location loc, Value phase,
+                          bool invert) {
+    Value value = phase;
+    if (invert) {
+      Value one = arith::ConstantIntOp::create(builder, loc, 1, 1);
+      value = arith::XOrIOp::create(builder, loc, value, one);
+    }
+    return arith::ExtUIOp::create(builder, loc, builder.getI32Type(), value);
+  }
+
+  static Value createIndex(OpBuilder &builder, Location loc, Operation *use,
+                           Value base, Value stage) {
+    Value capturedBase = captureForUse(use, base);
+    return musa_tle::BarrierIndexOp::create(builder, loc, capturedBase, stage);
+  }
+
+  LogicalResult rewrite(ModuleOp module,
+                        std::map<std::string, PipeState> &pipes,
+                        DenseMap<Operation *, ttg::TMACopyOp> &commitCopies) {
+    SmallVector<Operation *> pipeOps;
+    module.walk([&](Operation *op) {
+      if (isPipeOp(op))
+        pipeOps.push_back(op);
+    });
+
+    for (Operation *op : pipeOps) {
+      PipeState &state = pipes.at(getPipeKey(op));
+      OpBuilder builder(op);
+      Location loc = op->getLoc();
+
+      if (auto create = dyn_cast<tle::PipeCreateOp>(op)) {
+        auto capacity = builder.getI32IntegerAttr(state.capacity);
+        auto one = builder.getI32IntegerAttr(1);
+        auto pending = builder.getI32IntegerAttr(0);
+        auto ready = builder.getI32IntegerAttr(1);
+        auto bytes = builder.getI32IntegerAttr(state.transactionBytes);
+        state.fullBase = musa_tle::BarrierAllocOp::create(
+            builder, loc, capacity, one, pending, bytes);
+        state.emptyBase = musa_tle::BarrierAllocOp::create(
+            builder, loc, capacity,
+            builder.getI32IntegerAttr(state.consumerWarps), ready,
+            IntegerAttr());
+        create.erase();
+        continue;
+      }
+
+      if (auto acquire = dyn_cast<tle::PipeWriterAcquireOp>(op)) {
+        Value barrier =
+            createIndex(builder, loc, op, state.emptyBase, acquire.getStage());
+        Value phase = toI32Phase(builder, loc, acquire.getPhase(), true);
+        musa_tle::BarrierWaitOp::create(builder, loc, barrier, phase);
+        acquire.erase();
+        continue;
+      }
+
+      if (auto commit = dyn_cast<tle::PipeWriterCommitOp>(op)) {
+        ttg::TMACopyOp copy = commitCopies.lookup(op);
+        if (!copy)
+          return commit.emitOpError("lost the analyzed pipe TME copy");
+        OpBuilder copyBuilder(copy);
+        Value barrier = createIndex(copyBuilder, copy.getLoc(), copy,
+                                    state.fullBase, commit.getStage());
+        auto replacement =
+            ttg::TMACopyOp::create(copyBuilder, copy.getLoc(), copy.getSrc(),
+                                   copy.getDst(), copy.getIndices(), barrier);
+        replacement->setDiscardableAttrs(copy->getDiscardableAttrDictionary());
+        replacement->setAttr("expect_bytes", copyBuilder.getI32IntegerAttr(
+                                                 state.transactionBytes));
+        copy.erase();
+        commit.erase();
+        continue;
+      }
+
+      if (auto wait = dyn_cast<tle::PipeReaderWaitOp>(op)) {
+        Value barrier =
+            createIndex(builder, loc, op, state.fullBase, wait.getStage());
+        Value phase = toI32Phase(builder, loc, wait.getPhase(), false);
+        musa_tle::BarrierWaitOp::create(builder, loc, barrier, phase);
+        if (!wait.getIsClosed().use_empty()) {
+          Value notClosed = arith::ConstantIntOp::create(builder, loc, 0, 1);
+          wait.getIsClosed().replaceAllUsesWith(notClosed);
+        }
+        wait.erase();
+        continue;
+      }
+
+      if (isa<tle::PipeWriterCloseOp>(op))
+        return op->emitOpError("writer.close must have failed analysis");
+
+      auto release = cast<tle::PipeReaderReleaseOp>(op);
+      Value barrier =
+          createIndex(builder, loc, op, state.emptyBase, release.getStage());
+      Value phase = arith::ConstantIntOp::create(builder, loc, 0, 32);
+      musa_tle::BarrierArriveOp::create(builder, loc, barrier, phase,
+                                        builder.getI32IntegerAttr(1));
+      release.erase();
+    }
+
+    bool hasPipeOps = false;
+    module.walk([&](Operation *op) { hasPipeOps |= isPipeOp(op); });
+    if (hasPipeOps)
+      return module.emitError("mthreads TLE pipe lowering left lifecycle ops");
+    return success();
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    std::map<std::string, PipeState> pipes;
+    DenseMap<Operation *, ttg::TMACopyOp> commitCopies;
+    if (failed(analyze(module, pipes, commitCopies)) ||
+        failed(rewrite(module, pipes, commitCopies)))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+} // namespace mlir
+
+#endif // __TLE__

--- a/third_party/mthreads/tle/dialect/lib/Transforms/LowerSqmma.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/LowerSqmma.cpp
@@ -33,6 +33,8 @@ namespace {
 constexpr llvm::StringLiteral
     kAutoSharedLayoutAttr("musa_tle.auto_shared_layout");
 constexpr llvm::StringLiteral kExplicitSqmmaAttr("musa_tle.explicit_sqmma");
+constexpr llvm::StringLiteral kEnableEncodingRematerializationAttr(
+    "tle.enable_encoding_rematerialization");
 
 struct SelectedSqmmaConfig {
   SmallVector<unsigned, 3> instrShape;
@@ -193,14 +195,17 @@ static LogicalResult updateOperandLayout(musa_tle::SqmmaOp op,
   // partition. Changing the captured root value type does not update those
   // block arguments automatically, so keep the isolation boundary consistent
   // with the inferred TME/SQMMA layout.
+  SmallVector<Value, 4> rootAliases{root.getResult()};
   root->getParentOfType<tt::FuncOp>().walk(
       [&](ttg::WarpSpecializePartitionsOp partitions) {
         for (auto [index, capture] :
              llvm::enumerate(partitions.getExplicitCaptures())) {
           if (capture != root.getResult())
             continue;
-          for (Region &partition : partitions.getPartitionRegions())
+          for (Region &partition : partitions.getPartitionRegions()) {
             partition.getArgument(index).setType(newRootTy);
+            rootAliases.push_back(partition.getArgument(index));
+          }
         }
       });
 
@@ -230,7 +235,7 @@ static LogicalResult updateOperandLayout(musa_tle::SqmmaOp op,
       auto srcTy = cast<ttg::MemDescType>(index.getSrc().getType());
       auto dstTy = cast<ttg::MemDescType>(index.getType());
       if (srcTy.getRank() != dstTy.getRank() + 1 ||
-          index.getSrc() != root.getResult())
+          !llvm::is_contained(rootAliases, index.getSrc()))
         return;
       if (index.getResult().getType() != desiredTy) {
         index.getResult().setType(desiredTy);
@@ -283,6 +288,9 @@ struct TritonMUSAGPUTLELowerSqmmaPass
       if (isa<musa_tle::SqmmaOp, musa_tle::SqmmaWaitOp>(candidate))
         worklist.push_back(candidate);
     });
+    if (!dots.empty())
+      module->setAttr(kEnableEncodingRematerializationAttr,
+                      UnitAttr::get(module.getContext()));
 
     DenseMap<musa_tle::SqmmaOp, ttg::MUSASqmmaEncodingAttr> encodings;
     for (musa_tle::SqmmaOp dot : dots) {

--- a/third_party/mthreads/tle/dialect/lib/Transforms/LowerSqmma.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/LowerSqmma.cpp
@@ -1,0 +1,361 @@
+#ifdef __TLE__
+
+#include "Dialect/MUSA/IR/Dialect.h"
+#include "Dialect/MUSATLE/IR/Dialect.h"
+#include "TritonMUSACommon/MMAContractUtils.h"
+#include "TritonMUSACommon/MMAOperandUtils.h"
+#include "TritonMUSACommon/SqmmaAttrUtils.h"
+#include "TritonMUSACommon/TMEUtils.h"
+#include "TritonMUSAGPUTransforms/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+#include <algorithm>
+#include <limits>
+#include <optional>
+
+using namespace mlir;
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+namespace musa = mlir::triton::musa;
+namespace musa_tle = mlir::triton::musa_tle;
+
+namespace {
+
+constexpr llvm::StringLiteral
+    kAutoSharedLayoutAttr("musa_tle.auto_shared_layout");
+constexpr llvm::StringLiteral kExplicitSqmmaAttr("musa_tle.explicit_sqmma");
+
+struct SelectedSqmmaConfig {
+  SmallVector<unsigned, 3> instrShape;
+  SmallVector<unsigned, 2> warpsPerCTA;
+};
+
+static std::optional<SelectedSqmmaConfig>
+selectSqmmaConfig(unsigned m, unsigned n, unsigned k, unsigned numWarps,
+                  musa::SQMMAEltType operandType) {
+  if (numWarps < 4 || numWarps % 4 != 0)
+    return std::nullopt;
+  static constexpr unsigned kMN[] = {128, 64, 32, 16};
+  static constexpr unsigned kK[] = {128, 64, 32, 16};
+
+  std::optional<SelectedSqmmaConfig> best;
+  unsigned bestCount = std::numeric_limits<unsigned>::max();
+  unsigned bestVolume = 0;
+  for (unsigned instM : kMN) {
+    if (m % instM != 0)
+      continue;
+    for (unsigned instN : kMN) {
+      if (n % instN != 0 ||
+          !musa::isSupportedSqmmaInstrMN(operandType, instM, instN))
+        continue;
+      for (unsigned instK : kK) {
+        if (k % instK != 0 || !musa::isSupportedSqmma(operandType, operandType,
+                                                      musa::SQMMAEltType::f32,
+                                                      instM, instN, instK))
+          continue;
+        for (unsigned warpsM = 4; warpsM <= numWarps; warpsM *= 2) {
+          if (numWarps % warpsM != 0)
+            continue;
+          unsigned warpsN = numWarps / warpsM;
+          unsigned tileM = instM * (warpsM / 4);
+          unsigned tileN = instN * warpsN;
+          if (m % tileM != 0 || n % tileN != 0)
+            continue;
+          unsigned count = (m / tileM) * (n / tileN) * (k / instK);
+          unsigned volume = instM * instN * instK;
+          if (!best || count < bestCount ||
+              (count == bestCount && volume > bestVolume)) {
+            best = SelectedSqmmaConfig{{instM, instN, instK}, {warpsM, warpsN}};
+            bestCount = count;
+            bestVolume = volume;
+          }
+        }
+      }
+    }
+  }
+  return best;
+}
+
+static ttg::CGAEncodingAttr prependBufferDim(ttg::CGAEncodingAttr cgaLayout) {
+  auto prependOne = [](SmallVector<unsigned> values) {
+    values.insert(values.begin(), 1);
+    return values;
+  };
+  SmallVector<unsigned> order{0};
+  for (unsigned dim : cgaLayout.getCTAOrder())
+    order.push_back(dim + 1);
+  return ttg::CGAEncodingAttr::fromSplitParams(
+      cgaLayout.getContext(), prependOne(cgaLayout.getCTAsPerCGA()),
+      prependOne(cgaLayout.getCTASplitNum()), order);
+}
+
+static ttg::SwizzledSharedEncodingAttr
+prependBufferDim(ttg::SwizzledSharedEncodingAttr encoding) {
+  SmallVector<unsigned> order;
+  for (unsigned dim : encoding.getOrder())
+    order.push_back(dim + 1);
+  order.push_back(0);
+  return ttg::SwizzledSharedEncodingAttr::get(
+      encoding.getContext(), encoding.getVec(), encoding.getPerPhase(),
+      encoding.getMaxPhase(), order, prependBufferDim(encoding.getCGALayout()));
+}
+
+static ttg::LocalAllocOp findRootAlloc(Value value) {
+  llvm::SmallPtrSet<void *, 16> visited;
+  while (value && visited.insert(value.getAsOpaquePointer()).second) {
+    if (auto alloc = value.getDefiningOp<ttg::LocalAllocOp>())
+      return alloc;
+    Operation *def = value.getDefiningOp();
+    if (auto index = dyn_cast_or_null<ttg::MemDescIndexOp>(def))
+      value = index.getSrc();
+    else if (auto subslice = dyn_cast_or_null<ttg::MemDescSubsliceOp>(def))
+      value = subslice.getSrc();
+    else if (auto reinterpret =
+                 dyn_cast_or_null<ttg::MemDescReinterpretOp>(def))
+      value = reinterpret.getSrc();
+    else if (auto reshape = dyn_cast_or_null<ttg::MemDescReshapeOp>(def))
+      value = reshape.getSrc();
+    else if (auto trans = dyn_cast_or_null<ttg::MemDescTransOp>(def))
+      value = trans.getSrc();
+    else
+      break;
+  }
+  return {};
+}
+
+static musa::SQMMALayout inferLayout(ttg::MemDescType type) {
+  auto order = ttg::getOrder(type);
+  bool rowMajor = !order.empty() && order.front() + 1 == type.getRank();
+  return rowMajor ? musa::SQMMALayout::row : musa::SQMMALayout::col;
+}
+
+static LogicalResult updateOperandLayout(musa_tle::SqmmaOp op,
+                                         unsigned operandIdx,
+                                         ttg::MUSASqmmaEncodingAttr mmaEnc) {
+  Value operand = operandIdx == 0 ? op.getA() : op.getB();
+  auto operandTy = cast<ttg::MemDescType>(operand.getType());
+  int64_t elemBytes =
+      std::max<int64_t>(1, (operandTy.getElementTypeBitWidth() + 7) / 8);
+  ttg::LocalAllocOp root = findRootAlloc(operand);
+  if (!root)
+    return op.emitOpError("requires SQMMA operands rooted at ttg.local_alloc");
+  if (!root->hasAttr(kAutoSharedLayoutAttr))
+    return op.emitOpError(
+        "requires layout=None for initial mthreads TLE SQMMA operands");
+
+  auto order = ttg::getOrder(operandTy);
+  auto cga = ttg::getCGALayout(operandTy.getEncoding());
+  auto dotEncoding = ttg::DotOperandEncodingAttr::get(
+      op.getContext(), operandIdx, mmaEnc, operandTy.getElementType());
+  auto shared = musa::composeMusaOperandSharedLayout(
+      dotEncoding, operandTy.getShape(), order, cga, operandTy.getElementType(),
+      /*needTrans=*/false);
+  if (!shared)
+    return op.emitOpError(
+               "failed to infer PH1 SQMMA shared layout for operand ")
+           << operandIdx;
+
+  auto desiredTy = ttg::MemDescType::get(
+      operandTy.getShape(), operandTy.getElementType(), *shared,
+      operandTy.getMemorySpace(), operandTy.getMutableMemory(),
+      operandTy.getAllocShape());
+  if (failed(musa::resolveTMESwizzleConfigFromEncoding(desiredTy)))
+    return op.emitOpError(
+               "inferred SQMMA shared layout is not uniquely TME-compatible "
+               "for operand ")
+           << operandIdx;
+
+  auto rootTy = cast<ttg::MemDescType>(root.getType());
+  Attribute rootEncoding = *shared;
+  if (rootTy.getRank() == operandTy.getRank() + 1)
+    rootEncoding = prependBufferDim(*shared);
+  else if (rootTy.getRank() != operandTy.getRank())
+    return op.emitOpError("unsupported staged SQMMA allocation rank");
+
+  auto newRootTy =
+      ttg::MemDescType::get(rootTy.getShape(), rootTy.getElementType(),
+                            rootEncoding, rootTy.getMemorySpace(),
+                            rootTy.getMutableMemory(), rootTy.getAllocShape());
+  root.getResult().setType(newRootTy);
+  operand.setType(desiredTy);
+
+  bool rowMajor = inferLayout(desiredTy) == musa::SQMMALayout::row;
+  auto checkAndSet = [&](Operation *target) -> LogicalResult {
+    if (!target)
+      return success();
+    if (auto oldIdx = musa::getSqmmaOpIdx(target)) {
+      auto oldBytes = musa::getSqmmaElemBytes(target);
+      bool oldRow = musa::getSqmmaRowMajor(target, rowMajor);
+      if (*oldIdx != static_cast<int64_t>(operandIdx) || !oldBytes ||
+          *oldBytes != elemBytes || oldRow != rowMajor)
+        return target->emitOpError("conflicting TLE SQMMA consumer contract");
+    }
+    musa::setSqmmaAttrs(target, operandIdx, elemBytes, rowMajor);
+    return success();
+  };
+  if (failed(checkAndSet(root.getOperation())) ||
+      failed(checkAndSet(operand.getDefiningOp())))
+    return failure();
+
+  // Keep stage views and warp-specialize explicit captures type-consistent.
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    root->getParentOfType<tt::FuncOp>().walk([&](ttg::MemDescIndexOp index) {
+      auto srcTy = cast<ttg::MemDescType>(index.getSrc().getType());
+      auto dstTy = cast<ttg::MemDescType>(index.getType());
+      if (srcTy.getRank() != dstTy.getRank() + 1 ||
+          index.getSrc() != root.getResult())
+        return;
+      if (index.getResult().getType() != desiredTy) {
+        index.getResult().setType(desiredTy);
+        (void)checkAndSet(index.getOperation());
+        changed = true;
+      }
+    });
+  }
+  return success();
+}
+
+static LogicalResult verifyAsyncUses(musa_tle::SqmmaOp op) {
+  for (OpOperand &use : op.getD().getUses()) {
+    Operation *user = use.getOwner();
+    if (auto next = dyn_cast<musa_tle::SqmmaOp>(user)) {
+      if (use.getOperandNumber() == 2)
+        continue;
+    }
+    if (isa<musa_tle::SqmmaWaitOp, scf::YieldOp, scf::ForOp>(user))
+      continue;
+    return op.emitOpError(
+        "async result must be consumed by musa_tle.sqmma_wait before "
+        "ordinary tensor use");
+  }
+  return success();
+}
+
+static bool isMmaEncoded(Value value) {
+  auto type = dyn_cast<RankedTensorType>(value.getType());
+  return type &&
+         isa_and_nonnull<ttg::MUSASqmmaEncodingAttr>(type.getEncoding());
+}
+
+} // namespace
+
+namespace mlir {
+
+#define GEN_PASS_DEF_TRITONMUSAGPUTLELOWERSQMMA
+#include "TritonMUSAGPUTransforms/Passes.h.inc"
+
+struct TritonMUSAGPUTLELowerSqmmaPass
+    : impl::TritonMUSAGPUTLELowerSqmmaBase<TritonMUSAGPUTLELowerSqmmaPass> {
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    SmallVector<musa_tle::SqmmaOp> dots;
+    SmallVector<Operation *> worklist;
+    module.walk([&](Operation *candidate) {
+      if (auto dot = dyn_cast<musa_tle::SqmmaOp>(candidate))
+        dots.push_back(dot);
+      if (isa<musa_tle::SqmmaOp, musa_tle::SqmmaWaitOp>(candidate))
+        worklist.push_back(candidate);
+    });
+
+    DenseMap<musa_tle::SqmmaOp, ttg::MUSASqmmaEncodingAttr> encodings;
+    for (musa_tle::SqmmaOp dot : dots) {
+      if (failed(verifyAsyncUses(dot)))
+        return signalPassFailure();
+      auto aTy = cast<ttg::MemDescType>(dot.getA().getType());
+      auto bTy = cast<ttg::MemDescType>(dot.getB().getType());
+      auto operandType = musa::getWmmaEltType(aTy.getElementType());
+      if (!operandType) {
+        dot.emitOpError("cannot map operand dtype to an SQMMA element type");
+        return signalPassFailure();
+      }
+      unsigned numWarps = ttg::maybeLookupNumWarps(dot).value_or(0);
+      auto config =
+          selectSqmmaConfig(aTy.getShape()[0], bTy.getShape()[1],
+                            aTy.getShape()[1], numWarps, *operandType);
+      if (!config) {
+        dot.emitOpError("cannot select a supported SQMMA configuration");
+        return signalPassFailure();
+      }
+      auto accTy = cast<RankedTensorType>(dot.getC().getType());
+      auto cga = ttg::getCGALayout(accTy.getEncoding());
+      auto mmaEnc = ttg::MUSASqmmaEncodingAttr::get(
+          dot.getContext(), 3, 1, config->warpsPerCTA, cga, config->instrShape);
+      encodings[dot] = mmaEnc;
+    }
+
+    // Infer all physical layouts before replacing any TLE SQMMA op.
+    for (musa_tle::SqmmaOp dot : dots) {
+      if (failed(updateOperandLayout(dot, 0, encodings[dot])) ||
+          failed(updateOperandLayout(dot, 1, encodings[dot])))
+        return signalPassFailure();
+    }
+
+    DenseMap<Value, Value> nativeAccumulators;
+    for (Operation *candidate : worklist) {
+      OpBuilder builder(candidate);
+      if (auto dot = dyn_cast<musa_tle::SqmmaOp>(candidate)) {
+        auto oldAccTy = cast<RankedTensorType>(dot.getC().getType());
+        auto nativeTy = RankedTensorType::get(
+            oldAccTy.getShape(), oldAccTy.getElementType(), encodings[dot]);
+        Value nativeAcc = nativeAccumulators.lookup(dot.getC());
+        if (!nativeAcc) {
+          if (isMmaEncoded(dot.getC()))
+            nativeAcc = dot.getC();
+          else
+            nativeAcc = ttg::ConvertLayoutOp::create(builder, dot.getLoc(),
+                                                     nativeTy, dot.getC());
+        }
+        Value useC = arith::ConstantIntOp::create(builder, dot.getLoc(), 1, 1);
+        auto config = cast<ttg::MUSASqmmaEncodingAttr>(nativeTy.getEncoding());
+        auto instr = config.getInstrShape();
+        auto operandType = musa::getWmmaEltType(
+            cast<ttg::MemDescType>(dot.getA().getType()).getElementType());
+        assert(operandType && "SQMMA operand type must be verified");
+        auto nativeDot = musa::SquadDotOp::create(
+            builder, dot.getLoc(), nativeTy, dot.getA(), dot.getB(), nativeAcc,
+            useC, instr[0], instr[1], instr[2], musa::SQMMAEltType::f32,
+            *operandType, *operandType,
+            inferLayout(cast<ttg::MemDescType>(dot.getA().getType())),
+            inferLayout(cast<ttg::MemDescType>(dot.getB().getType())), true,
+            musa::SQMMAAccumulationMode::hardware,
+            static_cast<int32_t>(dot.getInputPrecision()), 0);
+        nativeDot->setAttr(kExplicitSqmmaAttr, builder.getUnitAttr());
+        nativeAccumulators[dot.getD()] = nativeDot.getD();
+        continue;
+      }
+
+      auto wait = cast<musa_tle::SqmmaWaitOp>(candidate);
+      Value nativeInput = nativeAccumulators.lookup(wait.getInput());
+      if (!nativeInput) {
+        wait.emitOpError("input must be the async result of musa_tle.sqmma");
+        return signalPassFailure();
+      }
+      auto nativeWait =
+          musa::SquadDotWaitOp::create(builder, wait.getLoc(), nativeInput);
+      nativeWait->setAttr(kExplicitSqmmaAttr, builder.getUnitAttr());
+      Value released = ttg::ConvertLayoutOp::create(builder, wait.getLoc(),
+                                                    wait.getOutput().getType(),
+                                                    nativeWait.getResult(0));
+      wait.getOutput().replaceAllUsesWith(released);
+      wait.erase();
+    }
+
+    for (musa_tle::SqmmaOp dot : llvm::reverse(dots))
+      dot.erase();
+  }
+};
+
+} // namespace mlir
+
+#endif // __TLE__

--- a/third_party/mthreads/tle/dialect/lib/Transforms/LowerSqmma.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/LowerSqmma.cpp
@@ -152,7 +152,8 @@ static LogicalResult updateOperandLayout(musa_tle::SqmmaOp op,
     return op.emitOpError("requires SQMMA operands rooted at ttg.local_alloc");
   if (!root->hasAttr(kAutoSharedLayoutAttr))
     return op.emitOpError(
-        "requires layout=None for initial mthreads TLE SQMMA operands");
+        "requires layout=None and nv_mma_shared_layout=True for initial "
+        "mthreads TLE SQMMA operands");
 
   auto order = ttg::getOrder(operandTy);
   auto cga = ttg::getCGALayout(operandTy.getEncoding());

--- a/third_party/mthreads/tle/dialect/lib/Transforms/LowerSqmma.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/LowerSqmma.cpp
@@ -188,6 +188,22 @@ static LogicalResult updateOperandLayout(musa_tle::SqmmaOp op,
   root.getResult().setType(newRootTy);
   operand.setType(desiredTy);
 
+  // Explicit warp-specialize captures are represented by operands on the
+  // isolated partitions container and corresponding block arguments in every
+  // partition. Changing the captured root value type does not update those
+  // block arguments automatically, so keep the isolation boundary consistent
+  // with the inferred TME/SQMMA layout.
+  root->getParentOfType<tt::FuncOp>().walk(
+      [&](ttg::WarpSpecializePartitionsOp partitions) {
+        for (auto [index, capture] :
+             llvm::enumerate(partitions.getExplicitCaptures())) {
+          if (capture != root.getResult())
+            continue;
+          for (Region &partition : partitions.getPartitionRegions())
+            partition.getArgument(index).setType(newRootTy);
+        }
+      });
+
   bool rowMajor = inferLayout(desiredTy) == musa::SQMMALayout::row;
   auto checkAndSet = [&](Operation *target) -> LogicalResult {
     if (!target)

--- a/third_party/mthreads/tle/dialect/lib/Transforms/LowerTMETransactions.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/LowerTMETransactions.cpp
@@ -1,0 +1,130 @@
+#ifdef __TLE__
+
+#include "Dialect/MUSA/IR/Dialect.h"
+#include "TritonMUSACommon/TMEUtils.h"
+#include "TritonMUSAGPUTransforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/ADT/STLExtras.h"
+
+#include <cstdint>
+#include <limits>
+#include <optional>
+
+namespace mlir {
+
+#define GEN_PASS_DEF_TRITONMUSAGPUTLELOWERTMETRANSACTIONS
+#include "TritonMUSAGPUTransforms/Passes.h.inc"
+
+namespace {
+
+namespace ttg = triton::gpu;
+namespace ttmg = triton::musa;
+
+static FailureOr<int32_t>
+resolveIssueThread(ttmg::AsyncTMECopyGlobalToLocalOp copy) {
+  auto ws = copy->getParentOfType<ttg::WarpSpecializeOp>();
+  if (!ws)
+    return 0;
+
+  Region *copyRegion = copy->getParentRegion();
+  if (ws.getDefaultRegion().isAncestor(copyRegion)) {
+    copy.emitOpError(
+        "mthreads TLE completion TME copy must be in the producer partition");
+    return failure();
+  }
+
+  std::optional<unsigned> partitionIndex;
+  for (auto [index, region] : llvm::enumerate(ws.getPartitionRegions())) {
+    if (region->isAncestor(copyRegion)) {
+      partitionIndex = index;
+      break;
+    }
+  }
+  if (!partitionIndex || *partitionIndex != 0) {
+    copy.emitOpError(
+        "mthreads TLE completion TME copy must be in the producer partition");
+    return failure();
+  }
+
+  ModuleOp module = copy->getParentOfType<ModuleOp>();
+  auto numWarps = module->getAttrOfType<IntegerAttr>(ttg::AttrNumWarpsName);
+  auto threadsPerWarp =
+      module->getAttrOfType<IntegerAttr>(ttg::AttrNumThreadsPerWarp);
+  if (!numWarps || !threadsPerWarp || numWarps.getInt() <= 0 ||
+      threadsPerWarp.getInt() <= 0) {
+    copy.emitOpError("mthreads TLE producer issue thread requires "
+                     "ttg.num-warps and ttg.threads-per-warp");
+    return failure();
+  }
+
+  int64_t issueThread = numWarps.getInt() * threadsPerWarp.getInt();
+  if (issueThread > std::numeric_limits<int32_t>::max()) {
+    copy.emitOpError("mthreads TLE producer issue thread exceeds int32 range");
+    return failure();
+  }
+  return static_cast<int32_t>(issueThread);
+}
+
+class LowerTMETransactionsPass
+    : public impl::TritonMUSAGPUTLELowerTMETransactionsBase<
+          LowerTMETransactionsPass> {
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    IRRewriter rewriter(&getContext());
+
+    SmallVector<ttmg::AsyncTMECopyGlobalToLocalOp> copies;
+    module.walk([&](ttmg::AsyncTMECopyGlobalToLocalOp copy) {
+      if (copy->hasAttr(ttmg::kTLEExpectBytesAttr))
+        copies.push_back(copy);
+    });
+
+    for (ttmg::AsyncTMECopyGlobalToLocalOp copy : copies) {
+      auto expectBytes =
+          copy->getAttrOfType<IntegerAttr>(ttmg::kTLEExpectBytesAttr);
+      if (!expectBytes || !expectBytes.getType().isInteger(32) ||
+          expectBytes.getInt() <= 0) {
+        copy.emitOpError(
+            "mthreads TLE completion TME copy requires positive expect_bytes");
+        signalPassFailure();
+        return;
+      }
+
+      FailureOr<int32_t> issueThread = resolveIssueThread(copy);
+      if (failed(issueThread)) {
+        signalPassFailure();
+        return;
+      }
+
+      Location loc = copy.getLoc();
+      auto issueThreadAttr = rewriter.getI32IntegerAttr(*issueThread);
+      auto explicitCompletionAttr = rewriter.getUnitAttr();
+
+      rewriter.setInsertionPoint(copy);
+      Value bytes =
+          arith::ConstantIntOp::create(rewriter, loc, expectBytes.getInt(), 32);
+      auto addTrans = ttmg::BarrierAddTransOp::create(
+          rewriter, loc, copy.getBarId(), bytes, copy.getPred());
+
+      rewriter.setInsertionPointAfter(copy);
+      auto arrive = ttmg::ArriveBarrierNoRetOp::create(
+          rewriter, loc, copy.getBarId(), copy.getPred());
+
+      for (Operation *op : {addTrans.getOperation(), copy.getOperation(),
+                            arrive.getOperation()}) {
+        op->setAttr(ttmg::kTMEIssueThreadAttr, issueThreadAttr);
+        op->setAttr(ttmg::kTMEExplicitCompletionAttr, explicitCompletionAttr);
+      }
+      copy->removeAttr(ttmg::kTLEExpectBytesAttr);
+    }
+  }
+};
+
+} // namespace
+} // namespace mlir
+
+#endif // __TLE__

--- a/third_party/mthreads/tle/dialect/lib/Transforms/LowerWarpSpecialize.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/LowerWarpSpecialize.cpp
@@ -1,0 +1,160 @@
+#ifdef __TLE__
+
+#include "TritonMUSAGPUTransforms/Passes.h"
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/PatternMatch.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include <cstdint>
+#include <limits>
+
+namespace mlir {
+
+#define GEN_PASS_DEF_TRITONMUSAGPUTLEPREPAREWARPSPECIALIZE
+#include "TritonMUSAGPUTransforms/Passes.h.inc"
+
+namespace {
+
+namespace ttg = triton::gpu;
+
+static constexpr StringLiteral kStaticWarpSpecializeAttr =
+    "musa_tle.static_warp_specialize";
+class PrepareWarpSpecializePass
+    : public impl::TritonMUSAGPUTLEPrepareWarpSpecializeBase<
+          PrepareWarpSpecializePass> {
+  LogicalResult prepareWarpSpecialize(ModuleOp mod, ttg::WarpSpecializeOp ws,
+                                      IRRewriter &rewriter) {
+    auto func = ws->getParentOfType<triton::FuncOp>();
+    if (!func)
+      return ws.emitOpError("requires a parent Triton function");
+
+    Block &entry = func.getBody().front();
+    if (ws->getBlock() != &entry)
+      return ws.emitOpError(
+          "mthreads TLE static warp_specialize must be in the function entry "
+          "block");
+    if (!ws->getNextNode() || !isa<triton::ReturnOp>(ws->getNextNode()) ||
+        ws->getNextNode()->getNextNode())
+      return ws.emitOpError(
+          "mthreads TLE static warp_specialize must be the final operation "
+          "before tt.return");
+    if (ws.getNumResults() != 0)
+      return ws.emitOpError(
+          "mthreads TLE static warp_specialize does not support results");
+
+    auto partitions = ws.getPartitionOp();
+    if (partitions.getPartitionRegions().size() != 1)
+      return ws.emitOpError(
+          "mthreads TLE static warp_specialize requires exactly one producer "
+          "partition");
+    if (ws.getPartitionNumWarps().size() != 1 ||
+        ws.getPartitionNumWarps().front() <= 0)
+      return ws.emitOpError(
+          "mthreads TLE static warp_specialize requires a positive static "
+          "producer warp count");
+
+    Region &consumerRegion = ws.getDefaultRegion();
+    Region &producerRegion = partitions.getPartitionRegions().front();
+    if (!consumerRegion.hasOneBlock() || !producerRegion.hasOneBlock())
+      return ws.emitOpError(
+          "mthreads TLE static warp_specialize requires single-block "
+          "consumer and producer regions");
+
+    Block &consumerBlock = consumerRegion.front();
+    Block &producerBlock = producerRegion.front();
+    auto consumerYield =
+        dyn_cast<ttg::WarpYieldOp>(consumerBlock.getTerminator());
+    if (!consumerYield || consumerYield.getNumOperands() != 0)
+      return ws.emitOpError(
+          "mthreads TLE static warp_specialize consumer must yield no values");
+    if (!isa<ttg::WarpReturnOp>(producerBlock.getTerminator()))
+      return ws.emitOpError(
+          "mthreads TLE static warp_specialize producer must end with "
+          "ttg.warp_return");
+
+    ValueRange captures = partitions.getExplicitCaptures();
+    if (producerBlock.getNumArguments() != captures.size())
+      return ws.emitOpError(
+          "mthreads TLE static warp_specialize producer capture count "
+          "mismatch");
+    DominanceInfo dominance(func);
+    for (Value capture : captures) {
+      if (!dominance.dominates(capture, ws.getOperation()))
+        return ws.emitOpError(
+            "mthreads TLE static warp_specialize capture must dominate the "
+            "partition split");
+    }
+
+    int32_t baseNumWarps = ttg::lookupNumWarps(ws);
+    if (baseNumWarps <= 0)
+      return ws.emitOpError(
+          "mthreads TLE static warp_specialize consumer warp count must be "
+          "positive");
+    int32_t producerWarps = ws.getPartitionNumWarps().front();
+    int32_t warpSize = ttg::TritonGPUDialect::getThreadsPerWarp(mod);
+    int64_t totalNumWarps64 =
+        static_cast<int64_t>(baseNumWarps) + producerWarps;
+    int64_t producerBegin64 = static_cast<int64_t>(baseNumWarps) * warpSize;
+    int64_t totalThreads64 = totalNumWarps64 * warpSize;
+    if (warpSize <= 0 ||
+        totalNumWarps64 > std::numeric_limits<int32_t>::max() ||
+        producerBegin64 > std::numeric_limits<int32_t>::max() ||
+        totalThreads64 > std::numeric_limits<int32_t>::max())
+      return ws.emitOpError(
+          "mthreads TLE static warp_specialize thread count overflow");
+
+    int32_t totalNumWarps = static_cast<int32_t>(totalNumWarps64);
+    if (auto existingStartIds = ws.getWarpGroupStartIds()) {
+      if (existingStartIds->size() != 1 ||
+          existingStartIds->front() != baseNumWarps)
+        return ws.emitOpError(
+            "mthreads TLE static producer must begin after the default "
+            "partition");
+    } else {
+      ws.setWarpGroupStartIds({baseNumWarps});
+    }
+    if (auto existing =
+            mod->getAttrOfType<IntegerAttr>("ttg.total-num-warps")) {
+      if (existing.getInt() != totalNumWarps)
+        return ws.emitOpError(
+            "mthreads TLE static warp_specialize conflicts with existing "
+            "ttg.total-num-warps");
+    } else {
+      mod->setAttr("ttg.total-num-warps",
+                   rewriter.getI32IntegerAttr(totalNumWarps));
+    }
+
+    return success();
+  }
+
+public:
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    SmallVector<ttg::WarpSpecializeOp> marked;
+    mod.walk([&](ttg::WarpSpecializeOp ws) {
+      if (ws->hasAttr(kStaticWarpSpecializeAttr))
+        marked.push_back(ws);
+    });
+    if (marked.empty())
+      return;
+    if (marked.size() != 1) {
+      marked[1].emitOpError(
+          "mthreads TLE static warp_specialize supports exactly one marked "
+          "operation per module");
+      return signalPassFailure();
+    }
+
+    IRRewriter rewriter(&getContext());
+    if (failed(prepareWarpSpecialize(mod, marked.front(), rewriter)))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+} // namespace mlir
+
+#endif // __TLE__

--- a/third_party/mthreads/tle/dialect/lib/Transforms/LowerWarpSpecializeToLLVM.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/LowerWarpSpecializeToLLVM.cpp
@@ -1,0 +1,308 @@
+#ifdef __TLE__
+
+#include "Dialect/MUSA/IR/Dialect.h"
+#include "TritonMUSACommon/BarrierUtils.h"
+#include "TritonMUSAGPUTransforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include <cstdint>
+#include <limits>
+#include <utility>
+
+namespace mlir {
+
+#define GEN_PASS_DEF_TRITONMUSAGPUTLELOWERWARPSPECIALIZE
+#include "TritonMUSAGPUTransforms/Passes.h.inc"
+
+namespace {
+
+namespace ttg = triton::gpu;
+namespace ttmg = triton::musa;
+
+static constexpr StringLiteral kStaticWarpSpecializeAttr =
+    "musa_tle.static_warp_specialize";
+static constexpr StringLiteral kLocalSyncIntrinsic = "llvm.musa.syncthreads.lm";
+static constexpr StringLiteral kBarRecordIntrinsic =
+    "llvm.musa.async.bar.record";
+
+struct PartitionSync {
+  LLVM::CallIntrinsicOp op;
+  int32_t numWarps;
+};
+
+static LogicalResult lowerWarpGroupBarriers(LLVM::LLVMFuncOp func,
+                                            ttg::WarpSpecializeOp ws,
+                                            IRRewriter &rewriter) {
+  ModuleOp module = func->getParentOfType<ModuleOp>();
+  auto consumerWarpsAttr =
+      module->getAttrOfType<IntegerAttr>(ttg::AttrNumWarpsName);
+  if (!consumerWarpsAttr || consumerWarpsAttr.getInt() <= 0 ||
+      consumerWarpsAttr.getInt() > std::numeric_limits<int32_t>::max())
+    return ws.emitOpError(
+        "mthreads TLE default partition requires a positive int32 "
+        "ttg.num-warps");
+  int32_t consumerWarps = static_cast<int32_t>(consumerWarpsAttr.getInt());
+
+  Region &producerRegion = *ws.getPartitionRegions().front();
+  Region &consumerRegion = ws.getDefaultRegion();
+  SmallVector<LLVM::CallIntrinsicOp> redundantSyncs;
+  SmallVector<PartitionSync> syncs;
+
+  producerRegion.walk([&](LLVM::CallIntrinsicOp call) {
+    if (call.getIntrin() == kLocalSyncIntrinsic)
+      redundantSyncs.push_back(call);
+  });
+
+  bool seenSqmma = false;
+  consumerRegion.walk<WalkOrder::PreOrder>([&](Operation *op) {
+    auto call = dyn_cast<LLVM::CallIntrinsicOp>(op);
+    if (!call)
+      return WalkResult::advance();
+    if (call.getIntrin().starts_with("llvm.musa.sqmma.fmma.")) {
+      seenSqmma = true;
+      return WalkResult::advance();
+    }
+    if (call.getIntrin() != kLocalSyncIntrinsic)
+      return WalkResult::advance();
+    if (seenSqmma)
+      syncs.push_back({call, consumerWarps});
+    else
+      redundantSyncs.push_back(call);
+    return WalkResult::advance();
+  });
+
+  for (LLVM::CallIntrinsicOp redundant : redundantSyncs)
+    rewriter.eraseOp(redundant);
+  if (syncs.empty())
+    return success();
+
+  auto reserved = ttmg::reserveBarrierIdRange(
+      syncs.front().op, static_cast<int32_t>(syncs.size()));
+  if (failed(reserved))
+    return syncs.front().op.emitOpError(
+        "mthreads TLE partition synchronization exhausted hardware barrier "
+        "ids");
+
+  LLVM::CallIntrinsicOp initializationRendezvous;
+  for (Operation *op = ws->getPrevNode(); op; op = op->getPrevNode()) {
+    auto call = dyn_cast<LLVM::CallIntrinsicOp>(op);
+    if (call && call.getIntrin() == kLocalSyncIntrinsic) {
+      initializationRendezvous = call;
+      break;
+    }
+  }
+
+  Location loc = initializationRendezvous ? initializationRendezvous.getLoc()
+                                          : ws.getLoc();
+  if (initializationRendezvous)
+    rewriter.setInsertionPoint(initializationRendezvous);
+  else
+    rewriter.setInsertionPoint(ws);
+  Value phase = arith::ConstantIntOp::create(rewriter, loc, 0, 32);
+  llvm::DenseMap<Operation *, Value> barrierIds;
+  SmallVector<std::pair<Value, Value>> initializationArgs;
+  int32_t nextId = *reserved;
+  for (PartitionSync &sync : syncs) {
+    Value id = arith::ConstantIntOp::create(rewriter, loc, nextId++, 32);
+    Value count =
+        arith::ConstantIntOp::create(rewriter, loc, sync.numWarps, 32);
+    initializationArgs.push_back({id, count});
+    barrierIds[sync.op.getOperation()] = id;
+  }
+
+  Value tid =
+      LLVM::CallIntrinsicOp::create(
+          rewriter, loc, rewriter.getI32Type(),
+          rewriter.getStringAttr("llvm.musa.read.ptx.sreg.tid.x"), ValueRange{})
+          .getResult(0);
+  Value issueInit = arith::CmpIOp::create(rewriter, loc,
+                                          arith::CmpIPredicate::eq, tid, phase);
+  auto initIf = scf::IfOp::create(rewriter, loc, issueInit, false);
+  rewriter.setInsertionPointToStart(&initIf.getThenRegion().front());
+  for (auto [id, count] : initializationArgs)
+    LLVM::CallIntrinsicOp::create(
+        rewriter, loc, rewriter.getStringAttr("llvm.musa.async.init.arrival"),
+        ValueRange{id, count, phase});
+
+  rewriter.setInsertionPointAfter(initIf);
+  if (!initializationRendezvous)
+    LLVM::CallIntrinsicOp::create(rewriter, loc,
+                                  rewriter.getStringAttr(kLocalSyncIntrinsic),
+                                  ValueRange{});
+
+  for (PartitionSync &sync : syncs) {
+    rewriter.setInsertionPoint(sync.op);
+    Value id = barrierIds.lookup(sync.op.getOperation());
+    LLVM::CallIntrinsicOp::create(
+        rewriter, sync.op.getLoc(),
+        rewriter.getStringAttr("llvm.musa.async.arrive.none.phaseid"),
+        ValueRange{id});
+    LLVM::CallIntrinsicOp::create(
+        rewriter, sync.op.getLoc(),
+        rewriter.getStringAttr("llvm.musa.async.wait"), ValueRange{id, phase});
+    rewriter.eraseOp(sync.op);
+  }
+
+  SmallVector<LLVM::CallIntrinsicOp> oldBarRecords;
+  func.walk([&](LLVM::CallIntrinsicOp call) {
+    if (call.getIntrin() == kBarRecordIntrinsic)
+      oldBarRecords.push_back(call);
+  });
+  for (LLVM::CallIntrinsicOp record : oldBarRecords)
+    rewriter.eraseOp(record);
+  rewriter.setInsertionPointToStart(&func.getBody().front());
+  Value barCount = arith::ConstantIntOp::create(
+      rewriter, func.getLoc(), ttmg::getReservedBarrierCount(func), 32);
+  LLVM::CallIntrinsicOp::create(rewriter, func.getLoc(),
+                                rewriter.getStringAttr(kBarRecordIntrinsic),
+                                ValueRange{barCount});
+  return success();
+}
+
+static LogicalResult lowerStaticWarpSpecialize(LLVM::LLVMFuncOp func,
+                                               ttg::WarpSpecializeOp ws,
+                                               IRRewriter &rewriter) {
+  if (ws.getNumResults() != 0 || ws.getPartitionRegions().size() != 1 ||
+      ws.getPartitionNumWarps().size() != 1)
+    return ws.emitOpError(
+        "mthreads TLE late lowering requires one producer, one consumer, and "
+        "no results");
+
+  Region &producerRegion = *ws.getPartitionRegions().front();
+  Region &consumerRegion = ws.getDefaultRegion();
+  if (producerRegion.empty() || consumerRegion.empty())
+    return ws.emitOpError("mthreads TLE static partitions must not be empty");
+
+  auto partitions = ws.getPartitionOp();
+  ValueRange captures = partitions.getExplicitCaptures();
+  Block &producerEntry = producerRegion.front();
+  if (producerEntry.getNumArguments() != captures.size())
+    return ws.emitOpError("producer capture count changed during lowering");
+  for (auto [argument, capture] :
+       llvm::zip(producerEntry.getArguments(), captures)) {
+    if (argument.getType() != capture.getType())
+      return ws.emitOpError(
+          "producer capture types were not converted consistently");
+    argument.replaceAllUsesWith(capture);
+  }
+  producerEntry.eraseArguments([](BlockArgument) { return true; });
+
+  ModuleOp module = func->getParentOfType<ModuleOp>();
+  auto consumerWarpsAttr =
+      module->getAttrOfType<IntegerAttr>(ttg::AttrNumWarpsName);
+  auto threadsPerWarpAttr =
+      module->getAttrOfType<IntegerAttr>(ttg::AttrNumThreadsPerWarp);
+  if (!consumerWarpsAttr || !threadsPerWarpAttr ||
+      consumerWarpsAttr.getInt() <= 0 || threadsPerWarpAttr.getInt() <= 0)
+    return ws.emitOpError("late lowering requires positive ttg.num-warps and "
+                          "ttg.threads-per-warp");
+  int64_t boundary64 = consumerWarpsAttr.getInt() * threadsPerWarpAttr.getInt();
+  if (boundary64 > std::numeric_limits<int32_t>::max())
+    return ws.emitOpError("static partition boundary exceeds int32 range");
+  int32_t boundary = static_cast<int32_t>(boundary64);
+
+  SmallVector<ttg::WarpReturnOp> producerReturns;
+  producerRegion.walk(
+      [&](ttg::WarpReturnOp op) { producerReturns.push_back(op); });
+  SmallVector<ttg::WarpYieldOp> consumerYields;
+  consumerRegion.walk(
+      [&](ttg::WarpYieldOp op) { consumerYields.push_back(op); });
+  if (producerReturns.empty() || consumerYields.empty())
+    return ws.emitOpError("static partitions lost their terminators");
+
+  Block *dispatch = ws->getBlock();
+  Block *continuation =
+      rewriter.splitBlock(dispatch, std::next(ws->getIterator()));
+  Region &funcBody = func.getBody();
+  auto &funcBlocks = funcBody.getBlocks();
+  Block *producerRoot = &producerRegion.front();
+  Block *consumerRoot = &consumerRegion.front();
+  funcBlocks.splice(continuation->getIterator(), producerRegion.getBlocks());
+  Block *producerJoin =
+      rewriter.createBlock(&funcBody, continuation->getIterator());
+  funcBlocks.splice(continuation->getIterator(), consumerRegion.getBlocks());
+
+  for (ttg::WarpReturnOp op : producerReturns) {
+    rewriter.setInsertionPoint(op);
+    cf::BranchOp::create(rewriter, op.getLoc(), producerJoin);
+    rewriter.eraseOp(op);
+  }
+  for (ttg::WarpYieldOp op : consumerYields) {
+    if (op.getNumOperands() != 0)
+      return op.emitOpError(
+          "mthreads TLE static consumer must not yield values");
+    rewriter.setInsertionPoint(op);
+    cf::BranchOp::create(rewriter, op.getLoc(), continuation);
+    rewriter.eraseOp(op);
+  }
+
+  Location loc = ws.getLoc();
+  rewriter.eraseOp(ws);
+  rewriter.setInsertionPointToEnd(dispatch);
+  Value tid =
+      LLVM::CallIntrinsicOp::create(
+          rewriter, loc, rewriter.getI32Type(),
+          rewriter.getStringAttr("llvm.musa.read.ptx.sreg.tid.x"), ValueRange{})
+          .getResult(0);
+  Value boundaryValue =
+      arith::ConstantIntOp::create(rewriter, loc, boundary, 32);
+  Value isProducer = arith::CmpIOp::create(
+      rewriter, loc, arith::CmpIPredicate::uge, tid, boundaryValue);
+  cf::CondBranchOp::create(rewriter, loc, isProducer, producerRoot,
+                           ValueRange{}, producerJoin, ValueRange{});
+
+  rewriter.setInsertionPointToEnd(producerJoin);
+  Value isConsumer = arith::CmpIOp::create(
+      rewriter, loc, arith::CmpIPredicate::ult, tid, boundaryValue);
+  cf::CondBranchOp::create(rewriter, loc, isConsumer, consumerRoot,
+                           ValueRange{}, continuation, ValueRange{});
+  return success();
+}
+
+class LowerWarpSpecializePass
+    : public impl::TritonMUSAGPUTLELowerWarpSpecializeBase<
+          LowerWarpSpecializePass> {
+public:
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    SmallVector<ttg::WarpSpecializeOp> marked;
+    module.walk([&](ttg::WarpSpecializeOp ws) {
+      if (ws->hasAttr(kStaticWarpSpecializeAttr))
+        marked.push_back(ws);
+    });
+    if (marked.empty())
+      return;
+    if (marked.size() != 1) {
+      marked[1].emitOpError(
+          "mthreads TLE static warp_specialize supports exactly one marked "
+          "operation per module");
+      return signalPassFailure();
+    }
+
+    auto func = marked.front()->getParentOfType<LLVM::LLVMFuncOp>();
+    if (!func) {
+      marked.front().emitOpError(
+          "mthreads TLE late lowering requires an LLVM function");
+      return signalPassFailure();
+    }
+
+    IRRewriter rewriter(&getContext());
+    if (failed(lowerWarpGroupBarriers(func, marked.front(), rewriter)) ||
+        failed(lowerStaticWarpSpecialize(func, marked.front(), rewriter)))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+} // namespace mlir
+
+#endif // __TLE__

--- a/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
+++ b/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
@@ -157,11 +157,22 @@ void init_triton_musa_tle_ir(py::module m) {
                                           memorySpace,
                                           /*mutableMemory=*/true, allocShape);
            })
-      .def("create_tma_copy",
-           [](TritonOpBuilder &self, mlir::Value src, mlir::Value dst,
-              std::vector<mlir::Value> indices) -> void {
-             self.create<ttg::TMACopyOp>(src, dst, indices);
-           })
+      .def(
+          "create_tma_copy",
+          [](TritonOpBuilder &self, mlir::Value src, mlir::Value dst,
+             std::vector<mlir::Value> indices, py::object completionBarrier,
+             int32_t expectBytes) -> void {
+            mlir::Value barrier;
+            if (!completionBarrier.is_none())
+              barrier = py::cast<mlir::Value>(completionBarrier);
+            auto op = self.create<ttg::TMACopyOp>(src, dst, indices, barrier);
+            if (expectBytes >= 0)
+              op->setAttr("expect_bytes",
+                          self.getBuilder().getI32IntegerAttr(expectBytes));
+          },
+          py::arg("src"), py::arg("dst"), py::arg("indices"),
+          py::arg("completionBarrier") = py::none(),
+          py::arg("expectBytes") = -1)
       .def("create_local_pointers",
            [](TritonOpBuilder &self, mlir::Type resultTy, mlir::Value memDesc,
               py::args args) -> mlir::OpState {

--- a/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
+++ b/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
@@ -349,6 +349,8 @@ void init_triton_musa_tle_dialect_passes_ttgpuir(py::module m) {
                      mlir::createTritonMUSAGPUTLELowerExclusiveCumsum);
   ADD_PASS_WRAPPER_0("add_tle_lower_barrier_allocations",
                      mlir::createTritonMUSAGPUTLELowerBarrierAllocations);
+  ADD_PASS_WRAPPER_0("add_tle_lower_tme_transactions",
+                     mlir::createTritonMUSAGPUTLELowerTMETransactions);
   ADD_PASS_WRAPPER_0("add_tle_insert_local_pointer_barriers",
                      mlir::createTritonMUSAGPUTLEInsertLocalPointerBarriers);
   ADD_PASS_WRAPPER_0("add_tle_optimize_local_pointer_loads",

--- a/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
+++ b/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
@@ -175,16 +175,25 @@ void init_triton_musa_tle_ir(py::module m) {
       .def("create_memdesc_index",
            [](TritonOpBuilder &self, mlir::Type resultType, mlir::Value src,
               mlir::Value index) -> mlir::Value {
-             auto srcType = mlir::dyn_cast<ttg::MemDescType>(src.getType());
-             if (!srcType || srcType.getShape().empty())
-               throw py::value_error(
-                   "mthreads TLE memdesc index requires a memdesc source");
-
              auto indexType =
                  mlir::dyn_cast<mlir::IntegerType>(index.getType());
              if (!indexType || !indexType.isInteger(32))
                throw py::value_error(
                    "mthreads TLE memdesc index requires an int32 index");
+
+             if (src.getType().isInteger(32)) {
+               // The public barrier object still asks for a logical slot type,
+               // but mthreads barriers are hardware IDs rather than memdescs.
+               (void)resultType;
+               return self
+                   .create<mlir::triton::musa_tle::BarrierIndexOp>(src, index)
+                   .getBarId();
+             }
+
+             auto srcType = mlir::dyn_cast<ttg::MemDescType>(src.getType());
+             if (!srcType || srcType.getShape().empty())
+               throw py::value_error(
+                   "mthreads TLE memdesc index requires a memdesc source");
 
              llvm::APInt constantIndex;
              if (mlir::matchPattern(index,
@@ -199,6 +208,51 @@ void init_triton_musa_tle_ir(py::module m) {
              }
 
              return self.create<ttg::MemDescIndexOp>(resultType, src, index);
+           })
+      .def("create_barrier_alloc",
+           [](TritonOpBuilder &self, mlir::Type resultType, int32_t numBarriers,
+              int32_t arriveCount, int32_t initPolarity,
+              int32_t expectBytes) -> mlir::Value {
+             // The frontend result type is a logical barrier-array type.  The
+             // backend handle is an i32 base ID and is resolved by late
+             // mthreads barrier lowering.
+             (void)resultType;
+             if (numBarriers > 63)
+               throw py::value_error(
+                   "mthreads TLE barrier allocation exceeds the 63 hardware "
+                   "barrier id limit");
+             auto &builder = self.getBuilder();
+             mlir::IntegerAttr expectBytesAttr;
+             if (expectBytes > 0)
+               expectBytesAttr = builder.getI32IntegerAttr(expectBytes);
+             return self.create<mlir::triton::musa_tle::BarrierAllocOp>(
+                 builder.getI32IntegerAttr(numBarriers),
+                 builder.getI32IntegerAttr(arriveCount),
+                 builder.getI32IntegerAttr(initPolarity), expectBytesAttr);
+           })
+      .def("create_barrier_wait_mbarrier",
+           [](TritonOpBuilder &self, mlir::Value barrier,
+              mlir::Value phase) -> void {
+             self.create<mlir::triton::musa_tle::BarrierWaitOp>(barrier, phase);
+           })
+      .def("create_barrier_arrive_mbarrier",
+           [](TritonOpBuilder &self, mlir::Value barrier, int32_t arriveCount,
+              mlir::Value phase) -> void {
+             auto &builder = self.getBuilder();
+             self.create<mlir::triton::musa_tle::BarrierArriveOp>(
+                 barrier, phase, builder.getI32IntegerAttr(arriveCount));
+           })
+      .def("create_barrier_wait_named",
+           [](TritonOpBuilder &, mlir::Value, int32_t, int32_t) -> void {
+             throw py::value_error(
+                 "mthreads TLE named barrier backend is unsupported; "
+                 "phaseIdx is required");
+           })
+      .def("create_barrier_arrive_named",
+           [](TritonOpBuilder &, mlir::Value, int32_t, int32_t) -> void {
+             throw py::value_error(
+                 "mthreads TLE named barrier backend is unsupported; "
+                 "phaseIdx is required");
            })
       .def("create_exclusive_cumsum",
            [](TritonOpBuilder &self, mlir::Type exclusiveTy, mlir::Type totalTy,

--- a/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
+++ b/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
@@ -5,6 +5,7 @@
 #include "ir.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/Pass/PassManager.h"
 #include "passes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -170,6 +171,34 @@ void init_triton_musa_tle_ir(py::module m) {
                indices.push_back(py::cast<mlir::Value>(arg));
              return self.create<mlir::triton::musa_tle::LocalPointersOp>(
                  resultTy, memDesc, indices);
+           })
+      .def("create_memdesc_index",
+           [](TritonOpBuilder &self, mlir::Type resultType, mlir::Value src,
+              mlir::Value index) -> mlir::Value {
+             auto srcType = mlir::dyn_cast<ttg::MemDescType>(src.getType());
+             if (!srcType || srcType.getShape().empty())
+               throw py::value_error(
+                   "mthreads TLE memdesc index requires a memdesc source");
+
+             auto indexType =
+                 mlir::dyn_cast<mlir::IntegerType>(index.getType());
+             if (!indexType || !indexType.isInteger(32))
+               throw py::value_error(
+                   "mthreads TLE memdesc index requires an int32 index");
+
+             llvm::APInt constantIndex;
+             if (mlir::matchPattern(index,
+                                    mlir::m_ConstantInt(&constantIndex))) {
+               int64_t slot = constantIndex.getSExtValue();
+               int64_t leadingDimension = srcType.getShape().front();
+               if (slot < 0 || slot >= leadingDimension)
+                 throw py::value_error("mthreads TLE memdesc index " +
+                                       std::to_string(slot) +
+                                       " out of bounds for leading dimension " +
+                                       std::to_string(leadingDimension));
+             }
+
+             return self.create<ttg::MemDescIndexOp>(resultType, src, index);
            })
       .def("create_exclusive_cumsum",
            [](TritonOpBuilder &self, mlir::Type exclusiveTy, mlir::Type totalTy,

--- a/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
+++ b/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
@@ -165,6 +165,16 @@ void init_triton_musa_tle_ir(py::module m) {
               mlir::Value value) -> mlir::Value {
              return self.create<ttg::LocalAllocOp>(resultTy, value);
            })
+      .def("mark_musa_tle_auto_shared_layout",
+           [](TritonOpBuilder &self, mlir::Value value) -> void {
+             mlir::Operation *def = value.getDefiningOp();
+             if (!def || !mlir::isa<ttg::LocalAllocOp>(def))
+               throw py::value_error(
+                   "mthreads TLE auto shared layout marker requires a "
+                   "ttg.local_alloc result");
+             def->setAttr("musa_tle.auto_shared_layout",
+                          self.getBuilder().getUnitAttr());
+           })
       .def("get_memdesc_type",
            [](TritonOpBuilder &self, std::vector<int64_t> shape,
               mlir::Type &elementType, mlir::Attribute &encoding,
@@ -205,6 +215,25 @@ void init_triton_musa_tle_ir(py::module m) {
           py::arg("src"), py::arg("dst"), py::arg("indices"),
           py::arg("completionBarrier") = py::none(),
           py::arg("expectBytes") = -1)
+      .def("create_tle_wgmma",
+           [](TritonOpBuilder &self, mlir::Value a, mlir::Value b,
+              mlir::Value c, mlir::triton::InputPrecision inputPrecision,
+              int maxNumImpreciseAcc, bool isAsync) -> mlir::Value {
+             return self
+                 .create<mlir::triton::musa_tle::SqmmaOp>(
+                     c.getType(), a, b, c, inputPrecision, maxNumImpreciseAcc,
+                     isAsync)
+                 .getD();
+           })
+      .def("create_tle_wgmma_wait",
+           [](TritonOpBuilder &self, mlir::Value input,
+              unsigned pendings) -> mlir::Value {
+             auto attr = self.getBuilder().getI32IntegerAttr(pendings);
+             return self
+                 .create<mlir::triton::musa_tle::SqmmaWaitOp>(input.getType(),
+                                                              input, attr)
+                 .getOutput();
+           })
       .def("create_local_pointers",
            [](TritonOpBuilder &self, mlir::Type resultTy, mlir::Value memDesc,
               py::args args) -> mlir::OpState {
@@ -351,6 +380,8 @@ void init_triton_musa_tle_dialect_passes_ttgpuir(py::module m) {
                      mlir::createTritonMUSAGPUTLESelectEncodings);
   ADD_PASS_WRAPPER_0("add_tle_lower_exclusive_cumsum",
                      mlir::createTritonMUSAGPUTLELowerExclusiveCumsum);
+  ADD_PASS_WRAPPER_0("add_tle_lower_sqmma",
+                     mlir::createTritonMUSAGPUTLELowerSqmma);
   ADD_PASS_WRAPPER_0("add_tle_lower_barrier_allocations",
                      mlir::createTritonMUSAGPUTLELowerBarrierAllocations);
   ADD_PASS_WRAPPER_0("add_tle_lower_tme_transactions",

--- a/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
+++ b/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
@@ -471,8 +471,12 @@ void init_triton_musa_tle_ir(py::module m) {
       .def("create_warp_specialize",
            [](TritonOpBuilder &self, std::vector<mlir::Type> resultTypes,
               std::vector<int32_t> partitionNumWarps) -> TLEWarpSpecializeOp {
-             return TLEWarpSpecializeOp(self.create<ttg::WarpSpecializeOp>(
-                 resultTypes, partitionNumWarps));
+             auto &builder = self.getBuilder();
+             auto op = self.create<ttg::WarpSpecializeOp>(resultTypes,
+                                                          partitionNumWarps);
+             op->setAttr("musa_tle.static_warp_specialize",
+                         builder.getUnitAttr());
+             return TLEWarpSpecializeOp(op);
            })
       .def("create_exclusive_cumsum",
            [](TritonOpBuilder &self, mlir::Type exclusiveTy, mlir::Type totalTy,
@@ -507,6 +511,10 @@ void init_triton_musa_tle_dialect_passes_ttgpuir(py::module m) {
                      mlir::createTritonMUSAGPUTLELowerSqmma);
   ADD_PASS_WRAPPER_0("add_tle_lower_pipe",
                      mlir::createTritonMUSAGPUTLELowerPipe);
+  ADD_PASS_WRAPPER_0("add_tle_prepare_warp_specialize",
+                     mlir::createTritonMUSAGPUTLEPrepareWarpSpecialize);
+  ADD_PASS_WRAPPER_0("add_tle_lower_warp_specialize",
+                     mlir::createTritonMUSAGPUTLELowerWarpSpecialize);
   ADD_PASS_WRAPPER_0("add_tle_lower_barrier_allocations",
                      mlir::createTritonMUSAGPUTLELowerBarrierAllocations);
   ADD_PASS_WRAPPER_0("add_tle_lower_tme_transactions",

--- a/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
+++ b/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
@@ -281,6 +281,10 @@ void init_triton_musa_tle_ir(py::module m) {
       .def("create_barrier_arrive_mbarrier",
            [](TritonOpBuilder &self, mlir::Value barrier, int32_t arriveCount,
               mlir::Value phase) -> void {
+             if (arriveCount != 1)
+               throw py::value_error(
+                   "mthreads hardware barrier arrive requires arrive_count = "
+                   "1");
              auto &builder = self.getBuilder();
              self.create<mlir::triton::musa_tle::BarrierArriveOp>(
                  barrier, phase, builder.getI32IntegerAttr(arriveCount));
@@ -351,6 +355,8 @@ void init_triton_musa_tle_dialect_passes_ttgpuir(py::module m) {
                      mlir::createTritonMUSAGPUTLELowerBarrierAllocations);
   ADD_PASS_WRAPPER_0("add_tle_lower_tme_transactions",
                      mlir::createTritonMUSAGPUTLELowerTMETransactions);
+  ADD_PASS_WRAPPER_0("add_tle_lower_barrier_operations",
+                     mlir::createTritonMUSAGPUTLELowerBarrierOperations);
   ADD_PASS_WRAPPER_0("add_tle_insert_local_pointer_barriers",
                      mlir::createTritonMUSAGPUTLEInsertLocalPointerBarriers);
   ADD_PASS_WRAPPER_0("add_tle_optimize_local_pointer_loads",

--- a/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
+++ b/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
@@ -8,6 +8,7 @@
 #include "mlir/IR/Matchers.h"
 #include "mlir/Pass/PassManager.h"
 #include "passes.h"
+#include "tle/dialect/include/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
@@ -20,6 +21,7 @@
 
 namespace py = pybind11;
 namespace ttg = mlir::triton::gpu;
+namespace tle = mlir::triton::tle;
 
 // Backend-local `musa_tle` dialect adapters. Frontend marker pass wrappers
 // live in tle/frontend/triton_mthreads_frontend.cc; keep them separate from
@@ -215,6 +217,127 @@ void init_triton_musa_tle_ir(py::module m) {
           py::arg("src"), py::arg("dst"), py::arg("indices"),
           py::arg("completionBarrier") = py::none(),
           py::arg("expectBytes") = -1)
+      .def("create_pipe_create",
+           [](TritonOpBuilder &self, std::vector<mlir::Value> fields,
+              int32_t capacity, const std::string &scope,
+              const std::string &pipeName, std::vector<std::string> fieldNames,
+              std::vector<std::string> readerNames, bool oneShot) -> void {
+             auto &builder = self.getBuilder();
+             llvm::SmallVector<mlir::Attribute> fieldNameAttrs;
+             for (llvm::StringRef name : fieldNames)
+               fieldNameAttrs.push_back(builder.getStringAttr(name));
+             llvm::SmallVector<mlir::Attribute> readerNameAttrs;
+             for (llvm::StringRef name : readerNames)
+               readerNameAttrs.push_back(builder.getStringAttr(name));
+             mlir::StringAttr pipeNameAttr;
+             if (!pipeName.empty())
+               pipeNameAttr = builder.getStringAttr(pipeName);
+             mlir::ArrayAttr readersAttr;
+             if (!readerNameAttrs.empty())
+               readersAttr = builder.getArrayAttr(readerNameAttrs);
+             mlir::BoolAttr oneShotAttr;
+             if (oneShot)
+               oneShotAttr = builder.getBoolAttr(true);
+             self.create<tle::PipeCreateOp>(
+                 fields, builder.getI32IntegerAttr(capacity),
+                 builder.getStringAttr(scope), pipeNameAttr,
+                 builder.getArrayAttr(fieldNameAttrs), readersAttr,
+                 oneShotAttr);
+           })
+      .def("create_pipe_writer_acquire",
+           [](TritonOpBuilder &self, std::vector<mlir::Value> fields,
+              mlir::Value stage, mlir::Value phase, int32_t capacity,
+              const std::string &scope, const std::string &pipeName,
+              std::vector<std::string> fieldNames) -> void {
+             auto &builder = self.getBuilder();
+             llvm::SmallVector<mlir::Attribute> fieldNameAttrs;
+             for (llvm::StringRef name : fieldNames)
+               fieldNameAttrs.push_back(builder.getStringAttr(name));
+             mlir::StringAttr pipeNameAttr;
+             if (!pipeName.empty())
+               pipeNameAttr = builder.getStringAttr(pipeName);
+             self.create<tle::PipeWriterAcquireOp>(
+                 fields, stage, phase, builder.getI32IntegerAttr(capacity),
+                 builder.getStringAttr(scope), pipeNameAttr,
+                 builder.getArrayAttr(fieldNameAttrs));
+           })
+      .def("create_pipe_writer_commit",
+           [](TritonOpBuilder &self, std::vector<mlir::Value> fields,
+              mlir::Value stage, int32_t capacity, const std::string &scope,
+              const std::string &pipeName,
+              std::vector<std::string> fieldNames) -> void {
+             auto &builder = self.getBuilder();
+             llvm::SmallVector<mlir::Attribute> fieldNameAttrs;
+             for (llvm::StringRef name : fieldNames)
+               fieldNameAttrs.push_back(builder.getStringAttr(name));
+             mlir::StringAttr pipeNameAttr;
+             if (!pipeName.empty())
+               pipeNameAttr = builder.getStringAttr(pipeName);
+             self.create<tle::PipeWriterCommitOp>(
+                 fields, stage, builder.getI32IntegerAttr(capacity),
+                 builder.getStringAttr(scope), pipeNameAttr,
+                 builder.getArrayAttr(fieldNameAttrs));
+           })
+      .def("create_pipe_writer_close",
+           [](TritonOpBuilder &self, std::vector<mlir::Value> fields,
+              mlir::Value stage, mlir::Value phase, int32_t capacity,
+              const std::string &scope, const std::string &pipeName,
+              std::vector<std::string> fieldNames) -> void {
+             auto &builder = self.getBuilder();
+             llvm::SmallVector<mlir::Attribute> fieldNameAttrs;
+             for (llvm::StringRef name : fieldNames)
+               fieldNameAttrs.push_back(builder.getStringAttr(name));
+             mlir::StringAttr pipeNameAttr;
+             if (!pipeName.empty())
+               pipeNameAttr = builder.getStringAttr(pipeName);
+             self.create<tle::PipeWriterCloseOp>(
+                 fields, stage, phase, builder.getI32IntegerAttr(capacity),
+                 builder.getStringAttr(scope), pipeNameAttr,
+                 builder.getArrayAttr(fieldNameAttrs));
+           })
+      .def("create_pipe_reader_wait",
+           [](TritonOpBuilder &self, std::vector<mlir::Value> fields,
+              mlir::Value stage, mlir::Value phase, int32_t capacity,
+              const std::string &scope, const std::string &pipeName,
+              std::vector<std::string> fieldNames,
+              const std::string &readerName,
+              std::vector<std::string>) -> mlir::Value {
+             auto &builder = self.getBuilder();
+             llvm::SmallVector<mlir::Attribute> fieldNameAttrs;
+             for (llvm::StringRef name : fieldNames)
+               fieldNameAttrs.push_back(builder.getStringAttr(name));
+             mlir::StringAttr pipeNameAttr;
+             if (!pipeName.empty())
+               pipeNameAttr = builder.getStringAttr(pipeName);
+             mlir::StringAttr readerNameAttr;
+             if (!readerName.empty())
+               readerNameAttr = builder.getStringAttr(readerName);
+             return self.create<tle::PipeReaderWaitOp>(
+                 builder.getI1Type(), fields, stage, phase,
+                 builder.getI32IntegerAttr(capacity),
+                 builder.getStringAttr(scope), pipeNameAttr,
+                 builder.getArrayAttr(fieldNameAttrs), readerNameAttr);
+           })
+      .def("create_pipe_reader_release",
+           [](TritonOpBuilder &self, std::vector<mlir::Value> fields,
+              mlir::Value stage, int32_t capacity, const std::string &scope,
+              const std::string &pipeName, std::vector<std::string> fieldNames,
+              const std::string &readerName, std::vector<std::string>) -> void {
+             auto &builder = self.getBuilder();
+             llvm::SmallVector<mlir::Attribute> fieldNameAttrs;
+             for (llvm::StringRef name : fieldNames)
+               fieldNameAttrs.push_back(builder.getStringAttr(name));
+             mlir::StringAttr pipeNameAttr;
+             if (!pipeName.empty())
+               pipeNameAttr = builder.getStringAttr(pipeName);
+             mlir::StringAttr readerNameAttr;
+             if (!readerName.empty())
+               readerNameAttr = builder.getStringAttr(readerName);
+             self.create<tle::PipeReaderReleaseOp>(
+                 fields, stage, builder.getI32IntegerAttr(capacity),
+                 builder.getStringAttr(scope), pipeNameAttr,
+                 builder.getArrayAttr(fieldNameAttrs), readerNameAttr);
+           })
       .def("create_tle_wgmma",
            [](TritonOpBuilder &self, mlir::Value a, mlir::Value b,
               mlir::Value c, mlir::triton::InputPrecision inputPrecision,
@@ -382,6 +505,8 @@ void init_triton_musa_tle_dialect_passes_ttgpuir(py::module m) {
                      mlir::createTritonMUSAGPUTLELowerExclusiveCumsum);
   ADD_PASS_WRAPPER_0("add_tle_lower_sqmma",
                      mlir::createTritonMUSAGPUTLELowerSqmma);
+  ADD_PASS_WRAPPER_0("add_tle_lower_pipe",
+                     mlir::createTritonMUSAGPUTLELowerPipe);
   ADD_PASS_WRAPPER_0("add_tle_lower_barrier_allocations",
                      mlir::createTritonMUSAGPUTLELowerBarrierAllocations);
   ADD_PASS_WRAPPER_0("add_tle_lower_tme_transactions",
@@ -400,7 +525,8 @@ void init_triton_musa_tle_dialect_passes_ttgpuir(py::module m) {
 }
 
 void register_triton_musa_tle_dialects(mlir::DialectRegistry &registry) {
-  registry.insert<mlir::triton::musa_tle::MUSATLEDialect>();
+  registry.insert<mlir::triton::musa_tle::MUSATLEDialect,
+                  mlir::triton::tle::TleDialect>();
 }
 
 #endif // __TLE__

--- a/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
+++ b/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
@@ -347,6 +347,8 @@ void init_triton_musa_tle_dialect_passes_ttgpuir(py::module m) {
                      mlir::createTritonMUSAGPUTLESelectEncodings);
   ADD_PASS_WRAPPER_0("add_tle_lower_exclusive_cumsum",
                      mlir::createTritonMUSAGPUTLELowerExclusiveCumsum);
+  ADD_PASS_WRAPPER_0("add_tle_lower_barrier_allocations",
+                     mlir::createTritonMUSAGPUTLELowerBarrierAllocations);
   ADD_PASS_WRAPPER_0("add_tle_insert_local_pointer_barriers",
                      mlir::createTritonMUSAGPUTLEInsertLocalPointerBarriers);
   ADD_PASS_WRAPPER_0("add_tle_optimize_local_pointer_loads",

--- a/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
+++ b/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
@@ -27,6 +27,28 @@ namespace ttg = mlir::triton::gpu;
 
 namespace {
 
+class TLEWarpSpecializeOp {
+public:
+  explicit TLEWarpSpecializeOp(ttg::WarpSpecializeOp op) : op(op) {}
+
+  mlir::Region &getDefaultRegion() { return op.getDefaultRegion(); }
+  mlir::Region &getPartitionOpHolder() { return op.getPartitionOpHolder(); }
+  mlir::Operation *getOperation() { return op.getOperation(); }
+
+  mlir::Value getResult(unsigned index) {
+    if (index >= op.getNumResults())
+      throw py::index_error("WarpSpecializeOp result index out of range");
+    return op.getResult(index);
+  }
+
+  void setRequestedRegisters(std::vector<int32_t> requestedRegisters) {
+    op.setRequestedRegisters(requestedRegisters);
+  }
+
+private:
+  ttg::WarpSpecializeOp op;
+};
+
 void checkCtaRank(llvm::ArrayRef<unsigned> order,
                   llvm::ArrayRef<unsigned> ctasPerCGA,
                   llvm::ArrayRef<unsigned> ctaSplitNum,
@@ -80,7 +102,17 @@ mlir::Attribute getSharedMemorySpace(mlir::MLIRContext *context,
 } // namespace
 
 void init_triton_musa_tle_ir(py::module m) {
-  (void)m;
+  py::class_<TLEWarpSpecializeOp>(m, "WarpSpecializeOp", py::module_local())
+      .def("get_default_region", &TLEWarpSpecializeOp::getDefaultRegion,
+           py::return_value_policy::reference)
+      .def("get_partition_op_holder",
+           &TLEWarpSpecializeOp::getPartitionOpHolder,
+           py::return_value_policy::reference)
+      .def("get_operation", &TLEWarpSpecializeOp::getOperation,
+           py::return_value_policy::reference)
+      .def("get_result", &TLEWarpSpecializeOp::getResult)
+      .def("set_requested_registers",
+           &TLEWarpSpecializeOp::setRequestedRegisters);
 
   auto *builderClsPtr = ir::getBuilderClass();
   if (!builderClsPtr)
@@ -264,6 +296,27 @@ void init_triton_musa_tle_ir(py::module m) {
              throw py::value_error(
                  "mthreads TLE named barrier backend is unsupported; "
                  "phaseIdx is required");
+           })
+      .def("create_warp_return",
+           [](TritonOpBuilder &self) -> mlir::Operation * {
+             return self.create<ttg::WarpReturnOp>();
+           })
+      .def("create_warp_yield",
+           [](TritonOpBuilder &self,
+              std::vector<mlir::Value> values) -> mlir::Operation * {
+             return self.create<ttg::WarpYieldOp>(values);
+           })
+      .def("create_warp_specialize_partitions",
+           [](TritonOpBuilder &self, std::vector<mlir::Value> explicitCaptures,
+              int32_t numPartitions) -> mlir::Operation * {
+             return self.create<ttg::WarpSpecializePartitionsOp>(
+                 explicitCaptures, numPartitions);
+           })
+      .def("create_warp_specialize",
+           [](TritonOpBuilder &self, std::vector<mlir::Type> resultTypes,
+              std::vector<int32_t> partitionNumWarps) -> TLEWarpSpecializeOp {
+             return TLEWarpSpecializeOp(self.create<ttg::WarpSpecializeOp>(
+                 resultTypes, partitionNumWarps));
            })
       .def("create_exclusive_cumsum",
            [](TritonOpBuilder &self, mlir::Type exclusiveTy, mlir::Type totalTy,


### PR DESCRIPTION
<!-- PR Title Format:
[TLE][BUILD][TEST][CI/CD][DOC][PROTON][BACKEND][FLIR] Brief description
[LANGUAGE][AUTOTUNER][LAYOUT][PIPELINE][WarpSpecialization] Brief description
Do not set the following title tags: [FEATURE][BUG][FixBug][Refine] ...
-->
## 1. Memory and buffered-tensor primitives

### 1.1 `buffer.slot(index)` and `barriers[index]`

`buffer.slot(index)` creates a view of one element of the leading stage
dimension. Constant and scalar dynamic indices are supported. Constant indices
are bounds checked during compilation. A block tensor is not accepted as a
stage index. Dynamic indices are not runtime bounds checked by this API, so the
kernel must keep them in range.

Barrier indexing follows the same static-or-scalar-dynamic model. Dynamic
indexing is kept as integer hardware-ID arithmetic; it does not create a
shared-memory barrier table.

## 2. Copy and TME completion primitives
### 2.1 Explicit TME completion with barrier

The supported explicit form is:

```python
full = tle.gpu.alloc_barriers(
    STAGES,
    arrive_count=1,
    init=tle.gpu.PENDING,
    expect_bytes=BLOCK_M * BLOCK_K * ELEMENT_BYTES,
)

tle.gpu.copy(
    a_desc,
    a_smem.slot(slot),
    (BLOCK_M, BLOCK_K),
    (m_offset, k_offset),
    barrier=full[slot],
)
tle.gpu.barrier_wait(full[slot], phaseIdx=phase)
```

The lowering emits transaction-byte registration, the TME load, and completion
arrival against the same hardware barrier ID. In a non-warp-specialized kernel,
thread 0 issues this sequence. In the supported warp-specialized form, the
issue thread is the first thread of producer partition 0.

Restrictions:

- Only descriptor global-to-shared TME copy accepts `barrier=`.
- A barrier array with more than one element must be explicitly indexed.
- `expect_bytes` must be a positive compile-time integer.
- The byte count is the complete logical transaction size and is not inferred
  by the standalone `copy(..., barrier=...)` API.
- A pipe-managed TME copy must not also carry an explicit user barrier.
- The explicit-completion copy must be in producer partition 0 when it is
  nested under the supported static `warp_specialize` form.

For an SQMMA-compatible grouped TME load whose leading width exceeds 256 bytes,
the current late lowering may emit multiple TME load intrinsics. Those emitted
segments receive the same logical `bar_id`. This does not relax the pipe
restriction that one acquire/commit interval contains exactly one logical TME
copy operation.

## 3. Barrier primitives

### 3.1 Allocation and resource model

`tle.gpu.alloc_barrier` and `tle.gpu.alloc_barriers` lower to ranges of MUSA
hardware barrier IDs. The barrier objects themselves do not consume shared
memory.

Hardware IDs are reserved from the mthreads function-wide resource pool. The
valid allocatable range is IDs 1 through 63. Explicit user barriers, pipe full
and empty rings, and warp-partition synchronization all consume this shared
budget. Compilation fails with a stable diagnostic when the combined demand
cannot be reserved.

All barrier allocations must be in the function entry block. When static warp
specialization is present, they must appear before the top-level
`warp_specialize`. All allocations must dominate the first barrier use. The
lowering initializes every allocated hardware barrier and emits one local CTA
rendezvous after initialization so that no partition can use an uninitialized
ID.

### 3.2 Phase-aware wait and arrive

The mthreads backend requires `phaseIdx`:

```python
tle.gpu.barrier_wait(barriers[slot], phaseIdx=iteration_phase)
tle.gpu.barrier_arrive(barriers[slot], arrive_count=1,
                       phaseIdx=iteration_phase)
```

The logical phase is reduced to one bit. The effective hardware phase is:

```text
(phaseIdx & 1) XOR initial_polarity
```

where `initial_polarity` is zero for `PENDING` and one for `READY`. Therefore,
`PENDING` and `READY` define the logical interpretation of generation zero;
they are not separate software state objects. Reusing a slot requires the
caller or pipe iteration mapping to advance/toggle the phase.

Static and scalar dynamic phases are supported. A block phase or non-integer
phase is rejected.

### 3.3 Arrival-count restriction

The allocation-time `arrive_count` is the number of arrivals required to
complete a hardware barrier generation and may be greater than one. However,
each emitted `barrier_arrive` operation can contribute only one arrival:

```python
tle.gpu.barrier_arrive(bar, arrive_count=1, phaseIdx=phase)
```

Passing an operation-level `arrive_count` other than one is rejected because
the current mthreads hardware lowering has no increment-by-N arrival operation.
For a consumer group, completion is achieved by convergent per-warp arrivals
against a barrier initialized with the consumer warp count.

### 3.4 Unsupported named-barrier path

The public frontend interprets `barrier_wait(bar)` or `barrier_arrive(bar)`
without `phaseIdx` as the generic named-barrier path. mthreads hardware barriers
are phase-aware resources and the backend does not implement the NVIDIA-style
named-barrier mechanism. Consequently, the no-`phaseIdx` form is rejected on
mthreads with the diagnostic that the named barrier backend is unsupported.

## 4. `tle.gpu.wgmma`  and  `tle.gpu.wgmma_wait`

The public API keeps the generic TLE spelling, but the mthreads frontend emits
backend-local operations:

```text
tle.gpu.wgmma      -> musa_tle.sqmma      -> ttmg.squad_dot
tle.gpu.wgmma_wait -> musa_tle.sqmma_wait -> ttmg.squad_dot_wait
```

The final LLVM IR contains MUSA SQMMA intrinsics and the hardware parameterless
SQMMA wait.

The currently supported contract is:

- A and B are rank-2 shared-memory `buffered_tensor` values.
- A and B have the same input dtype.
- Input dtype is `tl.float16`, `tl.bfloat16`, or `tl.float8e4nv`.
- The accumulator and output dtype are `tl.float32`.
- `max_num_imprecise_acc` is zero.
- `trans_a=False` and `trans_b=False`.
- M and N are at least 16 and divisible by 16.
- K is at least 16 and the complete M/N/K shape must admit a native PH1 SQMMA
  configuration.
- The active SQMMA warp count is at least four and divisible by four.
- Root A/B allocations use `layout=None, nv_mma_shared_layout=True` so the
  lowering can select a TME-compatible physical swizzle.

The compiler selects a supported native instruction shape and warp
distribution. A larger logical operation can be decomposed automatically. For
example, a logical `256 x 256 x 64` FP16 operation with 16 warps is covered by
a runtime test while the source contains one `wgmma` and one `wgmma_wait`.

An async result may feed the accumulator of another SQMMA or travel through the
supported loop-carried path, but it must pass through `wgmma_wait` before an
ordinary tensor consumer or store.

### 4.1 Wait limitation

Only the fully draining form is supported:

```python
acc = tle.gpu.wgmma_wait(0, acc)
```

`pendings > 0` is rejected. The initial implementation cannot keep multiple
independently addressable outstanding SQMMA groups and wait until only a
nonzero number remain. The returned accumulator is the dependency-released SSA
value and must be used after the wait.

### 4.2 Covered SQMMA types and shapes

Runtime coverage includes:

- FP16 with K in `{16, 32, 64}`;
- BF16 with K in `{16, 32, 64}`;
- FP8 E4M3 (`tl.float8e4nv`) with K in `{32, 64, 128}`;
- M/N pairs `(16,64)`, `(32,32)`, `(32,64)`, `(32,128)`, `(64,16)`,
  `(64,32)`, `(64,64)`, `(64,128)`, `(128,32)`, `(128,64)`, and
  `(128,128)`;
- a loop-carried accumulation case;
- the `256 x 256 x 64` macro-tile decomposition case.

This test matrix is evidence for the listed configurations, not a guarantee
that every shape satisfying only the divisibility checks can be mapped. The
native configuration selector remains authoritative and rejects an unmappable
shape during compilation.

## 5. `tle.pipe`

### 5.1 Supported API model

The initial mthreads pipe is a CTA-scoped, cyclic, single-producer/
single-consumer pipe with exactly one payload field:

```python
a_smem = tle.gpu.alloc(
    (STAGES, BLOCK_M, BLOCK_K),
    dtype=tl.float16,
    layout=None,
    nv_mma_shared_layout=True,
)

a_pipe = tle.pipe(
    capacity=STAGES,
    scope="cta",
    name="a",
    a=a_smem,
)

writer = a_pipe.writer()
reader = a_pipe.reader()

write_slot = writer.acquire(iteration)
tle.gpu.copy(a_desc, write_slot.a, (BLOCK_M, BLOCK_K), offsets)
writer.commit(iteration)

read_result = reader.wait(iteration)
tile = read_result.slot.a
# consume tile
reader.release(iteration)
```

`slot.a` is a view created from the current stage index; it is not an
independent allocation. The stage and phase are derived from the iteration:

```text
stage = iteration % capacity
phase = (iteration // capacity) % 2
```

The lowerer creates two hardware-barrier rings for each pipe:

- `full[capacity]`, initialized logically `PENDING`, with one producer/TME
  completion arrival;
- `empty[capacity]`, initialized logically `READY`, with an arrival count equal
  to the consumer warp count.

The lifecycle mapping is:

| Pipe operation | Hardware protocol |
| --- | --- |
| `writer.acquire(i)` | Wait for `empty[stage]` using the writer-side phase. |
| TME copy + `writer.commit(i)` | Attach the copy to `full[stage]`, register transaction bytes, and complete the barrier when TME finishes. |
| `reader.wait(i)` | Wait for `full[stage]`. |
| `reader.release(i)` | Each consumer warp contributes one arrival to `empty[stage]`. |

### 5.2 Pipe restrictions

The initial mthreads pipe intentionally rejects:

- more than one payload field in one pipe;
- named readers or multiple readers;
- reader field subsets;
- `one_shot=True`;
- `writer.close`;
- scopes other than `scope="cta"`;
- an explicit barrier on a pipe-managed copy;
- zero or more than one logical TME copy between a matching
  `writer.acquire` and `writer.commit`;
- transaction sizes that vary between commits on the same pipe;
- an acquire/commit or wait/release pair that cannot be matched in the same
  block and for the same stage;
- mixing non-warp-specialized endpoints and warp-specialized endpoints on the
  same pipe.

Because close is unsupported, `reader.wait(...).is_closed` is materialized as
constant false on the mthreads path and must not be used as an end-of-stream
signal.

The payload field must be shared memory, rank two or higher, and its leading
dimension must equal `capacity`. Capacity must be a positive compile-time
integer. Capacities 1, 2, and 3 have compile and runtime coverage. Larger
capacities are not categorically rejected, but they consume two hardware
barrier IDs per pipe stage and have not received the same runtime coverage.

Multiple independent single-field pipes are supported. The optimized MM uses
one pipe for A and one for B because each input has an independent TME
transaction. This preserves one logical TME transaction per full barrier and
avoids unsupported multi-field aggregation.

### 5.3 Pipe resource cost

The full and empty barrier rings use hardware IDs and add no shared-memory
bytes. The shared-memory cost is the payload allocation itself. For two input
pipes with stage capacity `S`, the barrier demand is `4 * S` IDs before adding
any other user or partition-synchronization barriers.

## 6. `tle.gpu.warp_specialize`

### 6.1 Supported static form

The supported model has one default consumer and one worker producer:

```python
tle.gpu.warp_specialize(
    (
        (consumer, consumer_args),
        (producer, producer_args),
    ),
    worker_num_warps=(PRODUCER_WARPS,),
    worker_num_regs=(PRODUCER_REGS,),
)
```

The kernel launch `num_warps` belongs to the default consumer partition.
`worker_num_warps[0]` belongs to the producer. The physical launch uses their
sum. Producer warp count is not hard-coded to four; runtime coverage includes
producer counts 1, 2, 4, and 8, including an equal 4-consumer/4-producer case.

The lowering preserves the common `ttg.warp_specialize` container until late
lowering, then emits two explicit thread predicates:

```text
if tid >= consumer_num_warps * 32:
    producer

if tid < consumer_num_warps * 32:
    consumer
```

These are two explicit conditional branches, not an `if/else` dispatch and not
a switch. The producer predicate appears first in CFG order and rejoins before
the consumer predicate; this CFG shape does not serialize producer and consumer
threads. Hardware barrier IDs used by partition synchronization are
rematerialized in the partition, so the control path does not require a
shared-memory mailbox.

### 6.2 Warp-specialize restrictions

The initial implementation requires:

- exactly one marked `warp_specialize` operation per module;
- exactly one default consumer and one producer partition;
- no values returned by the `warp_specialize` operation;
- placement in the Triton function entry block;
- placement as the final operation before `tt.return`;
- one block in each partition region;
- compile-time sequences for `worker_num_warps` and `worker_num_regs`;
- a positive producer warp count accepted by the common dialect verifier;
- captures that dominate the partition split;
- producer-side explicit-completion TME operations only in worker partition 0.

Multiple producers, multiple consumers, nested/static WS regions, partition
results, nonterminal WS placement, and dynamic warp counts are not supported.
The default and producer functions are emitted inline for mthreads, so this is
not an independent-device-kernel launch model.

### 6.3 Synchronization and shared-memory cost

The supported static WS control-flow lowering itself adds no shared-memory
allocation. Pipe barriers and post-SQMMA partition synchronization use hardware
barrier IDs. A local CTA rendezvous is retained for barrier initialization.
Consequently, the important resource constraint is the 63-ID hardware barrier
budget, in addition to the actual payload shared memory and register usage.

## 7. End-to-end matrix-multiplication status

The repository contains an optimized TLE warp-specialized MM and a common
correctness/performance harness at:

```text
third_party/mthreads/python/test/unit/tle/benchmark/test_mm.py
```

It compares:

- native Triton MM;
- optimized TLE-WS MM;
- `torch.matmul`.

The TLE-WS path combines automatic SQMMA shared layouts, two single-field
pipes, explicit TME completion, `wgmma`/`wgmma_wait`, and one static
consumer/producer split. Pipeline stages 1, 2, and 3 are accepted. The pytest
default correctness/performance case is `1024 x 1024 x 1024`; the command-line
harness also provides larger default shapes. Those larger presets are
benchmark inputs, not a claim that every preset is run in routine unit tests.

Example invocations:

```bash
python -m pytest -q -s \
  third_party/mthreads/python/test/unit/tle/benchmark/test_mm.py
```

```bash
python third_party/mthreads/python/test/unit/tle/benchmark/test_mm.py \
  --shape 1024 1024 1024 \
  --shape 8192 7168 16384 \
  --stages 1 2 3
```

The benchmark verifies numerical accuracy before reporting median latency and
the Triton/Torch, TLE-WS/Torch, and TLE-WS/Triton speed ratios.


| M | N | K | Stages | Torch (ms) | Triton (ms) | TLE-WS (ms) | Triton vs Torch | TLE-WS vs Torch | TLE-WS vs Triton |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 1024 | 1024 | 1024 | 1 | 0.029480 | 0.072020 | 0.047400 | 0.4093x | 0.6219x | 1.5194x |
| 1024 | 1024 | 1024 | 2 | 0.016360 | 0.062120 | 0.030240 | 0.2634x | 0.5410x | 2.0542x |
| 1024 | 1024 | 1024 | 3 | 0.016480 | 0.055280 | 0.029020 | 0.2981x | 0.5679x | 1.9049x |
| 2048 | 2048 | 2048 | 1 | 0.056160 | 0.230500 | 0.159200 | 0.2436x | 0.3528x | 1.4479x |
| 2048 | 2048 | 2048 | 2 | 0.056520 | 0.188720 | 0.094000 | 0.2995x | 0.6013x | 2.0077x |
| 2048 | 2048 | 2048 | 3 | 0.055660 | 0.161240 | 0.086560 | 0.3452x | 0.6430x | 1.8628x |
| 4096 | 4096 | 4096 | 1 | 0.414000 | 1.142960 | 0.771680 | 0.3622x | 0.5365x | 1.4811x |
| 4096 | 4096 | 4096 | 2 | 0.416640 | 0.898240 | 0.462880 | 0.4638x | 0.9001x | 1.9405x |
| 4096 | 4096 | 4096 | 3 | 0.417000 | 0.793680 | 0.438000 | 0.5254x | 0.9521x | 1.8121x |
| 8192 | 8192 | 8192 | 1 | 3.354360 | 8.501160 | 5.928640 | 0.3946x | 0.5658x | 1.4339x |
| 8192 | 8192 | 8192 | 2 | 3.334400 | 6.929920 | 3.548240 | 0.4812x | 0.9397x | 1.9531x |
| 8192 | 8192 | 8192 | 3 | 3.346360 | 6.090460 | 3.507880 | 0.5494x | 0.9540x | 1.7362x |
| 8192 | 7168 | 16384 | 1 | 5.821160 | 13.915180 | 10.253881 | 0.4183x | 0.5677x | 1.3571x |
| 8192 | 7168 | 16384 | 2 | 5.835540 | 11.634160 | 6.170440 | 0.5016x | 0.9457x | 1.8855x |
| 8192 | 7168 | 16384 | 3 | 5.819780 | 10.192900 | 5.830360 | 0.5710x | 0.9982x | 1.7482x |