### PR TITLE
[CI] Add cleanup step to ppu3.6 workflows before build

### DIFF
--- a/.github/workflows/ppu3.6-build-and-test.yml
+++ b/.github/workflows/ppu3.6-build-and-test.yml
@@ -57,6 +57,10 @@ jobs:
         with:
           backend: ppu
 
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
+
       - name: Build FlagTree
         if: steps.check_backend.outputs.should_skip != 'true'
         shell: bash

--- a/.github/workflows/ppu3.6-core-build-and-test.yml
+++ b/.github/workflows/ppu3.6-core-build-and-test.yml
@@ -57,6 +57,10 @@ jobs:
         with:
           backend: ppu
 
+      - name: Cleanup FlagTree Environment
+        if: steps.check_backend.outputs.should_skip != 'true'
+        uses: flagos-ai/FlagTree/.github/actions/cleanup-flagtree-env@main
+
       - name: Build FlagTree
         if: steps.check_backend.outputs.should_skip != 'true'
         shell: bash


### PR DESCRIPTION
Add FlagTree environment cleanup action to both ppu3.6-build-and-test and ppu3.6-core-build-and-test workflows to ensure a clean environment before building.

<!-- PR Title Format:
[TLE][BUILD][TEST][CI/CD][DOC][PROTON][BACKEND][FLIR] Brief description
[LANGUAGE][AUTOTUNER][LAYOUT][PIPELINE][WarpSpecialization] Brief description
Do not set the following title tags: [FEATURE][BUG][FixBug][Refine] ...
-->
