### PR TITLE
 [TLE-Distributed] Support tle.dsa distribute Op

### DIFF
--- a/.github/workflows/ascend3.5-build-and-test.yml
+++ b/.github/workflows/ascend3.5-build-and-test.yml
@@ -186,4 +186,6 @@ jobs:
           python3 06-swiglu.py
           python3 07-kv-rmsnorm-rope-cache.py
           pytest -s -k "accuracy" 08-add-rms-norm-bias.py
+          torchrun --nproc_per_node=2 09-ascend-allgather-gemm.py
+          torchrun --nproc_per_node=2 10-tle-d2d-barrier.py
           popd

--- a/python/requirements-ascend.txt
+++ b/python/requirements-ascend.txt
@@ -1,0 +1,3 @@
+--extra-index-url https://ascend.devcloud.huaweicloud.com/cann/pypi/simple/
+
+cann-shmem

--- a/python/setup_tools/utils/__init__.py
+++ b/python/setup_tools/utils/__init__.py
@@ -10,7 +10,8 @@ flagtree_submodules = {
                  commit_id="5842469a16b261e45a2c67fbfc308057622b03ee",
                  dst_path=os.path.join(flagtree_configs.flagtree_submodule_dir, "triton_shared")),
     "flir":
-    tools.Module(name="flir", url="https://github.com/flagos-ai/flir.git", commit_id="",
+    tools.Module(name="flir", url="https://github.com/flagos-ai/flir.git",
+                 commit_id="eb9f151a8fd6f7ee0950a53fb3edca0c5a8b7c67",
                  dst_path=os.path.join(flagtree_configs.flagtree_submodule_dir, "flir")),
 }
 

--- a/python/setup_tools/utils/ascend.py
+++ b/python/setup_tools/utils/ascend.py
@@ -49,7 +49,10 @@ def handle_editable_install_mode(is_editable=True):
             os.symlink(src, dst)
 
 
