### PR TITLE
[Metax][TLE] Metax TLE support local pointer.

### DIFF
--- a/.github/workflows/metax3.6-build-and-test.yml
+++ b/.github/workflows/metax3.6-build-and-test.yml
@@ -144,4 +144,7 @@ jobs:
             test_extract_tile_dynamic_index.py \
             test_extract_tile_static_index.py \
             test_insert_tile_dynamic_index.py \
-            test_insert_tile_static_index.py
+            test_insert_tile_static_index.py \
+            test_tle_gpu_local_ptr.py \
+            -k "not test_local_pointer_tiled_matmul_matches_torch and \
+                not test_local_pointer_full_view_dot_avoids_pointer_convert_layout"

--- a/python/setup_tools/utils/metax.py
+++ b/python/setup_tools/utils/metax.py
@@ -31,12 +31,9 @@ def register_cache(cache, flagtree_backend, check_env, set_llvm_env):
         post_hook=set_llvm_env,
     )
     cache.store(
-        file="metaxTritonPlugin.so",
-        condition=is_metax and not os.environ.get("FLAGTREE_PLUGIN"),
-        url="https://baai-cp-web.ks3-cn-beijing.ksyuncs.com/trans/metaxTritonPlugin-cpython3.12-x86_64_v0.6.1.tar.gz",
-        copy_dst_path=f"third_party/{flagtree_backend}",
-        md5_digest="afb7ab8f",
-    )
+        file="metaxTritonPlugin.so", condition=is_metax and not os.environ.get("FLAGTREE_PLUGIN"),
+        url="https://baai-cp-web.ks3-cn-beijing.ksyuncs.com/trans/metaxTritonPlugin-cpython3.12-x86_64_v0.6.2.tar.gz",
+        copy_dst_path=f"third_party/{flagtree_backend}", md5_digest="de37eb01")
 
 
 def install_extension(*args, **kargs):

--- a/third_party/metax/backend/compiler.py
+++ b/third_party/metax/backend/compiler.py
@@ -272,7 +272,7 @@ class MACABackend(BaseBackend):
         passes.ttgpuir.add_remove_layout_conversions(pm)
         passes.ttgpuir.add_optimize_thread_locality(pm)
         if enable_mctle:
-            #mctle.passes.add_reject_dot_op(pm)
+            mctle.passes.add_reject_dot_op(pm)
             mctle.passes.add_early_assign_memory_space(pm)
             mctle.passes.add_select_encodings(pm)
             mctle.passes.add_insert_local_pointer_barriers(pm)

--- a/third_party/metax/include/triton/Dialect/Triton/IR/Dialect.h
+++ b/third_party/metax/include/triton/Dialect/Triton/IR/Dialect.h
@@ -28,6 +28,12 @@ struct GlobalMemory : public SideEffects::Resource::Base<GlobalMemory> {
   StringRef getName() final { return "<GlobalMemory>"; }
 };
 
