### PR TITLE
[TLE] Fix SparseMLA local-pointer encoding propagation

### DIFF
--- a/python/test/regression/test_sparse_mla_autotune_configs.py
+++ b/python/test/regression/test_sparse_mla_autotune_configs.py
@@ -1,6 +1,9 @@
 import inspect
 import importlib.util
+import math
 from pathlib import Path
+
+import pytest
 
 
 def _load_sparse_mla_module():
@@ -74,3 +77,78 @@ def test_sparse_mla_bench_seed_is_explicit_and_shared():
     assert inspect.signature(module.run_bench_table).parameters["seed"].default == module.BENCH_DEFAULT_SEED
     assert inspect.signature(module.bench_sparse_mla_fwd).parameters["seed"].default == module.BENCH_DEFAULT_SEED
     assert "seed" in inspect.signature(module.benchmark_sparse_mla_fwd.fn).parameters
+
+
+def _run_forward_benchmark_callback(module, provider):
+    return module.benchmark_sparse_mla_fwd.fn(
+        B=1,
+        S=1,
+        SKV=1,
+        H=1,
+        HKV=1,
+        DQK=1,
+        DV=1,
+        topk=1,
+        provider=provider,
+        warmup=1,
+        rep=1,
+        tilelang_block_I=1,
+        tilelang_num_stages=1,
+        tilelang_threads=32,
+        input_mode="flashmla",
+        seed=1,
+    )
+
+
+def _stub_forward_benchmark_inputs(monkeypatch, module):
+    monkeypatch.setattr(module, "_get_bench_sparse_mla_inputs", lambda *args, **kwargs: (None, None, None, None))
+
+
+def _benchmark_failure(message):
+    def fail(*args, **kwargs):
+        raise RuntimeError(message)
+
+    return fail
+
+
+@pytest.mark.parametrize("provider", ["tle-flashmla-prefill", "tilelang"])
+def test_sparse_mla_benchmark_propagates_supported_provider_failure(monkeypatch, provider):
+    module = _load_sparse_mla_module()
+    _stub_forward_benchmark_inputs(monkeypatch, module)
+    monkeypatch.setattr(module, "_HAVE_TILELANG", True)
+    monkeypatch.setattr(module.triton.testing, "do_bench", _benchmark_failure("compile failed"))
+
+    with pytest.raises(RuntimeError, match="compile failed"):
+        _run_forward_benchmark_callback(module, provider)
+
+
+def test_sparse_mla_benchmark_skips_unavailable_optional_provider(monkeypatch):
+    module = _load_sparse_mla_module()
+    _stub_forward_benchmark_inputs(monkeypatch, module)
+    monkeypatch.setattr(module, "_HAVE_TILELANG", False)
+    monkeypatch.setattr(module.triton.testing, "do_bench", _benchmark_failure("unavailable provider was executed"))
+
+    result = _run_forward_benchmark_callback(module, "tilelang")
+
+    assert all(math.isnan(value) for value in result)
+
+
+def test_sparse_mla_single_benchmark_propagates_provider_failure(monkeypatch):
+    module = _load_sparse_mla_module()
+    _stub_forward_benchmark_inputs(monkeypatch, module)
+    monkeypatch.setattr(module, "triton_sparse_mla_fwd_interface", lambda *args, **kwargs: (None, None))
+    monkeypatch.setattr(module, "tle_sparse_mla_fwd_interface", _benchmark_failure("TLE compile failed"))
+    monkeypatch.setattr(module, "_bench_ms", lambda *args, **kwargs: 1.0)
+    monkeypatch.setattr(module, "_sparse_mla_tflops_from_topk_length", lambda *args, **kwargs: 1.0)
+
+    with pytest.raises(RuntimeError, match="TLE compile failed"):
+        module.bench_sparse_mla_fwd(B=1, S=1, SKV=1, H=1, HKV=1, DQK=1, DV=1, topk=1, check_outputs=False)
+
+
+def test_sparse_mla_benchmark_rejects_non_finite_timings(monkeypatch):
+    module = _load_sparse_mla_module()
+    _stub_forward_benchmark_inputs(monkeypatch, module)
+    monkeypatch.setattr(module.triton.testing, "do_bench", lambda *args, **kwargs: (float("nan"), 1.0, 2.0))
+
+    with pytest.raises(RuntimeError, match="non-finite timings"):
+        _run_forward_benchmark_callback(module, "triton")

