### PR TITLE
[PIPELINE] Add loop-carried TLE pipe cursors

### DIFF
--- a/python/test/tle/integration/test_tle_pipe_cursor.py
+++ b/python/test/tle/integration/test_tle_pipe_cursor.py
@@ -1,0 +1,60 @@
+# flagtree tle
+"""Code-generation tests for loop-carried typed-pipe cursors."""
+
+import pytest
+import torch
+import triton
+import triton.experimental.tle.language as tle
+import triton.language as tl
+from triton._C.libtriton import ir
+from triton.backends.compiler import GPUTarget
+from triton.compiler.compiler import ASTSource, make_backend
+
+_HOPPER_TARGET = GPUTarget("cuda", 90, 32)
+
+
+@triton.jit
+def _pipe_cursor_loop_kernel(out_ptr, start_iter, BLOCK: tl.constexpr):
+    offsets = tl.arange(0, BLOCK)
+    smem = tle.gpu.alloc([4, BLOCK], dtype=tl.int32, layout=None, scope=tle.gpu.smem, nv_mma_shared_layout=False)
+    pipe = tle.pipe(capacity=4, scope="cta", name="cursor_test", data=smem)
+    writer = pipe.writer()
+    cursor = writer.cursor(start_iter)
+    for iteration in range(0, 8):
+        slot = writer.acquire(cursor)
+        ptrs = tle.gpu.local_ptr(slot.data, (offsets, ))
+        tl.store(ptrs, offsets + iteration)
+        writer.commit(cursor)
+        cursor = cursor.advance()
+    tl.store(out_ptr, cursor.stage)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA GPU")
+def test_pipe_cursor_is_carried_as_stage_and_phase_without_loop_division():
+    backend = make_backend(_HOPPER_TARGET)
+    options = backend.parse_options({"num_warps": 4})
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    source = ASTSource(
+        fn=_pipe_cursor_loop_kernel,
+        signature={"out_ptr": "*i32", "start_iter": "i32"},
+        constexprs={"BLOCK": 64},
+    )
+    ttir = str(
+        source.make_ir(
+            _HOPPER_TARGET,
+            options,
+            backend.get_codegen_implementation(options),
+            backend.get_module_map(),
+            context,
+        ))
+
+    loop_line = next(line for line in ttir.splitlines() if "scf.for" in line)
+    loop_body = ttir[ttir.index(loop_line):ttir.index("scf.yield", ttir.index(loop_line))]
+    assert "iter_args" in loop_line
+    assert "i32, i1" in loop_line
+    assert "tle.pipe.writer_acquire" in ttir
+    assert "tle.pipe.writer_commit" in ttir
+    assert "arith.remsi" not in loop_body
+    assert "arith.divsi" not in loop_body

--- a/python/test/tle/unit/test_tle.py
+++ b/python/test/tle/unit/test_tle.py
@@ -561,6 +561,37 @@ class TestPipeFrontend:
         assert semantic.builder.pipe_ops[3] == ("reader_wait", ["base"], "stage_0", "pred_False", 4, "cta", "a", ["a"],
                                                 "", ["a"])
 
+    def test_pipe_cursor_is_typed_and_consumed_without_recomputing_position(self):
+        a, semantic = self._make_buffer([4, 16])
+        pipe = tle.pipe(capacity=4, scope="cta", name="a", a=a, _semantic=semantic)
+        writer = pipe.writer(_semantic=semantic)
+        reader = pipe.reader(_semantic=semantic)
+
+        cursor = reader.cursor(5, _semantic=semantic)
+        writer.acquire(cursor, _semantic=semantic)
+        writer.commit(cursor, _semantic=semantic)
+        reader.wait(cursor, _semantic=semantic)
+        reader.release(cursor, _semantic=semantic)
+
+        assert isinstance(cursor, tle.pipe_cursor)
+        assert cursor.type.capacity == 4
+        assert cursor.stage.dtype == tl.int32
+        assert cursor.phase.dtype == tl.int1
+        assert semantic.builder.pipe_ops[0][2:4] == ("stage_1", "pred_True")
+        assert semantic.builder.pipe_ops[2][2:4] == ("stage_1", "pred_True")
+
+    def test_pipe_rejects_cursor_from_a_different_capacity(self):
+        a, semantic = self._make_buffer([4, 16])
+        pipe = tle.pipe(capacity=4, a=a, _semantic=semantic)
+        other_cursor = tle.pipe_cursor(
+            3,
+            TestBufferedTensor._FakeTensor("stage_0", tl.int32),
+            TestBufferedTensor._FakeTensor("pred_False", tl.int1),
+        )
+
+        with pytest.raises(ValueError, match="does not match"):
+            pipe.reader(_semantic=semantic).wait(other_cursor, _semantic=semantic)
+
     def test_pipe_one_shot_keeps_frontend_contract(self):
         a, semantic = self._make_buffer([1, 16])
         pipe = tle.pipe(capacity=1, readers=("left", "right"), one_shot=True, a=a, _semantic=semantic)
