### PR TITLE
fix(nvidia): require a real CUDA torch in is_active()

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -762,7 +762,10 @@ class CudaDriver(GPUDriver):
     def is_active():
         try:
             import torch
-            return torch.cuda.is_available() and (torch.version.hip is None)
+            # `torch.cuda.is_available()` can be faked by accelerator shims
+            # (torch_npu with TORCH_TRANSFER_TO_NPU=1 reports the NPU as CUDA);
+            # a real CUDA build always carries a non-None `torch.version.cuda`.
+            return (torch.cuda.is_available() and torch.version.cuda is not None and (torch.version.hip is None))
         except ImportError:
             return False
 


### PR DESCRIPTION
## Target

`triton_v3.5.x` — the ascend backend lives on the triton 3.5 line, not `main`; the two-active-driver conflict this fixes only materializes there.

## What does this PR do?

Fixes `CUDABackend.is_active()` in `third_party/nvidia/backend/driver.py` firing on Ascend NPU hosts under torch_npu's transfer-to-NPU shim.

The current check — `torch.cuda.is_available() and (torch.version.hip is None)` — treats CUDA-API *availability* as evidence of a real CUDA torch. On Ascend hosts the shim (`TORCH_TRANSFER_TO_NPU=1`) fakes `torch.cuda.is_available()`, and the torch build is not a HIP build, so the nvidia backend reports active on a machine with no NVIDIA GPU. The Ascend `NPUDriver` is also active, so `triton.runtime.driver` sees two active backends and selection fails.

The fix requires `torch.version.cuda is not None` — a genuine CUDA build always carries the CUDA version string, and the shim does not fake it (this is the same guard upstream triton uses).

## Issue

Fixes #1022

## Verification

- Ascend 910B (CANN 9.0.0, torch_npu + `TORCH_TRANSFER_TO_NPU=1`): after the change driver probing yields `amd=False, ascend=True, nvidia=False`, and driver resolution lands on `NPUDriver`; the Triton workload runs end-to-end
- Real CUDA / HIP hosts: a CUDA torch always has `version.cuda` set and `version.hip` None — no behavior change
- `python -c "import ast; ast.parse(...)"` clean; change is a single boolean expression

This PR was written in part with the assistance of generative AI.