--- a/python/test/regression/test_sparse_mla_autotune_configs.py
+++ b/python/test/regression/test_sparse_mla_autotune_configs.py
@@ -105,6 +105,7 @@ def _stub_forward_benchmark_inputs(monkeypatch, module):
 
 
 def _benchmark_failure(message):
+
     def fail(*args, **kwargs):
         raise RuntimeError(message)
 

--- a/python/test/regression/test_sparse_mla_autotune_configs.py
+++ b/python/test/regression/test_sparse_mla_autotune_configs.py
@@ -1,9 +1,6 @@
 import inspect
 import importlib.util
-import math
 from pathlib import Path
-
-import pytest
 
 
 def _load_sparse_mla_module():
@@ -77,79 +74,3 @@ def test_sparse_mla_bench_seed_is_explicit_and_shared():
     assert inspect.signature(module.run_bench_table).parameters["seed"].default == module.BENCH_DEFAULT_SEED
     assert inspect.signature(module.bench_sparse_mla_fwd).parameters["seed"].default == module.BENCH_DEFAULT_SEED
     assert "seed" in inspect.signature(module.benchmark_sparse_mla_fwd.fn).parameters
-
-
-def _run_forward_benchmark_callback(module, provider):
-    return module.benchmark_sparse_mla_fwd.fn(
-        B=1,
-        S=1,
-        SKV=1,
-        H=1,
-        HKV=1,
-        DQK=1,
-        DV=1,
-        topk=1,
-        provider=provider,
-        warmup=1,
-        rep=1,
-        tilelang_block_I=1,
-        tilelang_num_stages=1,
-        tilelang_threads=32,
-        input_mode="flashmla",
-        seed=1,
-    )
-
-
-def _stub_forward_benchmark_inputs(monkeypatch, module):
-    monkeypatch.setattr(module, "_get_bench_sparse_mla_inputs", lambda *args, **kwargs: (None, None, None, None))
-
-
-def _benchmark_failure(message):
-
-    def fail(*args, **kwargs):
-        raise RuntimeError(message)
-
-    return fail
-
-
-@pytest.mark.parametrize("provider", ["tle-flashmla-prefill", "tilelang"])
-def test_sparse_mla_benchmark_propagates_supported_provider_failure(monkeypatch, provider):
-    module = _load_sparse_mla_module()
-    _stub_forward_benchmark_inputs(monkeypatch, module)
-    monkeypatch.setattr(module, "_HAVE_TILELANG", True)
-    monkeypatch.setattr(module.triton.testing, "do_bench", _benchmark_failure("compile failed"))
-
-    with pytest.raises(RuntimeError, match="compile failed"):
-        _run_forward_benchmark_callback(module, provider)
-
-
-def test_sparse_mla_benchmark_skips_unavailable_optional_provider(monkeypatch):
-    module = _load_sparse_mla_module()
-    _stub_forward_benchmark_inputs(monkeypatch, module)
-    monkeypatch.setattr(module, "_HAVE_TILELANG", False)
-    monkeypatch.setattr(module.triton.testing, "do_bench", _benchmark_failure("unavailable provider was executed"))
-
-    result = _run_forward_benchmark_callback(module, "tilelang")
-
-    assert all(math.isnan(value) for value in result)
-
-
-def test_sparse_mla_single_benchmark_propagates_provider_failure(monkeypatch):
-    module = _load_sparse_mla_module()
-    _stub_forward_benchmark_inputs(monkeypatch, module)
-    monkeypatch.setattr(module, "triton_sparse_mla_fwd_interface", lambda *args, **kwargs: (None, None))
-    monkeypatch.setattr(module, "tle_sparse_mla_fwd_interface", _benchmark_failure("TLE compile failed"))
-    monkeypatch.setattr(module, "_bench_ms", lambda *args, **kwargs: 1.0)
-    monkeypatch.setattr(module, "_sparse_mla_tflops_from_topk_length", lambda *args, **kwargs: 1.0)
-
-    with pytest.raises(RuntimeError, match="TLE compile failed"):
-        module.bench_sparse_mla_fwd(B=1, S=1, SKV=1, H=1, HKV=1, DQK=1, DV=1, topk=1, check_outputs=False)
-
-
-def test_sparse_mla_benchmark_rejects_non_finite_timings(monkeypatch):
-    module = _load_sparse_mla_module()
-    _stub_forward_benchmark_inputs(monkeypatch, module)
-    monkeypatch.setattr(module.triton.testing, "do_bench", lambda *args, **kwargs: (float("nan"), 1.0, 2.0))
-
-    with pytest.raises(RuntimeError, match="non-finite timings"):
-        _run_forward_benchmark_callback(module, "triton")