@@ -589,6 +620,7 @@ class TestIntegration:
         assert hasattr(tle, 'gpu')
         assert hasattr(tle, 'cumsum')
         assert hasattr(tle, 'pipe')
+        assert hasattr(tle, 'pipe_cursor')
         assert hasattr(tle, 'pipe_reader')
         assert hasattr(tle, 'pipe_writer')
         assert hasattr(tle.gpu, 'alloc')

--- a/python/triton/experimental/tle/language/__init__.py
+++ b/python/triton/experimental/tle/language/__init__.py
@@ -29,6 +29,7 @@ from .core import (
 )
 from .pipe import (
     pipe,
+    pipe_cursor,
     pipe_reader,
     pipe_slot,
     pipe_value,
@@ -90,6 +91,7 @@ __all__ = [
     "insert_tile",
     "MeshConfig",
     "pipe",
+    "pipe_cursor",
     "pipe_reader",
     "pipe_slot",
     "pipe_value",

--- a/python/triton/experimental/tle/language/gpu/types.py
+++ b/python/triton/experimental/tle/language/gpu/types.py
@@ -674,6 +674,61 @@ class pipe_wait_result(tl.base_value):
         return pipe_wait_result_type(self.slot.type)
 
 
+class pipe_cursor_type(tl.base_type):
+
+    def __init__(self, capacity: int):
+        self.capacity = capacity
+
+    def _unflatten_ir(self, handles: List[ir.value], cursor: int) -> Tuple["pipe_cursor", int]:
+        stage, cursor = tl.int32._unflatten_ir(handles, cursor)
+        phase, cursor = tl.int1._unflatten_ir(handles, cursor)
+        return pipe_cursor(self.capacity, stage, phase), cursor
+
+    def _flatten_ir_types(self, builder: ir.builder, out: List[ir.type]) -> None:
+        tl.int32._flatten_ir_types(builder, out)
+        tl.int1._flatten_ir_types(builder, out)
+
+    def mangle(self) -> str:
+        return f"pipe_cursor_{self.capacity}"
+
+    def __eq__(self, other) -> bool:
+        return type(self) is type(other) and self.capacity == other.capacity
+
+    def __str__(self) -> str:
+        return f"pipe_cursor<capacity={self.capacity}>"
+
+
+class pipe_cursor(tl.base_value):
+    """Loop-carried position in a cyclic pipe.
+
+    The cursor keeps the physical stage and generation phase as first-class IR
+    values so a loop can advance them without recomputing division and modulo
+    from an absolute iteration at every endpoint operation.
+    """
+
+    def __init__(self, capacity: int, stage: tl.tensor, phase: tl.tensor):
+        super().__init__()
+        self.capacity = capacity
+        self.stage = stage
+        self.phase = phase
+
+    def _flatten_ir(self, handles) -> None:
+        self.stage._flatten_ir(handles)
+        self.phase._flatten_ir(handles)
+
+    @property
+    def type(self):
+        return pipe_cursor_type(self.capacity)
+
+    @tl.builtin
+    def advance(self, _semantic=None):
+        next_stage = self.stage.__add__(1, _semantic=_semantic)
+        wrapped = next_stage.__eq__(self.capacity, _semantic=_semantic)
+        stage = tl.where(wrapped, 0, next_stage, _semantic=_semantic)
+        phase = self.phase.__xor__(wrapped, _semantic=_semantic)
+        return pipe_cursor(self.capacity, stage, phase)
+
+
 def _unwrap_pipe_constexpr(value):
     if isinstance(value, tl.constexpr):
         value = value.value
@@ -807,6 +862,10 @@ class pipe_value(tl.base_value):
 
     @tl.builtin
     def _stage_phase(self, iter, _semantic=None):
+        if isinstance(iter, pipe_cursor):
+            if iter.capacity != self.capacity:
+                raise ValueError(f"pipe cursor capacity {iter.capacity} does not match pipe capacity {self.capacity}")
+            return iter.stage, iter.phase
         iter = tl._unwrap_if_constexpr(iter)
         if isinstance(iter, int):
             stage = iter % self.capacity
@@ -818,6 +877,15 @@ class pipe_value(tl.base_value):
         phase = phase.__mod__(2, _semantic=_semantic)
         phase = phase.__ne__(0, _semantic=_semantic)
         return _semantic.to_tensor(stage), _semantic.to_tensor(phase)
+
+    @tl.builtin
+    def cursor(self, iter=0, _semantic=None):
+        stage, phase = self._stage_phase(iter, _semantic=_semantic)
+        if stage.dtype != tl.int32:
+            stage = stage.to(tl.int32, _semantic=_semantic)
+        if phase.dtype != tl.int1:
+            phase = phase.to(tl.int1, _semantic=_semantic)
+        return pipe_cursor(self.capacity, stage, phase)
 
     @tl.builtin
     def writer(self, _semantic=None):
@@ -902,6 +970,10 @@ class _pipe_endpoint(tl.base_value):
     @property
     def type(self):
         return self.type_cls(self.pipe.type, self.reader_name, self.field_names)
+
+    @tl.builtin
+    def cursor(self, iter=0, _semantic=None):
+        return self.pipe.cursor(iter, _semantic=_semantic)
 
 
 class pipe_writer(_pipe_endpoint):

--- a/python/triton/experimental/tle/language/pipe.py
+++ b/python/triton/experimental/tle/language/pipe.py
@@ -134,6 +134,7 @@ def pipe(
 
 
 pipe_slot = gpu_types.pipe_slot
+pipe_cursor = gpu_types.pipe_cursor
 pipe_value = gpu_types.pipe_value
 pipe_reader = gpu_types.pipe_reader
 pipe_writer = gpu_types.pipe_writer


### PR DESCRIPTION
<!--
Local source binding.
Source: codex/tle-pipe-cursor @ 805d3863ad04f3cd989040e59c9a54860c610137
Base: flagos-ai/FlagTree main @ df824d72097a31b4dca479ddfb7f480a470b7d66
Suggested title: [PIPELINE] Add loop-carried TLE pipe cursors
-->

## Summary

Add an opt-in, first-class `pipe_cursor<capacity>` that carries cyclic pipe
`stage:i32` and `phase:i1` as loop state.

The existing endpoint API accepts an absolute iteration. For dynamic loop
iterations, the frontend immediately expands every position into
`iter % capacity` and `(iter // capacity) % 2`; pipe IR then retains only the
computed stage and phase operands. This loses the fact that a sequential loop
can advance a ring cursor with one increment, one wrap test, and a phase toggle.

With this change, kernels may initialize `cursor = endpoint.cursor(iter)` and
advance it with `cursor = cursor.advance()`. Existing absolute-iteration calls
remain source-compatible and unchanged.

In a matched H20 FP8 einsum experiment, the cursor form removed `214,840`
dynamic instructions (`8.14%`) with identical launch resources and improved
five-process CUDA Graph latency from `0.0373608 ms` to `0.0372621 ms`
(`0.26%`). The benchmark required a companion kernel variant that opts into
the new API; this PR does not automatically rewrite existing kernels.

## Review map

1. Review `pipe_cursor_type`: it flattens to exactly `i32 stage` and `i1 phase`,
   and includes capacity in its type identity/mangling.
2. Review `pipe_cursor.advance()`: increment stage, wrap to zero at capacity,
   and toggle phase only on wrap.
3. Review `pipe_value.cursor()` and `_stage_phase()`: cursor consumers bypass
   absolute-iteration recomputation, while capacity mismatches fail before IR
   construction.
4. Review endpoint forwarding and public exports in `language/pipe.py` and
   `language/__init__.py`.
5. Review the TTIR regression: the loop carries `i32, i1` iter_args and its body
   contains pipe lifecycle operations but no `arith.remsi` or `arith.divsi`.

## Supported contract

| Surface | This PR |
|---|---|
| Existing API | `wait(iter)`, `release(iter)`, `acquire(iter)`, and `commit(iter)` remain valid |
| New API | `pipe.cursor(iter)`, `endpoint.cursor(iter)`, and `pipe_cursor.advance()` |
| Cursor state | Physical stage (`i32`) plus generation phase (`i1`) |
| Safety | A cursor from a different pipe capacity is rejected |
| Activation | Opt-in; a kernel must carry and pass the cursor explicitly |
| Lowering | Existing lifecycle operations and NVWS lowering remain unchanged |
| Random access | Preserved through the existing absolute-iteration path |
| Fallback/compatibility | Existing absolute-iteration endpoint calls remain the default path |

## Why this belongs at the language/type layer

The current frontend erases sequential cursor semantics before pipe lowering:

```text
absolute iteration
      -> frontend modulo/division
      -> pipe op(stage, phase)
      -> NVWS lowering forwards scalar operands
```

Local memoization and power-of-two strength reduction were tested separately;
both produced byte-identical final cubins because existing compiler passes
already handle those local expressions. The missing information is the
cross-iteration state transition itself.

The cursor makes that state explicit without changing the existing IR op
contract or removing random access:

```text
cursor(stage, phase)
      -> scf.for iter_args(stage, phase)
      -> lifecycle op consumes state directly
      -> cursor.advance()
```

## Validation

Current Draft source identity:
`805d3863ad04f3cd989040e59c9a54860c610137` based on
`df824d72097a31b4dca479ddfb7f480a470b7d66`.

The H20 correctness, timing, and NCU gates below ran on pre-rebase commit
`c81241609ada46c75b87e54bdeae24e2eae7b799`. Before publication, the single
feature commit was replayed onto the current base and its stable patch ID
remained unchanged; the two intervening upstream commits do not touch this
PR's files. These results are patch-identical pre-rebase evidence, not an
exact-current-commit H20 rerun.

| Gate | Location | Result | What it proves |
|---|---|---|---|
| Cursor/frontend TLE unit tests | NVIDIA H20 | historical PASS — `43 passed` | Cursor typing, endpoint consumption, capacity validation, and public exports |
| Cursor TTIR integration test | NVIDIA H20 | historical PASS — `1 passed` | Loop-carried `i32, i1` state and no loop-body `remsi/divsi` |
| Companion FP8 kernel output audit | NVIDIA H20 | historical PASS — `5/5` cursor outputs bitwise equal to matched Gluon references | Cursor lifecycle preserves the tested kernel result |
| Root NCU comparison | NVIDIA H20 | historical PASS | Dynamic instruction reduction with identical launch/resource metrics |
| Pre-commit hooks | Local, current Draft head | PASS | ruff, yapf, mypy, syntax, whitespace, and repository checks passed |

### Performance evidence

**Baseline:** the same companion typed-pipe kernel using the existing absolute
iteration endpoint API.

**Evidence boundary:** the patch-identical pre-rebase cursor implementation
plus a companion operator-level kernel migration on one H20 shape/config. This
is not an exact-current-commit rerun and is not evidence that unchanged kernels
improve automatically.

**Setup:** NVIDIA H20, `pro_b1=(b=1,h=16,r=7168,d=1024)`,
`4 warps / 8 stages / tile_order=0`, five fresh processes, 30 warmups and 200
CUDA Graph samples per process. Both TLE variants used the same FlagGems typed
pipe kernel; the candidate changed only the pipe position from absolute
iteration to the new cursor API. The table reports the median of per-process
average latency.

| Scenario | Absolute iteration | Cursor | Change |
|---|---:|---:|---:|
| CUDA Graph latency | `0.0373608 ms` | `0.0372621 ms` | `0.99736x` (`0.26%` lower) |
| Dynamic instructions | `2,639,002` | `2,424,162` | `-214,840` (`-8.14%`) |

NCU `2025.4.1` was run under authorized container root because the H20 driver
requires profiling privilege. Correctness, normal tests, and independent
timing ran as the mapped non-root user. The two profiled outputs were bitwise
equal.

| NCU launch/resource metric | Absolute iteration | Cursor |
|---|---:|---:|
| Grid / block | 78 / 256 | 78 / 256 |
| Registers per thread | 255 | 255 |
| Dynamic shared memory | 141,444 B | 141,444 B |
| Register spills | 0 | 0 |
| Waves per SM | 1 | 1 |
| TMA pipe activity | 0.62% | 0.62% |

The NCU replay duration is diagnostic only and is not used as the latency
claim. The `0.26%` latency result comes from the separate five-process CUDA
Graph gate.

<details>
<summary><strong>Five-process CUDA Graph averages</strong> — absolute values used for the median</summary>

| Replica | Absolute iteration (ms) | Cursor (ms) |
|---:|---:|---:|
| 0 | 0.03731088 | 0.03711344 |
| 1 | 0.03723168 | 0.03785536 |
| 2 | 0.03749408 | 0.03694288 |
| 3 | 0.04047392 | 0.03726208 |
| 4 | 0.03736080 | 0.04052672 |

</details>

## Files changed

- `python/triton/experimental/tle/language/gpu/types.py`
  — cursor type/value, initialization, advance, and endpoint consumption.
- `python/triton/experimental/tle/language/pipe.py`
  — public cursor alias.
- `python/triton/experimental/tle/language/__init__.py`
  — top-level export.
- `python/test/tle/unit/test_tle.py`
  — frontend/type/capacity tests.
- `python/test/tle/integration/test_tle_pipe_cursor.py`
  — TTIR loop-state and arithmetic regression.

## Known limits

- This is an opt-in language/API change, not an automatic compiler induction
  rewrite. Existing kernels keep their current code generation until migrated.
- Performance and NCU evidence are bounded to one companion FP8 kernel,
  shape, and configuration. The dynamic-instruction result is strong mechanism
  evidence; the observed `0.26%` latency result must not be generalized to all
  TLE kernels.
- Multi-reader, one-shot, close, and distributed pipe performance were not
  benchmarked. Existing absolute-iteration behavior remains the compatibility
  path for those users.
