### PR TITLE
[AMD] Guard degenerate axis info in atomic RMW lowering

### DIFF
--- a/test/Conversion/amd/tle_local_pointers_to_llvm.mlir
+++ b/test/Conversion/amd/tle_local_pointers_to_llvm.mlir
@@ -68,3 +68,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1201", "ttg.threads-per-warp" = 32 : i32} {
+  // tle.local_pointers has no axis-info visitor, so its result carries a
+  // degenerate rank-0 entry. The atomic lowering must tolerate that instead of
+  // indexing the contiguity vector, which is only a hint for intra-wave reduce.
+  // CHECK-LABEL: llvm.func @local_pointers_atomic_rmw
+  // CHECK: llvm.getelementptr {{.*}}!llvm.ptr<3>
+  // CHECK: llvm.atomicrmw fadd {{.*}} syncscope("workgroup") monotonic : !llvm.ptr<3>, f32
+  // CHECK-NOT: tle.local_pointers
+  tt.func public @local_pointers_atomic_rmw(%idx: tensor<32xi32, #blocked>, %val: tensor<32xf32, #blocked>) {
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<32xf32, #shared, #smem, mutable>
+    %ptrs = "tle.local_pointers"(%buf, %idx) : (!ttg.memdesc<32xf32, #shared, #smem, mutable>, tensor<32xi32, #blocked>) -> tensor<32x!tt.ptr<f32, 3>, #blocked>
+    %res = tt.atomic_rmw fadd, relaxed, cta, %ptrs, %val : (tensor<32x!tt.ptr<f32, 3>, #blocked>, tensor<32xf32, #blocked>) -> tensor<32xf32, #blocked>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1887,10 +1887,18 @@ struct AtomicRMWOpConversion
           !enableIntraWaveReduce;
       numElems = tensorTy.getNumElements();
 
+      // Ops without an axis-info visitor, such as tle.local_pointers, yield a
+      // rank-0 entry that cannot be indexed. The contiguity only refines the
+      // intra-wave reduce decision, so leave that disabled instead.
       auto threadOrder = getThreadOrder(tensorTy);
-      unsigned contigWithinLanes =
-          axisAnalysisPass.getAxisInfo(ptr)->getContiguity(threadOrder.front());
-      enableIntraWaveReduce &= contigWithinLanes == 1;
+      auto *ptrAxisInfo = axisAnalysisPass.getAxisInfo(ptr);
+      if (!ptrAxisInfo || ptrAxisInfo->getRank() == 0 || threadOrder.empty()) {
+        enableIntraWaveReduce = false;
+      } else {
+        unsigned contigWithinLanes =
+            ptrAxisInfo->getContiguity(threadOrder.front());
+        enableIntraWaveReduce &= contigWithinLanes == 1;
+      }
     }
 
     auto vecTy = vec_ty(valueElemTy, vec);


### PR DESCRIPTION
## Problem

Any tensor-indexed atomic on a shared-memory pointer crashes the compiler on the AMD backend with a segfault, e.g.

```python
buf = tle.gpu.alloc([BLOCK], dtype=tl.float32, scope=tle.gpu.smem, ...)
ptrs = tle.gpu.local_ptr(buf, (idx, ))
tl.atomic_add(ptrs, val)   # Segmentation fault during ConvertTritonAMDGPUToLLVM
```

## Root cause
 mentioned in #972 

`AtomicRMWOpConversion` dereferences the axis-info entry of its pointer operand and indexes the contiguity vector without checking either:

```cpp
unsigned contigWithinLanes =
    axisAnalysisPass.getAxisInfo(ptr)->getContiguity(threadOrder.front());
```

`tle.local_pointers` has no `AxisInfoVisitor`, so its result carries a degenerate rank-0 entry and the indexing walks off an empty vector. The value is only used to refine `enableIntraWaveReduce`, which is restricted to CDNA3/CDNA4, so on RDNA the crash happens while computing something that is never used.


## Fix

Check the entry before using it and fall back to disabling intra-wave reduce
when the contiguity is unavailable.

## Validation

Compiler behaviour, same input IR, only this patch differing:

| | before | after |
| --- | --- | --- |
| `tle_local_pointers_to_llvm.mlir` (new case) | `Segmentation fault` (exit 139) | `PASS` |

- Added lit coverage for `tt.atomic_rmw` on `tle.local_pointers`, checking it  lowers to `llvm.atomicrmw fadd ... : !llvm.ptr<3>`.
- `Conversion/amd`: 33/35 pass; the two failures (`async_ops_to_llvm_gfx1250`,  `cluster_load`) are pre-existing CHECK mismatches unrelated to this path.
- No CDNA regression: full lowering output of `tritongpu_to_llvm.mlir` for `arch=gfx942` and `arch=gfx950` is byte-identical before and after (matching md5), so the intra-wave reduce decision is untouched wherever axis  info is well-formed.
- `test_core.py -k atomic` on gfx1201: 832 passed, 132 skipped, 0 failed.
- Runtime check on gfx1201: 128 threads contending 8 LDS slots each end up at exactly 16, lowered to `ds_add_f32`, so the atomics are real and not lost  updates.
