### PR TITLE
[TLE][AMD] Rematerialize TLE matmul loads after WMMA selection

### DIFF
--- a/python/test/tle/unit/test_tle_gpu_local_ptr.py
+++ b/python/test/tle/unit/test_tle_gpu_local_ptr.py
@@ -11,6 +11,8 @@ import torch
 import triton
 import triton.language as tl
 import triton.experimental.tle.language as tle
+from triton._flagtree_backend import FLAGTREE_BACKEND
+from triton._internal_testing import is_hip
 
 BLOCK_SIZE = 64
 
@@ -23,6 +25,11 @@ def _is_enflame_backend():
 def _is_hcu_backend():
     target = triton.runtime.driver.active.get_current_target()
     return target.backend == "hip"
+
+
+def _is_amd_hip_backend():
+    # Native AMD (hip) excludes HCU, which sets FLAGTREE_BACKEND.
+    return is_hip() and not FLAGTREE_BACKEND
 
 
 def _require_cuda():
@@ -542,6 +549,51 @@ class TestTLELocalPointerKernel:
 
         expected = (a.float()) @ (b.float())
         torch.testing.assert_close(c, expected, atol=5e-3, rtol=5e-3)
+
+    def test_local_pointer_tiled_matmul_amd_avoids_second_staging(self):
+        if not _is_amd_hip_backend():
+            pytest.skip("AMD HIP backend is required")
+
+        block_m = 32
+        block_n = 32
+        block_k = 32
+        num_k_tiles = 2
+        m = block_m
+        n = block_n
+        k = block_k * num_k_tiles
+        a = torch.randn((m, k), device="cuda", dtype=torch.float16)
+        b = torch.randn((k, n), device="cuda", dtype=torch.float16)
+        c = torch.empty((m, n), device="cuda", dtype=torch.float32)
+
+        compiled = _local_pointer_tiled_matmul_kernel.warmup(
+            a,
+            b,
+            c,
+            a.stride(0),
+            a.stride(1),
+            b.stride(0),
+            b.stride(1),
+            c.stride(0),
+            c.stride(1),
+            block_m,
+            block_n,
+            block_k,
+            num_k_tiles,
+            2,
+            block_k // 2,
+            grid=(1, 1),
+            num_warps=4,
+            num_stages=1,
+        )
+
+        ttgir = compiled.asm["ttgir"]
+        # WMMA-rematerialized operands stay in registers: two allocs/stores
+        # for the two K tiles, and no local_load reload of the staged tiles.
+        assert ttgir.count("ttg.local_alloc") == 2
+        assert ttgir.count("ttg.local_store") == 2
+        assert "ttg.local_load" not in ttgir
+        assert compiled.metadata.shared == 4096
+        assert "v_wmma" in compiled.asm["amdgcn"]
 
     def test_local_pointer_axis_gather_matches_torch(self):
         rows = 8

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -230,6 +230,10 @@ class HIPBackend(BaseBackend):
             tle.passes.add_optimize_local_pointer_loads(pm)
             tle.passes.add_optimize_local_pointer_stores(pm)
         amd.passes.ttgpuir.add_accelerate_matmul(pm, options.arch, options.matrix_instr_nonkdim, options.kpack)
+        if tle is not None:
+            # Rematerialize local-pointer loads after WMMA/matmul layout
+            # selection so tiled TLE matmul does not stage shared operands twice.
+            tle.passes.add_optimize_local_pointer_loads(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)
         amd.passes.ttgpuir.add_optimize_epilogue(pm)
         amd.passes.ttgpuir.add_optimize_dot_operands(pm, options.arch)


### PR DESCRIPTION
## What

Re-run the TLE local-pointer load optimization once more after the AMD WMMA /
matmul layout selection pass (`add_accelerate_matmul`) in `make_ttgir`.

## Why

For tiled TLE matmul, operands are staged through shared memory via
`tle.gpu.local_ptr`. Before layout selection, the local-pointer load
optimization runs, but WMMA layout selection then re-introduces a second
staging of the same operands (an extra `local_load` reload). Re-running
`add_optimize_local_pointer_loads` after `add_accelerate_matmul` rematerializes
those loads so operands stay in registers instead of being reloaded from LDS.

The change is gated on `tle is not None`, so non-TLE compilation and other
backends are unaffected.

## Testing (gfx1201 / RDNA4)

- New unit test `test_local_pointer_tiled_matmul_amd_avoids_second_staging`
  asserts the post-optimization TTGIR keeps two `ttg.local_alloc` / two
  `ttg.local_store` for the two K tiles, has no `ttg.local_load` reload,
  uses 4096B shared, and emits `v_wmma`.
- The test targets native AMD only, guarded by
  `is_hip() and not FLAGTREE_BACKEND` (excludes HCU), matching the merged
  identity convention.
- `python/test/tle/unit/test_tle_gpu_local_ptr.py`: 13 passed.
- `test_tle_cumsum.py + test_tle_gpu_local_ptr.py`: 23 passed, 2 expected skips.
- Ruff 0.9.1 and YAPF 0.43.0: clean.
- Rebased onto current upstream `main`: conflict-free, 0 commits behind.

`compiler.py` is a pure Python pass-ordering change; no native rebuild required.