--- a/python/tutorials/tle/deepseek_v32/02-sparse-mla.py
+++ b/python/tutorials/tle/deepseek_v32/02-sparse-mla.py
@@ -26,7 +26,9 @@ try:
     from tilelang import language as T
 
     _HAVE_TILELANG = True
-except Exception:  # pragma: no cover - optional dependency
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+    if exc.name != "tilelang":
+        raise
     tilelang = None
     T = None
     _HAVE_TILELANG = False
@@ -35,7 +37,9 @@ try:
     import flash_mla
 
     _HAVE_FLASHMLA = True
-except Exception:  # pragma: no cover - optional dependency
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+    if exc.name != "flash_mla":
+        raise
     flash_mla = None
     _HAVE_FLASHMLA = False
 
@@ -3103,7 +3107,10 @@ BENCH_DEFAULT_SEED = 1
 
 def _bench_ms(fn, warmup=BENCH_DEFAULT_WARMUP_MS, rep=BENCH_DEFAULT_REP_MS):
     ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
-    return float(ms if not isinstance(ms, tuple) else ms[0])
+    ms = float(ms if not isinstance(ms, tuple) else ms[0])
+    if not math.isfinite(ms):
+        raise RuntimeError(f"Benchmark returned a non-finite timing: {ms}")
+    return ms
 
 
 _DECODE_BENCH_PROVIDERS = (["triton", "tle", "tle-pipe-pipelined"] +
@@ -3356,9 +3363,13 @@ def benchmark_sparse_mla_fwd(
         )
     except Exception as exc:  # pragma: no cover - depends on runtime/resource limits
         print(f"[bench:{provider}] failed for "
-              f"(B={B}, S={S}, SKV={SKV}, H={H}, HKV={HKV}, DQK={DQK}, DV={DV}, topk={topk}): {exc}")
-        return float("nan"), float("nan"), float("nan")
-    return ms, max_ms, min_ms
+              f"(B={B}, S={S}, SKV={SKV}, H={H}, HKV={HKV}, DQK={DQK}, DV={DV}, topk={topk}): {exc}",
+              flush=True)
+        raise
+    result = (ms, max_ms, min_ms)
+    if not all(math.isfinite(float(value)) for value in result):
+        raise RuntimeError(f"Benchmark provider {provider!r} returned non-finite timings: {result}")
+    return result
 
 
 @triton.testing.perf_report(
@@ -3530,9 +3541,13 @@ def benchmark_sparse_mla_decode(
         )
     except Exception as exc:  # pragma: no cover - depends on runtime/resource limits
         print(f"[decode-bench:{provider}] failed for "
-              f"(B={B}, S={S}, SKV={SKV}, H={H}, HKV={HKV}, DQK={DQK}, DV={DV}, topk={topk}): {exc}")
-        return float("nan"), float("nan"), float("nan")
-    return ms, max_ms, min_ms
+              f"(B={B}, S={S}, SKV={SKV}, H={H}, HKV={HKV}, DQK={DQK}, DV={DV}, topk={topk}): {exc}",
+              flush=True)
+        raise
+    result = (ms, max_ms, min_ms)
+    if not all(math.isfinite(float(value)) for value in result):
+        raise RuntimeError(f"Decode benchmark provider {provider!r} returned non-finite timings: {result}")
+    return result
 
 
 def run_bench_table(warmup=BENCH_DEFAULT_WARMUP_MS, rep=BENCH_DEFAULT_REP_MS, show_plots=False, tilelang_block_I=64,
@@ -3987,7 +4002,8 @@ def bench_sparse_mla_fwd(
         tle_tflops = _sparse_mla_tflops_from_topk_length(topk_length, H, DQK, DV, tle_ms)
         results.append(("tle", tle_ms, tle_tflops))
     except Exception as exc:  # pragma: no cover - depends on tle/runtime constraints
-        print(f"TLE bench skipped due to compile/runtime error: {exc}")
+        print(f"TLE bench failed due to compile/runtime error: {exc}", flush=True)
+        raise
 
     def run_tle_pipe():
         return tle_pipe_sparse_mla_fwd_interface(q, kv, indices, topk_length=topk_length, sm_scale=sm_scale, d_v=DV,
@@ -3999,7 +4015,8 @@ def bench_sparse_mla_fwd(
         tle_pipe_tflops = _sparse_mla_tflops_from_topk_length(topk_length, H, DQK, DV, tle_pipe_ms)
         results.append(("tle-pipe-pipelined", tle_pipe_ms, tle_pipe_tflops))
     except Exception as exc:  # pragma: no cover - depends on tle/runtime constraints
-        print(f"TLE pipe-pipelined bench skipped due to compile/runtime error: {exc}")
+        print(f"TLE pipe-pipelined bench failed due to compile/runtime error: {exc}", flush=True)
+        raise
 
     def run_tle_flashmla_prefill():
         return tle_flashmla_prefill_interface(q, kv, indices, topk_length=topk_length, sm_scale=sm_scale, d_v=DV,
@@ -4012,7 +4029,8 @@ def bench_sparse_mla_fwd(
                                                                           tle_flashmla_prefill_ms)
         results.append(("tle-flashmla-prefill", tle_flashmla_prefill_ms, tle_flashmla_prefill_tflops))
     except Exception as exc:  # pragma: no cover - depends on tle/runtime constraints
-        print(f"TLE FlashMLA-prefill bench skipped due to compile/runtime error: {exc}")
+        print(f"TLE FlashMLA-prefill bench failed due to compile/runtime error: {exc}", flush=True)
+        raise
 
     if _HAVE_TILELANG:
         resolved_block_i = _resolve_tilelang_block_i(topk, tilelang_block_I)
@@ -4040,7 +4058,8 @@ def bench_sparse_mla_fwd(
             tilelang_tflops = _sparse_mla_tflops_from_topk_length(topk_length, H, DQK, DV, tilelang_ms)
             results.append(("tilelang", tilelang_ms, tilelang_tflops))
         except Exception as exc:  # pragma: no cover - depends on tilelang/runtime constraints
-            print(f"TileLang bench skipped due to compile/runtime error: {exc}")
+            print(f"TileLang bench failed due to compile/runtime error: {exc}", flush=True)
+            raise
     else:
         print("TileLang is not installed, skip TileLang bench.")
 
@@ -4067,7 +4086,8 @@ def bench_sparse_mla_fwd(
                                                                             tilelang_pipelined_ms)
             results.append(("tilelang-pipelined", tilelang_pipelined_ms, tilelang_pipelined_tflops))
         except Exception as exc:  # pragma: no cover - depends on tilelang/runtime constraints
-            print(f"Pipelined TileLang bench skipped due to compile/runtime error: {exc}")
+            print(f"Pipelined TileLang bench failed due to compile/runtime error: {exc}", flush=True)
+            raise
 
         def run_tilelang_seesaw():
             return tilelang_sparse_mla_fwd_seesaw_interface(
@@ -4089,7 +4109,8 @@ def bench_sparse_mla_fwd(
             tilelang_seesaw_tflops = _sparse_mla_tflops_from_topk_length(topk_length, H, DQK, DV, tilelang_seesaw_ms)
             results.append(("tilelang-seesaw", tilelang_seesaw_ms, tilelang_seesaw_tflops))
         except Exception as exc:  # pragma: no cover - depends on tilelang/runtime constraints
-            print(f"Seesaw TileLang bench skipped due to compile/runtime error: {exc}")
+            print(f"Seesaw TileLang bench failed due to compile/runtime error: {exc}", flush=True)
+            raise
 
     if _HAVE_FLASHMLA:
         try:
@@ -4111,7 +4132,8 @@ def bench_sparse_mla_fwd(
             flashmla_tflops = _sparse_mla_tflops_from_topk_length(topk_length, H, DQK, DV, flashmla_ms)
             results.append(("flashmla", flashmla_ms, flashmla_tflops))
         except Exception as exc:  # pragma: no cover - depends on flashmla/runtime constraints
-            print(f"FlashMLA bench skipped due to compile/runtime error: {exc}")
+            print(f"FlashMLA bench failed due to compile/runtime error: {exc}", flush=True)
+            raise
     else:
         print("FlashMLA is not installed, skip FlashMLA bench.")
 
@@ -4254,7 +4276,8 @@ def bench_sparse_mla_decode(
         tle_tflops = _sparse_mla_tflops_from_topk_length(inputs["topk_length_flat"], H, DQK, DV, tle_ms)
         results.append(("tle", tle_ms, tle_tflops))
     except Exception as exc:  # pragma: no cover - depends on tle/runtime constraints
-        print(f"TLE decode bench skipped due to compile/runtime error: {exc}")
+        print(f"TLE decode bench failed due to compile/runtime error: {exc}", flush=True)
+        raise
 
     def run_tle_pipe():
         return tle_pipe_sparse_mla_fwd_interface(
@@ -4274,7 +4297,8 @@ def bench_sparse_mla_decode(
         tle_pipe_tflops = _sparse_mla_tflops_from_topk_length(inputs["topk_length_flat"], H, DQK, DV, tle_pipe_ms)
         results.append(("tle-pipe-pipelined", tle_pipe_ms, tle_pipe_tflops))
     except Exception as exc:  # pragma: no cover - depends on tle/runtime constraints
-        print(f"TLE pipe-pipelined decode bench skipped due to compile/runtime error: {exc}")
+        print(f"TLE pipe-pipelined decode bench failed due to compile/runtime error: {exc}", flush=True)
+        raise
 
     if _HAVE_TILELANG:
         resolved_block_i = _resolve_tilelang_block_i(topk, tilelang_block_I)
@@ -4300,7 +4324,8 @@ def bench_sparse_mla_decode(
             tilelang_tflops = _sparse_mla_tflops_from_topk_length(inputs["topk_length_flat"], H, DQK, DV, tilelang_ms)
             results.append(("tilelang", tilelang_ms, tilelang_tflops))
         except Exception as exc:  # pragma: no cover - depends on tilelang/runtime constraints
-            print(f"TileLang decode bench skipped due to compile/runtime error: {exc}")
+            print(f"TileLang decode bench failed due to compile/runtime error: {exc}", flush=True)
+            raise
 
         def run_tilelang_pipelined():
             return tilelang_sparse_mla_fwd_pipelined_interface(
@@ -4324,7 +4349,8 @@ def bench_sparse_mla_decode(
                                                                             tilelang_pipelined_ms)
             results.append(("tilelang-pipelined", tilelang_pipelined_ms, tilelang_pipelined_tflops))
         except Exception as exc:  # pragma: no cover - depends on tilelang/runtime constraints
-            print(f"Pipelined TileLang decode bench skipped due to compile/runtime error: {exc}")
+            print(f"Pipelined TileLang decode bench failed due to compile/runtime error: {exc}", flush=True)
+            raise
 
         def run_tilelang_seesaw():
             return tilelang_sparse_mla_fwd_seesaw_interface(
@@ -4348,7 +4374,8 @@ def bench_sparse_mla_decode(
                                                                          tilelang_seesaw_ms)
             results.append(("tilelang-seesaw", tilelang_seesaw_ms, tilelang_seesaw_tflops))
         except Exception as exc:  # pragma: no cover - depends on tilelang/runtime constraints
-            print(f"Seesaw TileLang decode bench skipped due to compile/runtime error: {exc}")
+            print(f"Seesaw TileLang decode bench failed due to compile/runtime error: {exc}", flush=True)
+            raise
     else:
         print("TileLang is not installed, skip TileLang decode bench.")
 
@@ -4372,7 +4399,8 @@ def bench_sparse_mla_decode(
             flashmla_tflops = _sparse_mla_tflops_from_topk_length(inputs["topk_length_flat"], H, DQK, DV, flashmla_ms)
             results.append(("flashmla", flashmla_ms, flashmla_tflops))
         except Exception as exc:  # pragma: no cover - depends on flashmla/runtime constraints
-            print(f"FlashMLA decode bench skipped due to compile/runtime error: {exc}")
+            print(f"FlashMLA decode bench failed due to compile/runtime error: {exc}", flush=True)
+            raise
     else:
         print("FlashMLA is not installed, skip FlashMLA decode bench.")
 

--- a/python/tutorials/tle/deepseek_v32/02-sparse-mla.py
+++ b/python/tutorials/tle/deepseek_v32/02-sparse-mla.py
@@ -3362,9 +3362,9 @@ def benchmark_sparse_mla_fwd(
             rep=rep,
         )
     except Exception as exc:  # pragma: no cover - depends on runtime/resource limits
-        print(f"[bench:{provider}] failed for "
-              f"(B={B}, S={S}, SKV={SKV}, H={H}, HKV={HKV}, DQK={DQK}, DV={DV}, topk={topk}): {exc}",
-              flush=True)
+        print(
+            f"[bench:{provider}] failed for "
+            f"(B={B}, S={S}, SKV={SKV}, H={H}, HKV={HKV}, DQK={DQK}, DV={DV}, topk={topk}): {exc}", flush=True)
         raise
     result = (ms, max_ms, min_ms)
     if not all(math.isfinite(float(value)) for value in result):
@@ -3540,9 +3540,9 @@ def benchmark_sparse_mla_decode(
             rep=rep,
         )
     except Exception as exc:  # pragma: no cover - depends on runtime/resource limits
-        print(f"[decode-bench:{provider}] failed for "
-              f"(B={B}, S={S}, SKV={SKV}, H={H}, HKV={HKV}, DQK={DQK}, DV={DV}, topk={topk}): {exc}",
-              flush=True)
+        print(
+            f"[decode-bench:{provider}] failed for "
+            f"(B={B}, S={S}, SKV={SKV}, H={H}, HKV={HKV}, DQK={DQK}, DV={DV}, topk={topk}): {exc}", flush=True)
         raise
     result = (ms, max_ms, min_ms)
     if not all(math.isfinite(float(value)) for value in result):

--- a/third_party/tle/dialect/lib/Transforms/TleSelectEncodings.cpp
+++ b/third_party/tle/dialect/lib/Transforms/TleSelectEncodings.cpp
@@ -750,8 +750,9 @@ class SelectEncodingsPass
           for (OpOperand &use : ptrVal.getUses()) {
             Operation *owner = use.getOwner();
             if (auto load = dyn_cast<triton::LoadOp>(owner)) {
-              if (isRewritableFullViewLocalPointerLoad(load))
-                continue;
+              // Full-view loads do not participate in encoding inference because
+              // they are rewritten to local_load later.  Until that rewrite,
+              // however, their result type must still match the pointer type.
               if (Value mask = load.getMask()) {
                 Value convertedMask =
                     convertOperandEncoding(owner, mask, ptrEncoding);
@@ -768,14 +769,9 @@ class SelectEncodingsPass
                   dyn_cast<RankedTensorType>(load.getResult().getType());
               if (oldLoadTy != loadTy) {
                 load.getResult().setType(loadTy);
-                if (oldLoadTy) {
-                  OpBuilder::InsertionGuard guard(builder);
-                  builder.setInsertionPointAfter(load);
-                  auto bridge = builder.create<triton::gpu::ConvertLayoutOp>(
-                      load.getLoc(), oldLoadTy, load.getResult());
-                  load.getResult().replaceAllUsesExcept(bridge.getResult(),
-                                                        bridge.getOperation());
-                }
+                if (oldLoadTy)
+                  bridgeResultTypeToOldEncoding(load.getResult(), oldLoadTy,
+                                                builder);
               }
               continue;
             }

--- a/third_party/tle/dialect/lib/Transforms/TleSelectEncodings.cpp
+++ b/third_party/tle/dialect/lib/Transforms/TleSelectEncodings.cpp
@@ -750,9 +750,10 @@ class SelectEncodingsPass
           for (OpOperand &use : ptrVal.getUses()) {
             Operation *owner = use.getOwner();
             if (auto load = dyn_cast<triton::LoadOp>(owner)) {
-              // Full-view loads do not participate in encoding inference because
-              // they are rewritten to local_load later.  Until that rewrite,
-              // however, their result type must still match the pointer type.
+              // Full-view loads do not participate in encoding inference
+              // because they are rewritten to local_load later.  Until that
+              // rewrite, however, their result type must still match the
+              // pointer type.
               if (Value mask = load.getMask()) {
                 Value convertedMask =
                     convertOperandEncoding(owner, mask, ptrEncoding);

--- a/third_party/tle/test/GPU/test_tle_select_encodings.mlir
+++ b/third_party/tle/test/GPU/test_tle_select_encodings.mlir
@@ -19,7 +19,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// RUN: triton-opt %s -split-input-file -triton-tle-select-encodings | FileCheck %s
+// RUN: triton-opt %s -split-input-file -triton-tle-select-encodings -verify-each | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
 #blocked4 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
@@ -44,6 +44,34 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
   // CHECK: %[[A_IDX_CAST:.*]] = ttg.convert_layout %[[A_IDX]] : tensor<32x4xi32, #[[A_IDX_ENC]]> -> tensor<32x4xi32, #[[A_DATA_ENC]]>
   // CHECK: %[[A_PTRS:.*]] = "tle.local_pointers"(%{{.*}}, %[[A_IDX_CAST]]) {{.*}} : (!ttg.memdesc<1xi32, #shared, #smem, mutable>, tensor<32x4xi32, #[[A_DATA_ENC]]>) -> tensor<32x4x!tt.ptr<i32, 3>, #[[A_DATA_ENC]]>
   // CHECK: tt.atomic_rmw add, relaxed, cta, %{{.*}}, %[[A_ONES]], %[[A_MASK]] : (tensor<32x4x!tt.ptr<i32, 3>, #[[A_DATA_ENC]]>, tensor<32x4xi32, #[[A_DATA_ENC]]>, tensor<32x4xi1, #[[A_DATA_ENC]]>) -> tensor<32x4xi32, #[[A_DATA_ENC]]>
+}
+
+// -----
+
+#selected = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+#original = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tt.func @full_view_load_tracks_selected_pointer_encoding
+  tt.func @full_view_load_tracks_selected_pointer_encoding() -> tensor<32x4xi32, #original> {
+    %values = arith.constant dense<1> : tensor<32x4xi32, #selected>
+    %mask = arith.constant dense<true> : tensor<32x4xi1, #selected>
+    %smem = ttg.local_alloc : () -> !ttg.memdesc<32x4xi32, #shared, #smem, mutable>
+    %ptr = "tle.local_pointers"(%smem) : (!ttg.memdesc<32x4xi32, #shared, #smem, mutable>) -> tensor<32x4x!tt.ptr<i32, 3>, #original>
+    %loaded = tt.load %ptr : tensor<32x4x!tt.ptr<i32, 3>, #original>
+    %selected_ptr = ttg.convert_layout %ptr : tensor<32x4x!tt.ptr<i32, 3>, #original> -> tensor<32x4x!tt.ptr<i32, 3>, #selected>
+    %old = tt.atomic_rmw add, relaxed, cta, %selected_ptr, %values, %mask : (tensor<32x4x!tt.ptr<i32, 3>, #selected>, tensor<32x4xi32, #selected>, tensor<32x4xi1, #selected>) -> tensor<32x4xi32, #selected>
+    tt.return %loaded : tensor<32x4xi32, #original>
+  }
+  // CHECK: %[[VALUES:.*]] = arith.constant dense<1> : tensor<32x4xi32, #[[SELECTED:[A-Za-z0-9_]+]]>
+  // CHECK: %[[PTR:.*]] = "tle.local_pointers"(%{{.*}}) {{.*}} -> tensor<32x4x!tt.ptr<i32, 3>, #[[SELECTED]]>
+  // CHECK: %[[LOADED:.*]] = tt.load %[[PTR]] : tensor<32x4x!tt.ptr<i32, 3>, #[[SELECTED]]>
+  // CHECK: %[[BRIDGE:.*]] = ttg.convert_layout %[[LOADED]] : tensor<32x4xi32, #[[SELECTED]]> -> tensor<32x4xi32, #[[ORIGINAL:[A-Za-z0-9_]+]]>
+  // CHECK-NOT: ttg.convert_layout %[[PTR]]
+  // CHECK: tt.atomic_rmw add, relaxed, cta, %[[PTR]], %[[VALUES]], %{{.*}}
+  // CHECK: tt.return %[[BRIDGE]] : tensor<32x4xi32, #[[ORIGINAL]]>
 }
 
 // -----


### PR DESCRIPTION
## Background

The NVIDIA CI SparseMLA tutorial started failing all five `tle-flashmla-prefill` benchmark cases after TLE helper inlining was enabled. The compiler stopped in `TritonTleSelectEncodings` with:

```text
'tt.load' op failed to verify that result matches ptr type
```

The benchmark then caught the compilation exception, returned NaN timings, and exited with status 0. As a result, GitHub Actions continued to the next test and the delayed/buffered benchmark output made the failure look like a hang.

Failing run: https://github.com/flagos-ai/FlagTree/actions/runs/30510009926/job/90767823379

## Root cause

Full-view loads from `tle.local_pointers` are intentionally excluded from consumer encoding votes because they are rewritten to `ttg.local_load` later in the pipeline. However, `TleSelectEncodings` also skipped those loads while propagating a newly selected pointer encoding to users.

When another user selected a different encoding for the local pointer, the pointer result type changed while the full-view `tt.load` result retained its old encoding. Verification therefore failed before `TleOptimizeLocalPointerLoads` had a chance to rewrite the load.

Separately, the SparseMLA table and single-benchmark paths treated compile/runtime exceptions like unsupported optional providers, printed an error, and continued.

## Solution

- Keep rewritable full-view loads out of encoding inference, but always synchronize their result type with the selected pointer encoding.
- Insert a `convert_layout` bridge so existing consumers retain their original result layout.
- Add a `-verify-each` MLIR regression covering a full-view load whose local pointer is retagged by another consumer.
- Propagate import, compilation, and runtime exceptions from forward/decode table and single benchmarks.
- Preserve skip/NaN behavior only when an optional provider is genuinely unavailable.
- Reject non-finite measured timings instead of silently reporting them.

This behavior is identical locally and in CI; no CI-only flag is required.

## Validation

- The new `test_tle_select_encodings.mlir` case passes with `-triton-tle-select-encodings -verify-each`.
- On H800, the minimal SparseMLA reproducer (`B=1, S=1, SKV=2048, topk=2048`) compiles, launches, and matches the Triton output.
- A synthetic compilation failure in the default table benchmark exits the Python process with status 1.
- Python syntax and diff checks pass.

The full TLE lit invocation reports 63/70 passing; the remaining failures are in unrelated alignment, remote-pointer, and WGMMA checks, while the added regression passes independently.
