### PR TITLE
[Metax][MCTLE] Add NVMMAShared encoding builder binding

### DIFF
--- a/third_party/metax/plugin/mctle/triton_mctle.cc
+++ b/third_party/metax/plugin/mctle/triton_mctle.cc
@@ -95,6 +95,37 @@ void init_triton_mctle_ir(py::module &&m) {
              return mlir::cast<Attribute>(ttg::SwizzledSharedEncodingAttr::get(
                  context, vectorSize, perPhase, maxPhase, order, CTALayout));
            })
+      .def("make_nv_mma_shared_encoding_attr",
+           [](TritonOpBuilder &self, std::vector<int64_t> shape,
+              std::vector<unsigned> order, Type &elemType,
+              std::vector<unsigned> CTAsPerCGA,
+              std::vector<unsigned> CTASplitNum,
+              std::vector<unsigned> CTAOrder, bool fp4Padded,
+              bool swizzled) {
+             assert(shape.size() == order.size());
+             assert(order.size() == CTAsPerCGA.size());
+             assert(CTAsPerCGA.size() == CTASplitNum.size());
+             assert(CTASplitNum.size() == CTAOrder.size());
+
+             auto context = self.getBuilder().getContext();
+             auto CTALayout = ttg::CTAEncodingAttr::fromSplitParams(
+                 context, CTAsPerCGA, CTASplitNum, CTAOrder);
+
+             if (swizzled) {
+               return mlir::cast<Attribute>(
+                   ttg::NVMMASharedEncodingAttr::get(
+                       context, shape, order, CTALayout, elemType,
+                       fp4Padded));
+             }
+
+             return mlir::cast<Attribute>(
+                 ttg::NVMMASharedEncodingAttr::get(
+                     context,
+                     /*swizzlingByteWidth=*/0,
+                     /*transposed=*/order[0] == 0,
+                     elemType.getIntOrFloatBitWidth(),
+                     fp4Padded, CTALayout));
+           })
       .def("create_local_alloc",
            [](TritonOpBuilder &self, std::vector<int64_t> shape,
               Type &elementType, Attribute &encoding) -> mlir::Value {


### PR DESCRIPTION
## Summary

MetaX MCTLE already provides the shared-memory allocation and local-pointer
builder APIs required by TLE, including `create_local_alloc` and
`create_local_pointers`.

However, it is missing the
`make_nv_mma_shared_encoding_attr` builder binding required by TLE kernels
using `NVMMASharedEncodingAttr`.

This change exposes the existing TritonGPU
`NVMMASharedEncodingAttr` construction through the MCTLE builder, aligning
MCTLE with the corresponding generic TLE builder API.

This change only adds the missing builder binding. It does not introduce a new
IR type, compiler pass, or MMA lowering implementation.

## Testing

Tested on MetaX C550 with:

- PyTorch: `2.8.0+metax3.7.2.0`
- Triton: `3.6.0`
- Target: `GPUTarget(backend='maca', arch=80, warp_size=64)`

A minimal TLE kernel was used to exercise the following path:

```text
NVMMAShared alloc
    -> local_ptr
    -> shared store/load
    -> global output
```

### Without this binding

The MCTLE builder contains:

```text
make_nv_mma_shared_encoding_attr : False
create_local_alloc               : True
create_local_pointers            : True
```

The same kernel fails during TLE compilation at `tle.gpu.alloc` with:

```text
AttributeError:
'triton._C.libtriton.ir.builder' object has no attribute
'make_nv_mma_shared_encoding_attr'
```

### With this binding

The MCTLE builder contains:

```text
make_nv_mma_shared_encoding_attr : True
create_local_alloc               : True
create_local_pointers            : True
```

The same kernel compiles and runs successfully on MetaX C550:

```text
max_abs_diff : 0.0
equal        : True

NVMMAShared alloc + local_ptr + store/load: PASS
```