### PR TITLE
[FIX][TLE]: fix dsa buffer turning into tensor when crossing for scopes

### DIFF
--- a/python/test/tle/test_bind_buffer.py
+++ b/python/test/tle/test_bind_buffer.py
@@ -4,7 +4,7 @@ import triton.language as tl
 
 from triton.compiler.compiler import ASTSource
 from triton.compiler.code_generator import ast_to_ttir
-from triton._C.libtriton import ir, tle as tle_ir
+from triton._C.libtriton import ir, tle as tle_ir, buffer_ir
 from triton._C.libtriton.ascend import ir as ascend_ir
 
 
@@ -23,19 +23,25 @@ def compile_kernel(kernel, signature, constants):
     context = ir.context()
     ir.load_dialects(context)
     tle_ir.load_dialects(context)
+    buffer_ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     module = ast_to_ttir(kernel, src, context, Options(), {}, {})
     return str(module)
 
 
 @triton.jit
-def bind_buffer():
+def bind_buffer(XBLOCK: tl.constexpr, N: tl.constexpr):
+    # buffer is allocated outside the for loop and converted to a tensor inside the loop: entering the loop body triggers scope cloning,
+    # After cloning, the buffer must remain a buffer and not a tensor (buffer_type._unflatten_ir)
     # tle.dsa.ascend.UB is triton.language.extra.extension.cann.core.ascend_address_space.UB
-    buffer1 = tle.dsa.alloc(shape=[32, 32], dtype=tl.float32, mem_addr_space=tle.dsa.ascend.UB)
-    tle.dsa.to_tensor(buffer1, writable=True)
+    buffer1 = tle.dsa.alloc(shape=[XBLOCK], dtype=tl.float32, mem_addr_space=tle.dsa.ascend.UB)
+    acc = tl.zeros([XBLOCK], dtype=tl.float32)
+    for i in tl.range(0, N):
+        acc = acc + tle.dsa.to_tensor(buffer1, writable=True)
+    return acc
 
 
 if __name__ == "__main__":
     print("=" * 60)
-    mlir = compile_kernel(bind_buffer, {}, {})
+    mlir = compile_kernel(bind_buffer, {}, {"XBLOCK": 128, "N": 4})
     print(mlir)

--- a/python/triton/experimental/tle/language/dsa/types.py
+++ b/python/triton/experimental/tle/language/dsa/types.py
@@ -60,6 +60,9 @@ class buffer_type(tl.dtype):
     def scalar(self):
         return self.element_ty
 
+    def _unflatten_ir(self, handles, cursor):
+        return buffer(handles[cursor], self), cursor + 1
+
 
 # -----------------------
 # buffer


### PR DESCRIPTION
<!-- PR Title Format:
[TLE][BUILD][TEST][CI/CD][DOC][PROTON][BACKEND][FLIR] Brief description
[LANGUAGE][AUTOTUNER][LAYOUT][PIPELINE][WarpSpecialization] Brief description
Do not set the following title tags: [FEATURE][BUG][FixBug][Refine] ...
-->
Background: When the frontend enters a for/if region, it clones the scope and reconstructs variables using the IR handle via _unflatten_ir. The buffer_type of dsa does not implement this interface, resulting in buffers allocated outside the loop/branch being reconstructed as regular tl.tensor after cloning, leading to compilation errors.

Change: Complete the missing _unflatten_ir for buffer_type to ensure type stability after cloning; modify the test_bind_buffer.py test case to cover this scenario