### PR TITLE
[BACKEND] Fix CANN 8.5.1 bishengir compatibility

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -95,6 +95,18 @@ def make_ttir(mod, metadata, opt):
     return mod
 
 
+def _normalize_mlir_text_for_bishengir(linalg: str) -> str:
+    # CANN's bishengir tools cannot parse the newer ` to tensor<...>` result-type
+    # clause emitted by triton-opt for bufferization.to_tensor; strip it while
+    # keeping `restrict writable` (required by One-Shot Analysis).
+    if "bufferization.to_tensor" not in linalg:
+        return linalg
+    return "\n".join(
+        re.sub(r" to tensor<[^>]*>", "", line) if "bufferization.to_tensor" in line else line
+        for line in linalg.split("\n")
+    )
+
+
 def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
     # use triton_adapter to lower Triton-MLIR to linalg
     # Get Triton-MLIR as string
@@ -169,7 +181,7 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
             dump_manager = get_dump_manager(metadata["hash"])
             dump_manager.put(str(mod), "kernel.ttadapter.mlir", binary=False)
 
-        return str(mod)
+        return _normalize_mlir_text_for_bishengir(str(mod))
 
 
 def linalg_to_bc_by_triton_mlir_opt(linalg: str, metadata, opt):
@@ -712,7 +724,7 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
                 _compile_option_list += \
                     [f"--link-aicore-bitcode={bitcode}"]
 
-        _compile_option_list += [f"--link-aicore-bitcode={get_libdevice()}"]
+        pass
 
         disable_size_align_for_cast = metadata["disable_size_align_for_cast"]
         if disable_size_align_for_cast is not None:
@@ -866,7 +878,7 @@ class NPUOptions:
     #
     # If False, the compilation flow is:
     #   Linalg IR → LLIR → Binary (via bishengir-compile directly)
-    use_bytecode: bool = True
+    use_bytecode: bool = False
     # take effect on the reorder instruction pattern for SIMT. The pattern is disabled by default.
     enable_simt_reorder_instruction: bool = False
     # disable simt fma optimization to get high precision

--- a/third_party/ascend/language/cann/libdevice.py
+++ b/third_party/ascend/language/cann/libdevice.py
@@ -125,6 +125,16 @@ def ldexp(arg0, arg1, _semantic=None):
 
 @core.extern
 def pow(arg0, arg1, _semantic=None):
+    int_dtypes = (core.dtype("int1"), core.dtype("int8"), core.dtype("int16"),
+                  core.dtype("int32"), core.dtype("int64"),
+                  core.dtype("uint8"), core.dtype("uint16"),
+                  core.dtype("uint32"), core.dtype("uint64"))
+    arg0 = _semantic.to_tensor(arg0)
+    arg1 = _semantic.to_tensor(arg1)
+    if arg0.dtype in int_dtypes:
+        arg0 = _semantic.cast(arg0, core.dtype("fp32"))
+    if arg1.dtype in int_dtypes:
+        arg1 = _semantic.cast(arg1, core.dtype("fp32"))
     if triton_enable_libdevice_simt() and is_compile_on_910_95:
         return core.extern_elementwise("", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__hmf_pow_fp32", core.dtype("fp32")),


### PR DESCRIPTION
### Description

FlagTree `triton_v3.5.x` targets LLVM 22 era MLIR syntax, but CANN 8.5.1's `bishengir` toolchain (2026-02, commit e4e2ba9841d1) is older and cannot parse three MLIR constructs emitted by FlagTree's compiler. This causes all Triton kernel compilations on Ascend to fail, making FlagGems kernels non-functional on CANN 8.5.1.

### Root Cause

Three incompatibilities between FlagTree MLIR emission and CANN 8.5.1 bishengir:

1. **`bufferization.to_tensor` result type clause** — FlagTree's `triton-opt` emits `bufferization.to_tensor ... to tensor<...>` with a result-type clause that bishengir cannot parse.

2. **`.mlirbc` bytecode** — FlagTree emits MLIR bytecode (`.mlirbc`) for inter-tool communication, but bishengir-opt cannot read the newer bytecode version.

3. **`--link-aicore-bitcode` flag** — FlagTree passes `--link-aicore-bitcode=<path>` to `bishengir-compile`, but CANN 8.5.1's bishengir-compile does not recognize this parameter.

4. **Integer `pow()` dtype** — `libdevice.pow()` passes integer arguments directly to the SIMT path, but bishengir does not support integer `pow`.

### Changes

**`compiler.py` (3 fixes)**:

1. Add `_normalize_mlir_text_for_bishengir()`: strips ` to tensor<...>` result-type clause from `bufferization.to_tensor` lines while keeping `restrict writable` (required by One-Shot Analysis).

2. Set `NPUOptions.use_bytecode = False`: use text MLIR instead of bytecode for inter-tool transfer.

3. Remove `--link-aicore-bitcode` from compile option list (replace with `pass`).

**`libdevice.py` (1 fix)**:

Cast integer arguments to `fp32` before calling the libdevice SIMT path in `pow()`.

### Testing

**Environment**: Ascend 910B2C x86_64 / CANN 8.5.1 (bishengir 2026-02)

```bash
# Before fix: all Triton kernel compilations fail
# After fix: FlagGems kernels compile and execute

python3 -c "
import torch
import flag_gems
flag_gems.enable()
x = torch.randn(1024, device='npu')
y = torch.relu(x)
print('FlagGems kernel OK:', y.shape)
"
```

Tested end-to-end with vllm-plugin-FL + FlagCX + FlagGems on Qwen3.6-35B-A3B (4-card TP=4):
- FlagGems Triton kernels compile via bishengir ✅
- Inference produces correct output ✅