-submodules = (Module(name="AscendNPU-IR", url="https://gitcode.com/Ascend/AscendNPU-IR.git", commit_id="4c304921",
+# submodules = (Module(name="AscendNPU-IR", url="https://gitcode.com/Ascend/AscendNPU-IR.git", commit_id="4c304921",
+#                      dst_path=os.path.join(flagtree_submodule_dir, "ascend/AscendNPU-IR")), )
+submodules = (Module(name="AscendNPU-IR", url="https://github.com/flagos-ai/FlagTree-AscendNPU-IR.git",
+                     branch="tle-ascend-3.5.x-dev", commit_id="17509803",
                      dst_path=os.path.join(flagtree_submodule_dir, "ascend/AscendNPU-IR")), )
 
 

--- a/python/triton/experimental/tle/__init__.py
+++ b/python/triton/experimental/tle/__init__.py
@@ -1,19 +1,4 @@
-# flagtree tle
-from .distributed import (
-    B,
-    P,
-    S,
-    ShardedTensor,
-    ShardingSpec,
-    device_mesh,
-    distributed_barrier,
-    distributed_dot,
-    make_sharded_tensor,
-    remote,
-    reshard,
-    shard_id,
-    sharding,
-)
+from . import backends
 
 from . import language
 
@@ -160,26 +145,13 @@ def __getattr__(name):
         from .language import dsa
         globals()[name] = dsa
         return dsa
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    try:
+        return getattr(backends, name)
+    except AttributeError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = [
-    "device_mesh",
-    "S",
-    "P",
-    "B",
-    "sharding",
-    "ShardingSpec",
-    "ShardedTensor",
-    "make_sharded_tensor",
-    "reshard",
-    "remote",
-    "shard_id",
-    "distributed_barrier",
-    "distributed_dot",
-    "language",
-    "dsa",
-]
+__all__ = ["language", "dsa", *backends.ops()]
 
 if raw is not None:
     __all__.append("raw")

--- a/python/triton/experimental/tle/backends.py
+++ b/python/triton/experimental/tle/backends.py
@@ -1,0 +1,84 @@
+# Copyright 2026- Xcoresigma Technology Co., Ltd
+
+from __future__ import annotations
+
+
+def _detect_backend() -> str:
+    from triton._flagtree_backend import FLAGTREE_BACKEND as _flagtree_backend
+
+    return _flagtree_backend.strip().lower() if _flagtree_backend else "nvidia"
+
+
+def _build_ascend_impl() -> dict[str, ...]:
+    from triton.experimental.tle.language.dsa.ascend.communication import (
+        cleanup_communicator,
+        create_dist_tensor,
+        init_communicator,
+    )
+    from triton.experimental.tle.language.dsa.ascend.distributed import (
+        MeshConfig,
+        device_mesh,
+        distributed_barrier,
+        gemm_swizzle2d_Nz,
+        remote,
+        shard_id,
+        swizzle2d_Nz,
+    )
+
+    return {
+        "init_communicator": init_communicator,
+        "create_dist_tensor": create_dist_tensor,
+        "cleanup_communicator": cleanup_communicator,
+        "device_mesh": device_mesh,
+        "MeshConfig": MeshConfig,
+        "remote": remote,
+        "shard_id": shard_id,
+        "distributed_barrier": distributed_barrier,
+        "swizzle2d_Nz": swizzle2d_Nz,
+        "gemm_swizzle2d_Nz": gemm_swizzle2d_Nz,
+    }
+
+
+def _build_nvidia_impl() -> dict[str, ...]:
+    from triton.experimental.tle.distributed import (
+        B,
+        P,
+        S,
+        ShardedTensor,
+        ShardingSpec,
+        device_mesh,
+        distributed_barrier,
+        distributed_dot,
+        make_sharded_tensor,
+        remote,
+        reshard,
+        shard_id,
+        sharding,
+    )
+
+    return {
+        "B": B,
+        "P": P,
+        "S": S,
+        "ShardedTensor": ShardedTensor,
+        "ShardingSpec": ShardingSpec,
+        "device_mesh": device_mesh,
+        "distributed_barrier": distributed_barrier,
+        "distributed_dot": distributed_dot,
+        "make_sharded_tensor": make_sharded_tensor,
+        "remote": remote,
+        "reshard": reshard,
+        "shard_id": shard_id,
+        "sharding": sharding,
+    }
+
+
+# Once at import time: build the selected backend's op table and expose every
+# op as a plain module attribute.
+BACKEND = _detect_backend()
+IMPL = _build_ascend_impl() if BACKEND == "ascend" else _build_nvidia_impl()
+globals().update(IMPL)
+
+
+def ops() -> list[str]:
+    return sorted(IMPL.keys())

--- a/python/triton/experimental/tle/language/dsa/ascend/communication.py
+++ b/python/triton/experimental/tle/language/dsa/ascend/communication.py
@@ -1,0 +1,77 @@
+# Copyright 2026- Xcoresigma Technology Co., Ltd
+
+import os
+import torch
+import torch.distributed as dist
+import shmem as ash
+
+_g_pe = None
+_g_world_size = None
+_g_mem_count = 0
+
+
+def _get_ash_ip_port():
+    # default to 8666 if ASH_MASTER_PORT is not set
+    ash_port = os.environ.get("ASH_MASTER_PORT", "8666")
+    # default to 127.0.0.1 if ASH_MASTER_ADDR is not set
+    ash_addr = os.environ.get("ASH_MASTER_ADDR", "127.0.0.1")
+    return f"tcp://{ash_addr}:{ash_port}"
+
+
+def init_communicator(ip_port=None, ash_size=None, engine_type=None):
+    global _g_pe, _g_world_size, _g_mem_count
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.npu.set_device(local_rank)
+    dist.init_process_group(backend="hccl", rank=local_rank)
+    _g_pe = dist.get_rank()
+    _g_world_size = dist.get_world_size()
+    dist.barrier()
+
+    ash.set_conf_store_tls(False, "")
+    attributes = ash.InitAttr()
+    attributes.my_rank = _g_pe
+    attributes.n_ranks = _g_world_size
+    attributes.local_mem_size = ash_size if ash_size is not None else 1024 * 1024 * 1024
+    attributes.ip_port = ip_port if ip_port is not None else _get_ash_ip_port()
+    # ROCE/RDMA is the inter-node (multi-machine) protocol; MTE is intra-node only.
+    if engine_type is None:
+        engine_type = ash.OpEngineType.MTE
+    attributes.option_attr.data_op_engine_type = engine_type
+    ret = ash.aclshmem_init(attributes)
+    if ret != 0:
+        raise ValueError("[ERROR] aclshmem_init failed")
+    _g_mem_count = 0
+
+
+def create_dist_tensor(buf_tensor):
+    """Allocate share memory for distributed communication.
+
+    Each successful allocation increments the global `_g_mem_count` by 1.
+    The communicator is finalized only when `cleanup_communicator` brings the
+    count back to 0.
+    """
+    global _g_mem_count
+    if isinstance(buf_tensor, torch.Tensor):
+        peer_mem = ash.aclshmem_create_tensor([buf_tensor.numel()], dtype=buf_tensor.dtype, device_id=_g_pe)
+        _g_mem_count += 1
+        return peer_mem
+    else:
+        raise ValueError("[ERROR] buf_tensor must be a tensor")
+
+
+def cleanup_communicator(peer_mem):
+    """Free one distributed tensor.
+
+    Decrements the global `_g_mem_count` by 1. Only when the count reaches 0
+    (i.e. all tensors created by `create_dist_tensor` have been freed) is
+    `aclshmem_finalize()` called.
+    """
+    global _g_mem_count
+    torch.npu.synchronize()
+    dist.barrier()
+    ash.aclshmem_free_tensor(peer_mem)
+    _g_mem_count -= 1
+    if _g_mem_count < 0:
+        raise ValueError("[ERROR] cleanup_communicator called more times than create_dist_tensor")
+    if _g_mem_count == 0:
+        ash.aclshmem_finalize()

--- a/python/triton/experimental/tle/language/dsa/ascend/core.py
+++ b/python/triton/experimental/tle/language/dsa/ascend/core.py
@@ -1,3 +1,5 @@
+# Copyright 2026- Xcoresigma Technology Co., Ltd
+
 from triton.language.extra.cann.extension.core import ascend_address_space, sub_vec_id, sub_vec_num, sync_block_set, sync_block_wait, sync_block_all
 import triton.language.extra.cann.extension as ascend_langugage_cann_extension
 from triton.language.extra.cann.extension import compile_hint, multibuffer

--- a/python/triton/experimental/tle/language/dsa/ascend/distributed.py
+++ b/python/triton/experimental/tle/language/dsa/ascend/distributed.py
@@ -1,0 +1,348 @@
+# Copyright 2026- Xcoresigma Technology Co., Ltd
+
+import triton.language.core as tl
+import triton.language as dl
+import triton
+from triton.language.core import builtin, tensor
+from typing import List
+
+_SHMEM_DTYPE_MAP = {
+    tl.float16: "half",
+    tl.float32: "float",
+    tl.bfloat16: "bfloat16",
+    tl.int8: "int8_t",
+    tl.int16: "int16_t",
+    tl.int32: "int32_t",
+    tl.int64: "int64_t",
+    tl.uint8: "uint8_t",
+    tl.uint16: "uint16_t",
+    tl.uint32: "uint32_t",
+    tl.uint64: "uint64_t",
+}
+
+
+def _shmem_dtype(dtype):
+    if hasattr(dtype, 'element_ty'):
+        return _SHMEM_DTYPE_MAP.get(dtype.element_ty, str(dtype.element_ty))
+    return _SHMEM_DTYPE_MAP.get(dtype, str(dtype))
+
+
+def _scalar_dtype(t):
+    d = t.dtype if hasattr(t, 'dtype') else t
+    return d.element_ty if hasattr(d, 'element_ty') else d
+
+
+def _dispatch(
+    func,
+    lib_name: str,
+    lib_path: str,
+    args: list,
+    arg_type_symbol_dict: dict,
+    is_pure: bool,
+    _semantic=None,
+):
+    if len(arg_type_symbol_dict) == 0:
+        raise ValueError("arg_type_symbol_dict is empty")
+
+    num_args = len(list(arg_type_symbol_dict.keys())[0])
+    if len(args) != num_args:
+        raise ValueError(f"length of input args does not match."
+                         f"Expect {len(args)}, got {num_args}")
+
+    arg_types = []
+    arg_list = []
+    for arg in args:
+        if isinstance(arg, tensor):
+            dtype = arg.dtype
+            if hasattr(dtype, 'element_ty'):
+                dtype = dtype.element_ty
+            arg_types.append(dtype)
+            arg_list.append(arg.handle)
+        else:
+            arg_types.append(type(arg))
+            arg_list.append(arg)
+    arg_types = tuple(arg_types)
+
+    if arg_types not in arg_type_symbol_dict:
+        raise ValueError(f"input arg type does not match."
+                         f"Expect one of {arg_type_symbol_dict.keys()}, got {arg_types}")
+    else:
+        symbol = arg_type_symbol_dict[arg_types][0]
+        ret_types = arg_type_symbol_dict[arg_types][1]
+        if not isinstance(ret_types, (List, tuple)):
+            ret_types = [ret_types]
+
+        if symbol == "":
+            raise ValueError("Symbol can not be empty")
+        call = func(
+            lib_name,
+            lib_path,
+            symbol,
+            arg_list,
+            [ret_type.to_ir(_semantic.builder) for ret_type in ret_types],
+            is_pure,
+        )
+
+        if len(ret_types) == 0:
+            return tensor(call, tl.void)
+        if len(ret_types) == 1:
+            return tensor(call.get_result(0), ret_types[0])
+        return tuple(tensor(call.get_result(i), ty) for i, ty in enumerate(ret_types))
+
+
+def _extern_call(
+    lib_name: str,
+    lib_path: str,
+    args: list,
+    arg_type_symbol_dict: dict,
+    is_pure: bool,
+    _semantic=None,
+):
+    """Dispatch an external function call. Supports ptr/block arguments."""
+    dispatch_args = args.copy()
+    for i in range(len(dispatch_args)):
+        dispatch_args[i] = _semantic.to_tensor(dispatch_args[i])
+
+    if len(arg_type_symbol_dict) == 0:
+        raise ValueError("arg_type_symbol_dict is empty")
+
+    num_args = len(list(arg_type_symbol_dict.keys())[0])
+    if len(args) != num_args:
+        raise ValueError(f"length of input args does not match."
+                         f"Expect {len(args)}, got {num_args}")
+
+    func = _semantic.builder.create_extern_call
+    return _dispatch(
+        func,
+        lib_name,
+        lib_path,
+        dispatch_args,
+        arg_type_symbol_dict,
+        is_pure,
+        _semantic,
+    )
+
+
+class MeshConfig:
+    """Lightweight mesh configuration for Ascend.
+
+    Only ``device`` level is implemented; ``node``, ``block_cluster``,
+    ``block`` accept values but trigger assert at usage time.
+    """
+
+    def __init__(self, device=None, node=None, block_cluster=None, block=None):
+        self.device = device
+        self.node = node
+        self.block_cluster = block_cluster
+        self.block = block
+
+    def __repr__(self):
+        return (f"MeshConfig(device={self.device}, node={self.node}, "
+                f"block_cluster={self.block_cluster}, block={self.block})")
+
+
+class device_mesh:
+    """Lightweight logical view of physical device topology."""
+
+    def __init__(self, topology: MeshConfig):
+        if not isinstance(topology, MeshConfig):
+            raise TypeError(f"topology must be MeshConfig, got {type(topology).__name__}")
+        self._mesh_config = topology
+        # Only device level is implemented
+        assert topology.node is None, "TODO: node level not yet implemented"
+        assert topology.block_cluster is None, "TODO: block_cluster level not yet implemented"
+        assert topology.block is None, "TODO: block level not yet implemented"
+        assert topology.device is not None and topology.device > 0, "device count must be > 0"
+
+    @property
+    def device_count(self) -> int:
+        return self._mesh_config.device
+
+    @property
+    def shape(self) -> tuple:
+        return (self.device_count, )
+
+    def __repr__(self):
+        return f"DeviceMesh(device={self.device_count})"
+
+
+@builtin
+def remote(
+    tensor,
+    shard_id=None,
+    scope=None,
+    space: str = None,
+    dtype: tl.dtype = None,
+    offset: int = None,
+    _semantic=None,
+):
+    """Distributed pointer shuffle: remote pointer access by peer rank.
+
+    Signature aligned with distributed.py::remote().
+    Currently only ``device`` level is supported.
+    """
+    scope = tl._unwrap_if_constexpr(scope)
+    if scope is not None:
+        assert isinstance(scope, device_mesh), f"scope must be device_mesh, got {type(scope).__name__}"
+
+    space = tl._unwrap_if_constexpr(space)
+    if space is not None and not isinstance(space, str):
+        raise TypeError(f"space must be str or None, got {type(space).__name__}")
+    assert space is None or space == "device", \
+        f"TODO: space='{space}' not yet implemented (only 'device' is supported)"
+
+    dtype = tl._unwrap_if_constexpr(dtype)
+    if dtype is not None:
+        assert dtype in _SHMEM_DTYPE_MAP, \
+            f"dtype {dtype} is not in the supported SHMEM type map: {list(_SHMEM_DTYPE_MAP.keys())}"
+
+    offset = tl._unwrap_if_constexpr(offset)
+    if offset is not None and not isinstance(offset, (int, tl.tensor)):
+        raise TypeError(f"offset must be int, tl.tensor, or None, got {type(offset).__name__}")
+
+    assert not tensor.type.is_block() and tensor.type.is_ptr(), "only support scalar pointer"
+    rank = _semantic._convert_elem_to_ir_value(shard_id, require_i64=False)
+    remote_ptr = tl.tensor(_semantic.builder.create_symm_at(tensor.handle, rank), tensor.type)
+
+    # offset is accepted for interface compatibility but not yet applied at
+    # the HIVM level — the TT addptr is lost during TT→HIVM bufferization.
+    # Callers should use `remote_ptr + offset` at the call site instead.
+    assert offset is None, "offset not applied at the HIVM level"
+    # TODO: wire offset into symm_at / HIVM custom op
+
+    return remote_ptr
+
+
+@builtin
+def shard_id(
+    mesh=None,
+    axis=-1,
+    device_dptr=None,
+    _semantic=None,
+):
+    """Return current shard coordinate.
+
+    Signature aligned with distributed.py::shard_id().
+    Currently only ``device`` axis is supported.
+    """
+    mesh = tl._unwrap_if_constexpr(mesh)
+    if mesh is not None:
+        assert isinstance(mesh, device_mesh), f"mesh must be device_mesh, got {type(mesh).__name__}"
+
+    axis = tl._unwrap_if_constexpr(axis)
+    if isinstance(axis, str):
+        assert axis == "device", f"TODO: axis='{axis}' not yet implemented (only 'device' is supported)"
+        axis = 0
+        if device_dptr is not None:
+            assert isinstance(device_dptr, tl.tensor) and device_dptr.dtype.is_ptr(), \
+                "device_dptr must be a pointer tensor"
+    elif not isinstance(axis, int):
+        raise TypeError(f"axis must be int or str, got {type(axis).__name__}")
+    else:
+        assert axis == -1 or axis == 0, f"TODO: axis={axis} not yet implemented (only 'device'/0/-1)"
+
+    axis = _semantic._convert_elem_to_ir_value(axis, require_i64=False)
+    return tl.tensor(_semantic.builder.create_get_rank(axis), tl.int32)
+
+
+@builtin
+def distributed_barrier(
+    mesh=None,
+    device_dptr=None,
+    space: str = None,
+    group_kind=None,
+    barrier_kind=None,
+    order=None,
+    index: int = None,
+    _semantic=None,
+):
+    """
+    Distributed barrier across all ranks.
+    Currently only ``device`` level is supported.
+    """
+    mesh = tl._unwrap_if_constexpr(mesh)
+    if mesh is not None:
+        assert isinstance(mesh, device_mesh), f"mesh must be device_mesh, got {type(mesh).__name__}"
+
+    space = tl._unwrap_if_constexpr(space)
+    if space is not None and not isinstance(space, str):
+        raise TypeError(f"space must be str or None, got {type(space).__name__}")
+    assert space is None or space == "device", \
+        f"TODO: space='{space}' not yet implemented (only 'device' is supported)"
+
+    index = tl._unwrap_if_constexpr(index)
+    if index is not None and not isinstance(index, int):
+        raise TypeError(f"index must be int or None, got {type(index).__name__}")
+
+    if device_dptr is not None:
+        assert isinstance(device_dptr, tl.tensor) and device_dptr.dtype.is_ptr(), \
+            "device_dptr must be a pointer tensor"
+
+    return _extern_call(
+        "libshmem_device",
+        "",
+        [],
+        {
+            (): ("aclshmem_barrier_all", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@triton.jit
+def swizzle2d_Nz(
+    iter_id,
+    rank_size,
+    data_row_shape,
+    data_col_shape,
+    tile_row_shape,
+    tile_col_shape,
+    comm_npu_split=1,
+):
+    """Ascend Nz-format 2D swizzle for communication tiles."""
+    data_row_loop_num = dl.cdiv(data_row_shape, tile_row_shape)
+    data_col_loop_num = dl.cdiv(data_col_shape, tile_col_shape)
+    data_loop_num = data_row_loop_num * data_col_loop_num
+    rank_stride = rank_size // comm_npu_split
+    swizzle_offset = comm_npu_split
+    rank_loop_num = dl.cdiv(rank_size, swizzle_offset)
+    rank_tile_idx = iter_id // (swizzle_offset * data_loop_num)
+    data_rank_tile_idx = iter_id % (swizzle_offset * data_loop_num)
+    rank_tile_size = swizzle_offset
+    if rank_tile_idx == rank_loop_num - 1:
+        rank_tile_size = rank_size - swizzle_offset * rank_tile_idx
+    data_tile_idx = data_rank_tile_idx // rank_tile_size
+    rank_idx = rank_tile_idx * swizzle_offset + data_rank_tile_idx % rank_tile_size
+    rank_idx = (rank_idx * rank_stride) % rank_size + (rank_idx * rank_stride) // rank_size
+    rank_idx = (rank_idx + data_tile_idx) % rank_size
+    data_row_idx = data_tile_idx // data_col_loop_num
+    data_col_idx = data_tile_idx % data_col_loop_num
+    comm_row_size = dl.minimum(data_row_shape - data_row_idx * tile_row_shape, tile_row_shape)
+    comm_col_size = dl.minimum(data_col_shape - data_col_idx * tile_col_shape, tile_col_shape)
+    return data_row_idx, data_col_idx, rank_idx, comm_row_size, comm_col_size
+
+
+@triton.jit
+def gemm_swizzle2d_Nz(
+    iter_id,
+    data_row_shape,
+    data_col_shape,
+    tile_row_shape,
+    tile_col_shape,
+    swizzle_offset=7,
+):
+    """Ascend Nz-format 2D swizzle for GEMM compute tiles."""
+    data_row_loop_num = dl.cdiv(data_row_shape, tile_row_shape)
+    data_col_loop_num = dl.cdiv(data_col_shape, tile_col_shape)
+    col_loop_num = dl.cdiv(data_col_loop_num, swizzle_offset)
+    n_tile_idx = iter_id // (swizzle_offset * data_row_loop_num)
+    m_n_tile_idx = iter_id % (swizzle_offset * data_row_loop_num)
+    n_tile_size = swizzle_offset
+    if n_tile_idx == col_loop_num - 1:
+        n_tile_size = data_col_loop_num - swizzle_offset * n_tile_idx
+    data_row_idx = m_n_tile_idx // n_tile_size
+    data_col_idx = n_tile_idx * swizzle_offset + m_n_tile_idx % n_tile_size
+    if n_tile_idx % 2 == 1:
+        data_row_idx = data_row_loop_num - data_row_idx - 1
+    return data_row_idx, data_col_idx

--- a/python/tutorials/tle/dsa/09-ascend-allgather-gemm.py
+++ b/python/tutorials/tle/dsa/09-ascend-allgather-gemm.py
@@ -1,0 +1,322 @@
+# Copyright 2026- Xcoresigma Technology Co., Ltd
+
+import enum
+import os
+import torch
+import torch.distributed as dist
+import triton
+import triton.language as tl
+import triton.experimental.tle as tle
+from triton.backends.ascend.testing import do_bench_npu
+
+# ANSI color codes
+GREEN = "\033[92m"
+RED = "\033[91m"
+RESET = "\033[0m"
+BOLD = "\033[1m"
+
+
+class TestMode(enum.IntEnum):
+    NONE = 0
+    TEST_SWIZZLE = 1
+
+
+@triton.jit
+def kernel_allgather_gemm(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    peer_mem_ptr,
+    # Distributed parameters
+    rank,
+    rank_size,
+    # Matrix dimensions
+    M,
+    N,
+    K,
+    # The stride variables represent how much to increase the ptr by when moving by 1
+    # element in a particular dimension. E.g. `stride_am` is how much to increase `a_ptr`
+    # by to get the element one row down (A has M rows).
+    stride_am,
+    stride_ak,  #
+    stride_bk,
+    stride_bn,  #
+    stride_cm,
+    stride_cn,
+    # Meta-parameters
+    pvalue: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    COMM_BLOCK_SIZE_M: tl.constexpr,
+    COMM_BLOCK_SIZE_K: tl.constexpr,
+    USE_COMM_SWIZZLE: tl.constexpr,
+    USE_GEMM_SWIZZLE: tl.constexpr,
+):
+    """Kernel for computing the matmul C = A x B.
+    A has shape (M, K), B has shape (K, N) and C has shape (M, N)
+    """
+    dtype = tl.float16
+    subblock_idx = tle.dsa.ascend.sub_vec_id()
+    ncore = tl.num_programs(axis=0)
+    pid = tl.program_id(axis=0)
+    num_loops_m = tl.cdiv(M, BLOCK_SIZE_M * pvalue)
+    num_loops_n = tl.cdiv(N, BLOCK_SIZE_N)
+    buffer_row_size = BLOCK_SIZE_M * pvalue * rank_size
+    for global_id_m in range(0, num_loops_m):
+        actual_block_size_m = BLOCK_SIZE_M * pvalue
+        # process tail block
+        if global_id_m == num_loops_m - 1:
+            actual_block_size_m = M - global_id_m * BLOCK_SIZE_M * pvalue
+        num_k_blocks = tl.cdiv(K, BLOCK_SIZE_K)
+        comm_num_m_blocks = tl.cdiv(actual_block_size_m, COMM_BLOCK_SIZE_M)
+        comm_num_k_blocks = tl.cdiv(K, COMM_BLOCK_SIZE_K)
+        if subblock_idx == 0:
+            for k in range(pid, comm_num_m_blocks * comm_num_k_blocks * rank_size, ncore):
+                if USE_COMM_SWIZZLE:
+                    block_id_m, block_id_k, target_rank, comm_row_shape, comm_col_shape = (tle.swizzle2d_Nz(
+                        k,
+                        rank_size,
+                        actual_block_size_m,
+                        K,
+                        COMM_BLOCK_SIZE_M,
+                        COMM_BLOCK_SIZE_K,
+                    ))
+                else:
+                    total_comm_tiles = comm_num_m_blocks * comm_num_k_blocks
+                    target_rank = k % rank_size
+                    tile_idx = (k // rank_size) % total_comm_tiles
+                    block_id_m = tile_idx // comm_num_k_blocks
+                    block_id_k = tile_idx % comm_num_k_blocks
+                    comm_row_shape = tl.minimum(actual_block_size_m - block_id_m * COMM_BLOCK_SIZE_M, COMM_BLOCK_SIZE_M)
+                    # comm_col_shape = tl.minimum(K - block_id_k * COMM_BLOCK_SIZE_K, COMM_BLOCK_SIZE_K)
+
+                remote_ptr = tle.remote(peer_mem_ptr, target_rank)
+                comm_offs_m = (tl.arange(0, COMM_BLOCK_SIZE_M) + block_id_m * COMM_BLOCK_SIZE_M +
+                               global_id_m * BLOCK_SIZE_M * pvalue)
+                comm_offs_k = (tl.arange(0, COMM_BLOCK_SIZE_K) + block_id_k * COMM_BLOCK_SIZE_K)
+                a_ptrs = a_ptr + (comm_offs_m[:, None] * stride_am + comm_offs_k[None, :] * stride_ak)
+                peermem_comm_offs_m = (global_id_m * buffer_row_size + rank * BLOCK_SIZE_M * pvalue +
+                                       block_id_m * COMM_BLOCK_SIZE_M + tl.arange(0, COMM_BLOCK_SIZE_M))
+                remote_ptrs = remote_ptr + (peermem_comm_offs_m[:, None] * stride_am + comm_offs_k[None, :] * stride_ak)
+                comm_msk_m = comm_offs_m[:, None] < M
+                peermem_comm_msk_m = (peermem_comm_offs_m[:, None] < global_id_m * buffer_row_size +
+                                      BLOCK_SIZE_M * rank * pvalue + block_id_m * COMM_BLOCK_SIZE_M + comm_row_shape)
+                a = tl.load(a_ptrs, mask=(comm_offs_k[None, :] < K) & comm_msk_m, other=0.0)
+                tl.store(remote_ptrs, a, mask=(comm_offs_k[None, :] < K) & peermem_comm_msk_m)
+
+        tle.distributed_barrier()
+
+        num_tiles_m = tl.cdiv(actual_block_size_m, BLOCK_SIZE_M)
+        for block_id in range(pid, num_tiles_m * num_loops_n * rank_size, ncore):
+            if USE_GEMM_SWIZZLE:
+                block_id_m, block_id_n = tle.gemm_swizzle2d_Nz(
+                    block_id,
+                    rank_size * BLOCK_SIZE_M * num_tiles_m,
+                    N,
+                    BLOCK_SIZE_M,
+                    BLOCK_SIZE_N,
+                )
+            else:
+                m_tiles_total = num_tiles_m * rank_size
+                block_id_m = (block_id // num_loops_n) % m_tiles_total
+                block_id_n = block_id % num_loops_n
+
+            rank_idx = block_id_m // num_tiles_m
+            block_id_m = rank_idx * pvalue + (block_id_m % num_tiles_m)
+            accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+            matmul_offs_am = (global_id_m * buffer_row_size + block_id_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M))
+            matmul_msk_am = matmul_offs_am[:, None] < (global_id_m * buffer_row_size +
+                                                       BLOCK_SIZE_M * rank_idx * pvalue + actual_block_size_m)
+            offs_bn = block_id_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            msk_n = offs_bn[None, :] < N
+            for block_id_k in range(0, num_k_blocks):
+                offs_k = tl.arange(0, BLOCK_SIZE_K) + block_id_k * BLOCK_SIZE_K
+                a_ptrs = peer_mem_ptr + (matmul_offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+                b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+                a = tl.load(a_ptrs, mask=(offs_k[None, :] < K) & matmul_msk_am, other=0.0)
+                b = tl.load(b_ptrs, mask=(offs_k[:, None] < K) & msk_n, other=0.0)
+                # We accumulate along the K dimension.
+                accumulator += tl.dot(a, b)
+            c = accumulator.to(dtype)
+            # -----------------------------------------------------------
+            # Write back the block of the output matrix C with masks.
+            offs_cm = (block_id_m // pvalue * M + global_id_m * BLOCK_SIZE_M * pvalue +
+                       (block_id_m % pvalue) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M))
+            offs_cn = block_id_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+            c_mask = (offs_cm[:, None] < M * (block_id_m // pvalue + 1)) & (offs_cn[None, :] < N)
+            tl.store(c_ptrs, c, mask=c_mask)
+
+
+def allgather_gemm(
+    A,
+    B,
+    C,
+    peer_mem,
+    rank,
+    rank_size,
+    pvalue,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    COMM_BLOCK_SIZE_M,
+    COMM_BLOCK_SIZE_K,
+    USE_COMM_SWIZZLE,
+    USE_GEMM_SWIZZLE,
+):
+    """consume gemm"""
+    M, K = A.shape
+    _, N = B.shape
+    ncore = 20
+    assert ncore <= 20, "block num should less than or equal physical aicore num"
+    kernel_allgather_gemm[ncore, 1, 1](
+        A,
+        B,
+        C,
+        peer_mem,
+        rank,
+        rank_size,
+        M,
+        N,
+        K,
+        A.stride(0),
+        A.stride(1),
+        B.stride(0),
+        B.stride(1),
+        C.stride(0),
+        C.stride(1),
+        pvalue,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        COMM_BLOCK_SIZE_M,
+        COMM_BLOCK_SIZE_K,
+        USE_COMM_SWIZZLE,
+        USE_GEMM_SWIZZLE,
+    )
+
+
+def torch_allgather_gemm(A_local, B, world_size):
+    """
+    torch allgather gemm using torch.distributed.all_gather
+    - A_local: local A tensor on this rank
+    - B: B tensor (same across all ranks)
+    - world_size: number of ranks
+    Returns: C_golden computed from all-gathered A tensors
+    """
+    # Create a list to hold gathered A tensors from all ranks
+    A_list = [torch.empty_like(A_local) for _ in range(world_size)]
+
+    # Gather all A tensors from all ranks
+    dist.all_gather(A_list, A_local)
+
+    # Concatenate all A tensors along the first dimension
+    A_golden = torch.cat(A_list, dim=0)
+
+    # Compute golden reference: C = A_golden @ B
+
+    C_golden = torch.matmul(A_golden, B)
+    return C_golden
+
+
+def run_test_distributed(TEST_MODE=TestMode.NONE):
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 256
+    COMM_BLOCK_SIZE_M = 20
+    COMM_BLOCK_SIZE_K = 256
+    pvalue = 4
+    tle.init_communicator()
+    pe = dist.get_rank()
+    world_size = dist.get_world_size()
+    size = BLOCK_SIZE_M * pvalue * K * world_size
+    buf_com = torch.full((size, ), 0.0, dtype=dtype).npu()
+    peer_mem = tle.create_dist_tensor(buf_com)
+
+    # Each rank creates its own local A and B tensors
+    A_local = torch.randn([M, K], dtype=dtype).npu()
+    B = torch.randn([K, N], dtype=dtype).npu()
+    C = torch.zeros([M * world_size, N], dtype=dtype).npu()
+
+    # Compute golden reference using torch.distributed.all_gather
+    C_golden = torch_allgather_gemm(A_local, B, world_size)
+
+    print(f"TEST_MODE: {TEST_MODE}")
+    if TEST_MODE == TestMode.TEST_SWIZZLE:
+        cases = [
+            ("both_swizzle", True, True),
+            ("comm_only", True, False),
+            ("gemm_only", False, True),
+            ("no_swizzle", False, False),
+        ]
+        results = []
+        rank = dist.get_rank()
+
+        for name, USE_COMM_SWIZZLE, USE_GEMM_SWIZZLE in cases:
+            us = do_bench_npu(
+                lambda: allgather_gemm(A_local, B, C, peer_mem, pe, world_size, pvalue, BLOCK_SIZE_M, BLOCK_SIZE_N,
+                                       BLOCK_SIZE_K, COMM_BLOCK_SIZE_M, COMM_BLOCK_SIZE_K, USE_COMM_SWIZZLE,
+                                       USE_GEMM_SWIZZLE), clear_l2_cache=True, collect_prof=False)
+            results.append((name, us))
+            if rank == 0:
+                print(f"{name:16s}: {us:.2f} us")
+        dist.barrier()
+        if rank == 0:
+            base = results[3][1]  # plain_none as baseline
+            print("\n[Relative to plain_none] (us)")
+            for name, us in results:
+                print(f"  {name:16s}: {us:.2f} us  (x{us / base:.3f})")
+
+    elif TEST_MODE == TestMode.NONE:
+        # Run the distributed kernel with local A
+        allgather_gemm(A_local, B, C, peer_mem, pe, world_size, pvalue, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K,
+                       COMM_BLOCK_SIZE_M, COMM_BLOCK_SIZE_K, USE_COMM_SWIZZLE=True, USE_GEMM_SWIZZLE=True)
+        passed = torch.tensor([1], dtype=torch.int32).npu()
+        error_msg = ""
+        try:
+            torch.testing.assert_close(C_golden, C, rtol=1e-3, atol=1e-3)
+        except AssertionError as e:
+            passed[0] = 0
+            error_msg = str(e)
+            raise
+
+        # Gather all ranks' pass/fail status
+        all_passed = [torch.zeros(1, dtype=torch.int32).npu() for _ in range(world_size)]
+        dist.all_gather(all_passed, passed)
+
+        # Print sequentially, one rank at a time
+        dist.barrier()
+        for rank_id in range(world_size):
+            if pe == rank_id:
+                if all_passed[rank_id].item() == 1:
+                    print(
+                        f"{GREEN}[PASS]{RESET} Rank {pe}: C_golden and C match within tolerances (rtol=1e-3, atol=1e-3).",
+                        flush=True,
+                    )
+                else:
+                    print(
+                        f"{RED}[FAIL]{RESET} Rank {pe}: C_golden and C do NOT match. Details:\n{error_msg}",
+                        flush=True,
+                    )
+            dist.barrier()
+        # Raise if any rank failed
+        if any(r.item() == 0 for r in all_passed):
+            if passed.item() == 0:
+                raise AssertionError(error_msg)
+    else:
+        raise ValueError(f"Unknown TEST_MODE: {TEST_MODE}")
+
+    tle.cleanup_communicator(peer_mem)
+
+
+if __name__ == "__main__":
+    dtype, M, N, K = [torch.float16, 4096, 4096, 4096]
+
+    # TEST_MODE: None, TEST_SWIZZLE
+    run_test_distributed(TEST_MODE=TestMode.NONE)
+    local_pe = int(os.environ["LOCAL_RANK"])
+    world_size = dist.get_world_size()
+    if local_pe == 0:
+        print(f"[INFO] Test passed successfully for {world_size} ranks!")

--- a/python/tutorials/tle/dsa/10-tle-d2d-barrier.py
+++ b/python/tutorials/tle/dsa/10-tle-d2d-barrier.py
@@ -1,0 +1,71 @@
+# Copyright 2026- Xcoresigma Technology Co., Ltd
+
+import torch
+import torch.distributed as dist
+import triton
+import triton.language as tl
+import triton.experimental.tle as tle
+
+DEVICE_MESH = tle.device_mesh(tle.MeshConfig(device=2))
+N = 8
+
+
+@triton.jit()
+def _barrier_d2d_kernel(out_ptr, device_dptr, mesh: tl.constexpr):
+    pid = tl.program_id(0)
+    local_rank = tle.shard_id(mesh, 'device', device_dptr=device_dptr)
+    n_rank = mesh.shape[0]
+    peer = (local_rank + 1) % n_rank
+
+    remote_mem = tle.remote(
+        device_dptr,
+        space="device",
+        dtype=tl.float32,
+        shard_id=peer,
+        # offset=pid
+    )
+    val = tl.load(remote_mem + pid)
+    tl.store(out_ptr + pid, val)
+    tle.distributed_barrier(mesh=mesh, device_dptr=device_dptr, space="device")
+
+
+def _runtime_verify(output, device_dptr, grid, rank, world_size):
+    dist.barrier()
+    _barrier_d2d_kernel[grid](device_dptr=device_dptr, out_ptr=output, mesh=DEVICE_MESH)
+
+    torch.npu.synchronize()
+
+    import sys
+    peer_rank = (rank + 1) % world_size
+    expected = torch.arange(N, dtype=torch.float32, device='npu') + peer_rank * 1000
+    if torch.allclose(output, expected):
+        print(f"[Rank {rank}] [PASSED] read peer rank {peer_rank}")
+    else:
+        print(f"[Rank {rank}] [FAILED] read peer rank {peer_rank}")
+        print(f"[Rank {rank}] expected[:4] = {expected[:4].cpu().tolist()}")
+        print(f"[Rank {rank}] output[:4] = {output[:4].cpu().tolist()}")
+        sys.exit(1)
+
+    tle.cleanup_communicator(device_dptr)
+
+
+class TestD2DBarrier:
+
+    def test_tle_d2d_barrier(self):
+        grid = (N, )
+
+        tle.init_communicator()
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+
+        x = (torch.arange(N, dtype=torch.float32, device="npu") + rank * 1000).clone()
+        device_dptr = tle.create_dist_tensor(x)
+        device_dptr.copy_(x)
+        output = torch.zeros(N, dtype=torch.float32, device="npu")
+
+        _runtime_verify(output, device_dptr, grid, rank, world_size)
+
+
+# cmd: torchrun --nproc-per-node=2 python/python/tutorials/tle/dsa/10-tle-d2d-barrier.py
+if __name__ == "__main__":
+    TestD2DBarrier().test_tle_d2d_barrier()

--- a/third_party/ascend/lib/TritonToHIVM/CMakeLists.txt
+++ b/third_party/ascend/lib/TritonToHIVM/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(TritonToHIVM
 
   DEPENDS
   TritonToHIVMConversionPassIncGen
+  TleDSATableGen
 
   LINK_LIBS
   BiShengIRHIVMDialect
@@ -11,4 +12,5 @@ add_triton_library(TritonToHIVM
   MLIRTransforms
   MLIRSupport
   TritonIR
+  TleDSAToHIVM
 )

--- a/third_party/ascend/lib/TritonToHIVM/TritonToHIVM.cpp
+++ b/third_party/ascend/lib/TritonToHIVM/TritonToHIVM.cpp
@@ -32,7 +32,7 @@
 #include "llvm/Support/LogicalResult.h"
 
 #include "ascend/include/Dialect/TritonAscend/IR/TritonAscendDialect.h"
-
+#include "tle/dsa/dialect/include/Conversion/TleToHIVM/TleDistributedOpToHIVMConverter.h"
 namespace mlir {
 namespace triton {
 #define GEN_PASS_DEF_TRITONTOHIVM
@@ -45,6 +45,7 @@ using namespace hivm;
 
 namespace {
 
+constexpr int patternBenefitPrioritizeOverLLVMConversions = 10;
 struct CoreAndPipes {
   TCoreTypeAttr core;
   PipeAttr producer;
@@ -161,7 +162,23 @@ void TritonToHIVMPass::runOnOperation() {
   ConversionTarget target(getContext());
   target.addLegalDialect<hivm::HIVMDialect>();
 
+  // CUBE_AND_VECTOR core type; otherwise VECTOR only.
+  bool existDot = false;
+  module.walk([&](triton::DotOp dotOp) {
+    existDot = true;
+    return WalkResult::interrupt();
+  });
+  module.walk([&](triton::DotScaledOp dotScaledOp) {
+    existDot = true;
+    return WalkResult::interrupt();
+  });
+
   RewritePatternSet patterns(&getContext());
+
+  // TLE distributed ops
+  mlir::triton::tle::populateTleDistributedOpToHIVMConversionPatterns(
+      patterns, patternBenefitPrioritizeOverLLVMConversions, existDot);
+
   patterns.add<TritonCustomOpToHIVMSyncOpConversion>(patterns.getContext());
   if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
     signalPassFailure();

--- a/third_party/tle/dsa/dialect/include/Conversion/TleToHIVM/TleDistributedOpToHIVMConverter.h
+++ b/third_party/tle/dsa/dialect/include/Conversion/TleToHIVM/TleDistributedOpToHIVMConverter.h
@@ -1,0 +1,14 @@
+// Copyright 2026- Xcoresigma Technology Co., Ltd
+
+#ifndef TRITON_TLE_CONVERSION_TLE_DISTRIBUTED_OP_TO_HIVM_CONVERTER_H_
+#define TRITON_TLE_CONVERSION_TLE_DISTRIBUTED_OP_TO_HIVM_CONVERTER_H_
+
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir::triton::tle {
+void populateTleDistributedOpToHIVMConversionPatterns(
+    mlir::RewritePatternSet &patterns, PatternBenefit benefit = 1,
+    bool existDot = false);
+}
+#endif

--- a/third_party/tle/dsa/dialect/include/IR/TleDSAOps.td
+++ b/third_party/tle/dsa/dialect/include/IR/TleDSAOps.td
@@ -149,5 +149,52 @@ def TLE_DSAMinOp : TLE_Op<"dsa_min", [Pure, MemoryEffects<[MemWrite]>,
 ///
 ///   let assemblyFormat = "$inA `,` $inB `,` $res attr-dict `:` type($inA) `,` type($inB) `,` type($res)";
 /// }
+def TT_GetRankOp : TLE_Op<"get_rank", [Pure]> {
+  let summary = "Rank of the calling PE";
+
+  let arguments = (ins I32:$axis);
+
+  let results = (outs I32:$result);
+
+  let assemblyFormat = "$axis attr-dict `:` type($result)";
+}
+
+def TT_SymmAtOp : TLE_Op<"symm_at", [
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+  TypesMatchWith<"remoteAddr matches symmAddr type", "symmAddr", "remoteAddr", "$_self">,
+]> {
+  let summary = "obtain the symmetric address on the specified Rank.";
+
+  let arguments = (ins
+    TT_Ptr:$symmAddr,
+    I32:$rank
+  );
+
+  let results = (outs TT_Ptr:$remoteAddr);
+
+  let assemblyFormat = "$symmAddr `,` $rank `,` attr-dict `:` qualified(type($symmAddr))";
+}
+
+
+def TT_ExternCallOp : TLE_Op<"extern_call", [
+   DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+]> {
+
+    let description = [{
+        call an external function $symbol implemented in $libpath/$libname with $args
+        return $libpath/$libname:$symbol($args...)
+    }];
+
+    let arguments = (ins Variadic<TT_Type>:$srcs, StrAttr:$libname, StrAttr:$libpath, StrAttr:$symbol, BoolAttr:$pure);
+
+    let results = (outs Variadic<TT_Type>:$result);
+
+    let assemblyFormat = "operands attr-dict `:` functional-type(operands, $result)";
+
+    let extraClassDeclaration = [{
+      // Interface method for ConditionallySpeculatable.
+      Speculation::Speculatability getSpeculatability();
+    }];
+}
 
 #endif

--- a/third_party/tle/dsa/dialect/lib/Conversion/CMakeLists.txt
+++ b/third_party/tle/dsa/dialect/lib/Conversion/CMakeLists.txt
@@ -1,3 +1,4 @@
 # Copyright 2026- Xcoresigma Technology Co., Ltd
 
 add_subdirectory(TleToLinalg)
+add_subdirectory(TleToHIVM)

--- a/third_party/tle/dsa/dialect/lib/Conversion/TleToHIVM/CMakeLists.txt
+++ b/third_party/tle/dsa/dialect/lib/Conversion/TleToHIVM/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright 2026- Xcoresigma Technology Co., Ltd
+
+add_triton_library(TleDSAToHIVM
+  TleDistributedOpToHIVMConverter.cpp
+
+  DEPENDS
+  TleDSATableGen
+
+  LINK_LIBS PUBLIC
+  TleIR
+  TleDSAIR
+  MLIRIR
+  MLIRTensorDialect
+)

--- a/third_party/tle/dsa/dialect/lib/Conversion/TleToHIVM/TleDistributedOpToHIVMConverter.cpp
+++ b/third_party/tle/dsa/dialect/lib/Conversion/TleToHIVM/TleDistributedOpToHIVMConverter.cpp
@@ -1,0 +1,164 @@
+// Copyright 2026- Xcoresigma Technology Co., Ltd
+
+#include "tle/dsa/dialect/include/Conversion/TleToHIVM/TleDistributedOpToHIVMConverter.h"
+
+#if __has_include("bishengir/Dialect/HIVM/IR/HIVM.h")
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#endif
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "tle/dsa/dialect/include/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Casting.h"
+#include <string>
+
+using namespace mlir;
+
+namespace {
+
+static std::string getTypeName(Type type) {
+  if (auto fpTy = llvm::dyn_cast<FloatType>(type)) {
+    if (fpTy.isBF16())
+      return "bfloat16";
+    else if (fpTy.isF16())
+      return "half";
+    else if (fpTy.isF32())
+      return "float";
+  }
+  if (auto intTy = llvm::dyn_cast<IntegerType>(type)) {
+    switch (intTy.getWidth()) {
+    case 8:
+      return "int8";
+    case 16:
+      return "int16";
+    case 32:
+      return "int32";
+    case 64:
+      return "int64";
+    }
+  }
+  return "unknown";
+}
+
+/// Generic template to convert TLE distributed ops to hivm.custom
+template <typename TleOp>
+class TleDistributedOpToHIVM : public OpRewritePattern<TleOp> {
+public:
+  TleDistributedOpToHIVM(MLIRContext *context, bool existDot = false,
+                         PatternBenefit benefit = PatternBenefit(1))
+      : OpRewritePattern<TleOp>(context, benefit), existDotFlag(existDot) {}
+
+  void inferCoreType(TleOp op) const {
+    // If kernel contains tt.dot, need both CUBE and VECTOR; otherwise VECTOR
+    // only.
+    auto coreType = existDotFlag ? hivm::TCoreType::CUBE_AND_VECTOR
+                                 : hivm::TCoreType::VECTOR;
+    op->setAttr(hivm::TCoreTypeAttr::name,
+                hivm::TCoreTypeAttr::get(op->getContext(), coreType));
+  }
+
+  LogicalResult matchAndRewrite(TleOp op,
+                                PatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+
+    inferCoreType(op);
+
+    // Determine symbol name
+    std::string symbolName;
+    if (auto sym = op->template getAttrOfType<StringAttr>("symbol")) {
+      symbolName = sym.str();
+    }
+    bool hasSideEffect = !mlir::isMemoryEffectFree(op.getOperation());
+
+    llvm::TypeSwitch<Operation *, void>(op)
+        .Case([&](triton::tle::SymmAtOp symmOp) {
+          auto elemTy =
+              llvm::cast<triton::PointerType>(symmOp.getSymmAddr().getType())
+                  .getPointeeType();
+          symbolName = "aclshmem_ptr_" + getTypeName(elemTy);
+        })
+        .Case([&](triton::tle::GetRankOp) { symbolName = "aclshmem_my_pe"; });
+
+    if (symbolName.empty()) {
+      symbolName = op->getName().stripDialect().str();
+    }
+
+    std::string customName = "dist." + symbolName;
+
+    // Build custom results (tensor outputs need tensor::EmptyOp)
+    llvm::SmallVector<Value> customResults;
+    for (auto res : op->getResults()) {
+      if (auto tensorTy = llvm::dyn_cast<RankedTensorType>(res.getType())) {
+        auto emptyOp = rewriter.create<tensor::EmptyOp>(
+            loc, tensorTy.getShape(), tensorTy.getElementType());
+        customResults.emplace_back(emptyOp);
+      }
+    }
+
+    auto customOp = rewriter.create<hivm::CustomOp>(
+        loc, op->getResultTypes(), customName, op->getOperands(), customResults,
+        ValueRange{});
+
+    // Copy original attrs first, then override with controlled values
+    customOp->setAttrs(op->getAttrs());
+    customOp->setAttr("hivm.is_distributed", rewriter.getUnitAttr());
+    customOp.setPipe(hivm::PIPE::PIPE_S);
+    customOp.setVFMode(hivm::VFMode::SIMD);
+    customOp->setAttr("symbol", rewriter.getStringAttr(symbolName));
+
+    if (!hasSideEffect) {
+      customOp->setAttr("no_side_effect", rewriter.getUnitAttr());
+    }
+
+    // Record GM addr argument indices for downstream passes
+    llvm::SmallVector<int> gmAddrArgsIndices;
+    auto funcOp = customOp->template getParentOfType<triton::FuncOp>();
+    if (funcOp) {
+      for (auto &&[idx, operand] : llvm::enumerate(customOp->getOperands())) {
+        if (!llvm::isa<triton::PointerType>(operand.getType()))
+          continue;
+        if (auto arg = llvm::dyn_cast<BlockArgument>(operand)) {
+          if (arg.getOwner() == &funcOp.getFunctionBody().front()) {
+            gmAddrArgsIndices.emplace_back(idx);
+          }
+        }
+      }
+    }
+    customOp->setAttr("gm_addr_args_indices",
+                      rewriter.getDenseI32ArrayAttr(gmAddrArgsIndices));
+
+    if (op->getNumResults() == 0) {
+      rewriter.eraseOp(op);
+    } else {
+      rewriter.replaceOp(op, customOp);
+    }
+
+    return success();
+  }
+
+private:
+  bool existDotFlag;
+};
+
+/// Helper to register patterns with existDot flag
+template <typename... Args>
+void registerTleDistributedOpToHIVM(
+    RewritePatternSet &patterns, bool existDot,
+    PatternBenefit benefit = PatternBenefit(1)) {
+  patterns.add<TleDistributedOpToHIVM<Args>...>(patterns.getContext(), existDot,
+                                                benefit);
+}
+
+} // namespace
+
+void mlir::triton::tle::populateTleDistributedOpToHIVMConversionPatterns(
+    mlir::RewritePatternSet &patterns, PatternBenefit benefit, bool existDot) {
+  registerTleDistributedOpToHIVM<
+      triton::tle::SymmAtOp, triton::tle::ExternCallOp, triton::tle::GetRankOp>(
+      patterns, existDot, benefit);
+}

--- a/third_party/tle/dsa/dialect/lib/IR/TleOps.cpp
+++ b/third_party/tle/dsa/dialect/lib/IR/TleOps.cpp
@@ -4,4 +4,32 @@
 #include "mlir/IR/Builders.h"
 #include "tle/dsa/dialect/include/IR/Dialect.h"
 
-namespace mlir::triton::tle {}
+namespace mlir::triton::tle {
+
+// -- SymmAtOp --
+void SymmAtOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Read::get(),
+                       SideEffects::DefaultResource::get());
+}
+
+// -- ExternCallOp --
+void ExternCallOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  if (getPure())
+    return;
+  effects.emplace_back(MemoryEffects::Write::get(),
+                       SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(),
+                       SideEffects::DefaultResource::get());
+}
+
+Speculation::Speculatability ExternCallOp::getSpeculatability() {
+  if (getPure())
+    return Speculation::Speculatable;
+  return Speculation::NotSpeculatable;
+}
+
+} // namespace mlir::triton::tle

--- a/third_party/tle/dsa/tle_ir.cc
+++ b/third_party/tle/dsa/tle_ir.cc
@@ -290,5 +290,23 @@ void init_tle_dsa_ir(py::module &&m) {
 
              return self.create<memref::SubViewOp>(source, mixedOffsets,
                                                    mixedSizes, mixedStrides);
+           })
+      // dist
+      .def("create_get_rank",
+           [](TritonOpBuilder &self, Value axis) -> Value {
+             return self.create<triton::tle::GetRankOp>(axis);
+           })
+      .def("create_symm_at",
+           [](TritonOpBuilder &self, Value ptr, Value rank) -> Value {
+             return self.create<triton::tle::SymmAtOp>(ptr.getType(), ptr,
+                                                       rank);
+           })
+      .def("create_extern_call",
+           [](TritonOpBuilder &self, const std::string &libName,
+              const std::string &libPath, const std::string &symbol,
+              std::vector<Value> &argList, const std::vector<Type> &retTypes,
+              bool isPure) -> OpState {
+             return self.create<triton::tle::ExternCallOp>(
+                 retTypes, argList, libName, libPath, symbol, isPure);
            });
 }


### PR DESCRIPTION
Support tle dist ops on Ascend backend, so kernels can do inter-card communication (allgather, device-to-device barrier, remote pointer access) purely in Triton and lower through HIVM.

The change adds:
- Frontend: the host side has `init_communicator`, `create_dist_tensor`, `cleanup_communicator`; the device side has `remote`, `distributed_barrier`, `swizzle`, `shard_id` ops. 
- DSA dialect: The new distributed ops in `TleToHIVM` converter that lowers them to HIVM.
- Tutorials: `09-ascend-allgather-gemm.py` and `10-tle-d2d-barrier.py`.

<!-- PR Title Format:
[TLE][BUILD][TEST][CI/CD][DOC][PROTON][BACKEND][FLIR] Brief description
[LANGUAGE][AUTOTUNER][LAYOUT][PIPELINE][WarpSpecialization] Brief description
Do not set the following title tags: [FEATURE][BUG][FixBug][Refine] ...
-->