+#ifdef __MCTLE__
+struct SharedMemory : public SideEffects::Resource::Base<SharedMemory> {
+  StringRef getName() final { return "<SharedMemory>"; }
+};
+#endif
+
 class DialectInferLayoutInterface
     : public DialectInterface::Base<DialectInferLayoutInterface> {
 public:

--- a/third_party/metax/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/third_party/metax/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -20,6 +20,9 @@ include "triton/Dialect/Triton/IR/TritonOpInterfaces.td"
 // Interfaces
 //
 def GlobalMemory : Resource<"::mlir::triton::GlobalMemory">;
+#ifdef __MCTLE__
+def SharedMemory : Resource<"::mlir::triton::SharedMemory">;
+#endif
 
 //
 // Op Base
@@ -351,8 +354,13 @@ def TT_StoreOp : TT_Op<"store", [
 def TT_AtomicRMWOp : TT_Op<"atomic_rmw", [
   SameOperandsAndResultShape,
   SameOperandsAndResultEncoding,
+#ifdef __MCTLE__
+  TypesMatchWith<"value type matches ptr type", "ptr", "val",
+                 "getPointeeType($_self)">,
+#else
   TypesMatchWith<"ptr type matches value type", "val", "ptr",
                  "getPointerTypeSameShape($_self)">,
+#endif
   TypesMatchWith<"mask type matches value type",
                  "val", "mask", "getI1SameShape($_self)",
                  "($_op.getOperands().size() <= 2) || std::equal_to<>()">
@@ -367,7 +375,12 @@ def TT_AtomicRMWOp : TT_Op<"atomic_rmw", [
 
     let arguments = (ins
       TT_AtomicRMWAttr:$atomic_rmw_op,
+#ifdef __MCTLE__
+      Arg<TT_PtrLike, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>,
+                           MemRead<SharedMemory>, MemWrite<SharedMemory>]>:$ptr,
+#else
       Arg<TT_PtrLike, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$ptr,
+#endif
       TT_Type:$val,
       Optional<TT_BoolLike>:$mask,
       TT_MemSemanticAttr:$sem,
@@ -387,10 +400,17 @@ def TT_AtomicRMWOp : TT_Op<"atomic_rmw", [
 def TT_AtomicCASOp : TT_Op<"atomic_cas", [
   SameOperandsAndResultShape,
   SameOperandsAndResultEncoding,
+#ifdef __MCTLE__
+  TypesMatchWith<"cmp type matches ptr type", "ptr", "cmp",
+                 "getPointeeType($_self)">,
+  TypesMatchWith<"value type matches ptr type", "ptr", "val",
+                 "getPointeeType($_self)">
+#else
   TypesMatchWith<"ptr type matches cmp type", "cmp", "ptr",
                   "getPointerTypeSameShape($_self)">,
   TypesMatchWith<"ptr type matches value type", "val", "ptr",
                   "getPointerTypeSameShape($_self)">
+#endif
 ]> {
     let summary = "atomic cas";
 
@@ -405,7 +425,12 @@ def TT_AtomicCASOp : TT_Op<"atomic_cas", [
     }];
 
     let arguments = (ins
+#ifdef __MCTLE__
+      Arg<TT_PtrLike, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>,
+                           MemRead<SharedMemory>, MemWrite<SharedMemory>]>:$ptr,
+#else
       Arg<TT_PtrLike, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$ptr,
+#endif // __MCTLE__
       TT_Type:$cmp,
       TT_Type:$val,
       TT_MemSemanticAttr:$sem,

--- a/third_party/metax/plugin/lib/TritonMETAXGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/metax/plugin/lib/TritonMETAXGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -7,9 +7,12 @@
 #include "Utility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Tools/LayoutUtils.h"
+#include <optional>
 
 using namespace mlir;
 using namespace mlir::triton;
+
+namespace ttg = mlir::triton::gpu;
 
 using ::mlir::LLVM::delinearize;
 using ::mlir::LLVM::getSharedMemoryBase;
@@ -30,6 +33,25 @@ Value maybeAnd(RewriterBase &rewriter, Location loc, Value a, Value b) {
   }
   return a ? a : b;
 }
+
+#ifdef __MCTLE__
+std::optional<unsigned> inferPtrAddrSpace(llvm::ArrayRef<Value> ptrElems) {
+  for (Value elem : ptrElems) {
+    if (auto ptrTy = dyn_cast<LLVM::LLVMPointerType>(elem.getType()))
+      return ptrTy.getAddressSpace();
+  }
+  return std::nullopt;
+}
+
+bool isSharedFamilyAddressSpace(unsigned addressSpace) {
+  return addressSpace == 3;
+}
+
+bool isSharedPointerValue(llvm::ArrayRef<Value> ptrElems,
+                          unsigned defaultAddrSpace = 1) {
+  return inferPtrAddrSpace(ptrElems).value_or(defaultAddrSpace) == 3;
+}
+#endif
 
 // Return a predicate that is true only if the current thread holds unique data,
 // according to freeVarsMask. The predicate may be null to indicate no
@@ -205,6 +227,31 @@ struct LoadStoreConversionBase {
     return std::min<unsigned>(128 / pointeeBitWidth, contiguity);
   }
 
+#ifdef __MCTLE__
+  unsigned getMaxVectorSizeByAlignment(Value ptr) const {
+    auto tensorTy = dyn_cast<RankedTensorType>(ptr.getType());
+    if (!tensorTy)
+      return 1;
+    auto *axisInfo = axisAnalysisPass.getAxisInfo(ptr);
+    if (!axisInfo || axisInfo->getRank() == 0)
+      return 1;
+
+    auto linAttr = ttg::toLinearEncoding(tensorTy);
+    auto order = linAttr.getOrder();
+    if (order.empty() || order[0] >= axisInfo->getRank())
+      return 1;
+
+    unsigned pointeeBitWidth = triton::getPointeeBitWidth(tensorTy);
+    if (pointeeBitWidth == 0)
+      return 1;
+    unsigned elemBytes = std::max<unsigned>(pointeeBitWidth / 8, 1);
+    unsigned maxMultipleBytes = axisInfo->getDivisibility(order[0]);
+    unsigned maxMultiple = std::max<unsigned>(maxMultipleBytes / elemBytes, 1);
+
+    return std::min<unsigned>(128 / pointeeBitWidth, maxMultiple);
+  }
+#endif
+
   unsigned getMaskAlignment(Value mask) const {
     return axisAnalysisPass.getMaskAlignment(mask);
   }
@@ -258,6 +305,23 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
     } else {
       vec = getVectorSize(ptr);
     }
+#ifdef __MCTLE__
+    auto ptrTensorTy = dyn_cast<RankedTensorType>(ptr.getType());
+    auto ptrElemTy = ptrTensorTy
+                         ? dyn_cast<PointerType>(ptrTensorTy.getElementType())
+                         : PointerType();
+    bool isSharedTensorPtr =
+        ptrElemTy && isSharedFamilyAddressSpace(ptrElemTy.getAddressSpace());
+    if (!llMask && isSharedTensorPtr) {
+      // For TLE local/shared pointer chains, AxisInfo contiguity can be
+      // conservative on packed contiguous lanes. The layout hint may recover
+      // the lane grouping, but it is only legal up to the vector width whose
+      // first element alignment is proven by AxisInfo divisibility.
+      // unsigned hint = ttg::inferTilePointerLayoutVectorHint(ptr);
+      unsigned alignmentBound = getMaxVectorSizeByAlignment(ptr);
+      vec = std::max(vec, alignmentBound);
+    }
+#endif
     unsigned numElems = getTotalElemsPerThread(ptr.getType());
     unsigned constRepeatPerThread = getThreadConstRepeatTimes(ptr);
     if (llMask) {
@@ -272,6 +336,9 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
     // Get the LLVM values for pointers
     auto ptrElems = unpackLLElements(loc, llPtr, rewriter);
     assert(ptrElems.size() == numElems);
+#ifdef __MCTLE__
+    const bool isSharedPtr = isSharedPointerValue(ptrElems);
+#endif
 
     // Get the LLVM values for mask
     SmallVector<Value> maskElems;
@@ -358,6 +425,30 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
       assert(wordNElems * nWords * numVecs == numElems);
       Value pred = mask ? maskElems[vecStart] : b.int_val(1, 1);
       Value zeroVal = b.bitcast(b.int_val(valueElemNBits, 0), valueElemTy);
+#ifdef __MCTLE__
+      if (isSharedPtr) {
+        Value addrVal = ptrElems[vecStart];
+        Type retTy = vec > 1 ? vec_ty(valueElemTy, vec) : valueElemTy;
+        Value lds_values =
+            targetInfo.loadDShared(rewriter, loc, addrVal, std::nullopt, retTy,
+                                   /*pred=*/pred);
+
+        if (vec == 1) {
+          for (int i = 0; i < constRepeatPerThread; i++) {
+            loadedVals.push_back(lds_values);
+          }
+        } else {
+          for (size_t elemIndex = 0; elemIndex < vec; elemIndex++) {
+            Value curr = b.extract_element(valueElemTy, lds_values,
+                                           b.i32_val(elemIndex));
+            for (int i = 0; i < constRepeatPerThread; i++) {
+              loadedVals.push_back(curr);
+            }
+          }
+        }
+        continue;
+      }
+#endif
       if (!disableOptFlag && !op.getIsVolatile()) {
         if (!disableLdgPred && isOtherValid &&
             (totalWidth == 128 || totalWidth == 64 || totalWidth == 32 ||
@@ -534,6 +625,9 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
 
     auto ptrElems = unpackLLElements(loc, llPtr, rewriter);
     auto valueElems = unpackLLElements(loc, llValue, rewriter);
+#ifdef __MCTLE__
+    const bool isSharedPtr = isSharedPointerValue(ptrElems);
+#endif
     assert(ptrElems.size() == valueElems.size());
 
     if (valueElemTy.isFloat(8)) {
@@ -603,6 +697,26 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
 
       // TODO(Superjomn) Add cache policy fields to StoreOp.
       // TODO(Superjomn) Deal with cache policy here.
+
+#ifdef __MCTLE__
+      if (isSharedPtr) {
+        Value pred = threadPred;
+        if (llMask) {
+          auto mask = maskElems[vecStart];
+          pred = maybeAnd(rewriter, loc, pred, mask);
+        }
+        Type retTy = vec_ty(valueElemTy, vec);
+        Value vec_values = b.undef(retTy);
+        for (size_t elemIndex = 0; elemIndex < vec; elemIndex++) {
+          Value elem = valueElems[vecStart + elemIndex];
+          vec_values =
+              b.insert_element(retTy, vec_values, elem, b.i32_val(elemIndex));
+        }
+        targetInfo.storeDShared(rewriter, loc, ptrElems[vecStart], std::nullopt,
+                                vec_values, pred);
+        continue;
+      }
+#endif
 
       Type valArgTy = IntegerType::get(ctx, width);
       auto wordTy = vec_ty(valueElemTy, wordNElems);

--- a/third_party/metax/plugin/mctle/dialect/include/Transforms/Passes.td
+++ b/third_party/metax/plugin/mctle/dialect/include/Transforms/Passes.td
@@ -122,4 +122,10 @@ def TritonTleLowerInsertTile
                            "mlir::triton::gpu::TritonGPUDialect"];
 }
 
+def TritonTleRejectDotOp
+    : Pass<"triton-tle-reject-dot-op", "mlir::ModuleOp"> {
+  let summary = "reject tt.dot in TLE kernels";
+  let dependentDialects = ["mlir::triton::TritonDialect"];
+}
+
 #endif // TRITON_TLE_PASSES

--- a/third_party/metax/plugin/mctle/triton_mctle.cc
+++ b/third_party/metax/plugin/mctle/triton_mctle.cc
@@ -131,6 +131,7 @@ void init_triton_mctle_ir(py::module &&m) {
 }
 
 void init_triton_mctle_passes(py::module &&m) {
+  ADD_PASS_WRAPPER_0("add_reject_dot_op", tle::createTritonTleRejectDotOp);
   ADD_PASS_WRAPPER_0("add_early_assign_memory_space",
                      tle::createTritonTleEarlyAssignMemorySpace);
   ADD_PASS_WRAPPER_0("add_select_encodings",

--- a/third_party/metax/spec/triton/language/semantic.py
+++ b/third_party/metax/spec/triton/language/semantic.py
@@ -1078,7 +1078,8 @@ class TritonSemantic(Generic[TensorTy]):
         return ret
 
     def load(self, ptr: TensorTy, mask: Optional[TensorTy], other: Optional[TensorTy], boundary_check: Tuple,
-             padding_option: str, cache_modifier: str, eviction_policy: str, is_volatile: bool) -> TensorTy:
+             padding_option: str, cache_modifier: str, eviction_policy: str, is_volatile: bool,
+             smem_hints: str = None) -> TensorTy:
         # Cache, eviction and padding options
         cache = self._str_to_load_cache_modifier(cache_modifier)
         eviction = self._str_to_eviction_policy(eviction_policy)


### PR DESCRIPTION
## METAX backend support for TLE GPU local pointers

This patch adds METAX/MACA support for TLE local pointers. TLE kernels can now create pointers to shared-memory allocations and access the referenced data through standard Triton load/store operations.

## Supported APIs

* `tle.gpu.alloc(..., scope=tle.gpu.smem)`
  * Allocates a TLE shared-memory buffer.

* `tle.gpu.local_ptr(buffer, indices=None)`
  * Creates local pointers to a TLE shared-memory allocation.
  * Supports full-buffer views when `indices` is omitted.
  * Supports indexed 1-D and multi-dimensional views.
  * Supports scalar, tensor, static, and dynamic indices.

* `tl.load(local_ptr, mask=None, other=None)`
  * Loads data through TLE local pointers.
  * Supports masked and unmasked loads.

* `tl.store(local_ptr, value, mask=None)`
  * Stores data through TLE local pointers.
  * Supports masked and unmasked stores.

These APIs can be used in elementwise kernels, loops, and conditional control-flow regions. Local pointers can also be used together with `tle.gpu.copy` to stage global-memory data in TLE shared memory before accessing it through `tl.load` and `tl.store`.

## Lowering path

Key points for the METAX implementation:

* Local-pointer loads and stores are lowered to METAX shared-memory load/store instructions.
* The lowering detects the address space of the generated LLVM pointers and selects the shared-memory path when necessary.
* Vectorized shared-memory loads and stores are supported when pointer alignment permits.
* Shared-memory side effects are modeled for Triton atomic operations.
* The TLE local-pointer barrier insertion pass remains enabled to preserve the required memory ordering.

## Scope and limitations

This PR enables TLE local pointers for load/store-based kernels.

TLE kernels containing a `tt.dot`/`tl.dot` operation are not supported on the METAX backend yet. Such kernels are rejected during compilation. Dot-based local-pointer tests are therefore excluded from the METAX test suite for now.