### PR TITLE
[TLE][MTHREADS] Support TLE set_layout interface on musa backend

### DIFF
--- a/python/triton/experimental/tle/language/gpu/mthreads/__init__.py
+++ b/python/triton/experimental/tle/language/gpu/mthreads/__init__.py
@@ -19,5 +19,16 @@
 # SOFTWARE.
 
 from . import buffer, common, copy, pipe, warp_specialize, wgmma
+from .types import MusaDotOperandEncoding, MusaSqmmaEncoding, MusaWmmaEncoding
 
-__all__ = ["buffer", "common", "copy", "pipe", "warp_specialize", "wgmma"]
+__all__ = [
+    "buffer",
+    "common",
+    "copy",
+    "pipe",
+    "warp_specialize",
+    "wgmma",
+    "MusaDotOperandEncoding",
+    "MusaSqmmaEncoding",
+    "MusaWmmaEncoding",
+]

--- a/python/triton/experimental/tle/language/gpu/mthreads/layout.py
+++ b/python/triton/experimental/tle/language/gpu/mthreads/layout.py
@@ -1,0 +1,204 @@
+# Copyright 2025-     FlagOS Contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""mthreads-specific explicit distributed layouts for TLE."""
+
+import triton.language.core as tl
+
+from ..types import distributed_encoding
+
+_MUSA_PH1_VERSION = [3, 1]
+
+
+def _normalize_static_int_sequence(values, name, *, require_positive=False):
+    values = tl._unwrap_if_constexpr(values)
+    if isinstance(values, tl.tuple):
+        values = tuple(values.values)
+    if not isinstance(values, (list, tuple)):
+        raise ValueError(f"mthreads TLE {name} must be a static sequence")
+
+    normalized = []
+    for index, value in enumerate(values):
+        value = tl._unwrap_if_constexpr(value)
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"mthreads TLE {name}[{index}] must be a compile-time integer")
+        if require_positive and value <= 0:
+            raise ValueError(f"mthreads TLE {name}[{index}] must be positive")
+        normalized.append(value)
+    return normalized
+
+
+def _is_power_of_two(value):
+    return value > 0 and (value & (value - 1)) == 0
+
+
+class _MusaMmaEncoding(distributed_encoding):
+    """Shared Python contract for PH1 MUSA matrix instruction layouts."""
+
+    _builder_method = None
+
+    def __init__(self, version, warps_per_cta, instr_shape, cga_layout=None):
+        super().__init__()
+        prefix = self.__class__.__name__
+        self.version = _normalize_static_int_sequence(version, f"{prefix} version", require_positive=True)
+        self.warps_per_cta = _normalize_static_int_sequence(
+            warps_per_cta,
+            f"{prefix} warps_per_cta",
+            require_positive=True,
+        )
+        self.instr_shape = _normalize_static_int_sequence(
+            instr_shape,
+            f"{prefix} instr_shape",
+            require_positive=True,
+        )
+
+        if len(self.version) != 2:
+            raise ValueError(f"{prefix} version must contain major and minor")
+        if self.version != _MUSA_PH1_VERSION:
+            raise ValueError(f"{prefix} currently supports only MUSA PH1 version [3, 1], got {self.version}")
+        if len(self.warps_per_cta) not in (2, 3):
+            raise ValueError(f"{prefix} warps_per_cta rank must be 2 or 3")
+        if any(not _is_power_of_two(value) for value in self.warps_per_cta):
+            raise ValueError(f"{prefix} warps_per_cta entries must be positive powers of two")
+        if len(self.warps_per_cta) == 3 and self.warps_per_cta[2] != 1:
+            raise ValueError(f"{prefix} rank-3 warps_per_cta must be [warps_m, warps_n, 1]")
+        if len(self.instr_shape) != 3:
+            raise ValueError(f"{prefix} instr_shape must contain logical (M, N, K)")
+
+        self.cga_layout = [] if cga_layout is None else self._normalize_cga_layout(cga_layout)
+        self._validate_instruction_shape()
+
+    def _normalize_cga_layout(self, cga_layout):
+        prefix = self.__class__.__name__
+        cga_layout = tl._unwrap_if_constexpr(cga_layout)
+        if isinstance(cga_layout, tl.tuple):
+            cga_layout = tuple(cga_layout.values)
+        if not isinstance(cga_layout, (list, tuple)):
+            raise ValueError(f"{prefix} cga_layout must be a static sequence of basis vectors")
+
+        normalized = []
+        for index, basis in enumerate(cga_layout):
+            basis = _normalize_static_int_sequence(basis, f"{prefix} cga_layout[{index}]")
+            if len(basis) != self.rank:
+                raise ValueError(f"{prefix} cga_layout[{index}] rank must match layout rank {self.rank}")
+            if any(value < 0 for value in basis):
+                raise ValueError(f"{prefix} cga_layout[{index}] entries must be non-negative")
+            normalized.append(basis)
+        return normalized
+
+    @property
+    def rank(self):
+        return len(self.warps_per_cta)
+
+    def _validate_instruction_shape(self):
+        raise NotImplementedError
+
+    def to_ir(self, builder):
+        method = getattr(builder, self._builder_method)
+        return method(self.version, self.warps_per_cta, self.cga_layout, self.instr_shape)
+
+    def __repr__(self):
+        return (f"{self.__class__.__name__}(version={self.version}, warps_per_cta={self.warps_per_cta}, "
+                f"instr_shape={self.instr_shape}, cga_layout={self.cga_layout})")
+
+    def __eq__(self, other):
+        return (type(self) is type(other) and self.version == other.version
+                and self.warps_per_cta == other.warps_per_cta and self.instr_shape == other.instr_shape
+                and self.cga_layout == other.cga_layout)
+
+    def __hash__(self):
+        return hash((type(self), tuple(self.version), tuple(self.warps_per_cta), tuple(self.instr_shape),
+                     tuple(tuple(basis) for basis in self.cga_layout)))
+
+
+class MusaWmmaEncoding(_MusaMmaEncoding):
+    """Explicit ``#ttg.musa_wmma`` encoding for a WMMA result or accumulator."""
+
+    _builder_method = "get_musa_wmma_layout"
+
+    def _validate_instruction_shape(self):
+        m, n, k = self.instr_shape
+        if m % 8 != 0:
+            raise ValueError("MusaWmmaEncoding instr_shape M must be a non-zero multiple of 8")
+        if n % 8 != 0:
+            raise ValueError("MusaWmmaEncoding instr_shape N must be a non-zero multiple of 8")
+        if k != 4 and k % 8 != 0:
+            raise ValueError("MusaWmmaEncoding instr_shape K must be 4 or a non-zero multiple of 8")
+
+
+class MusaSqmmaEncoding(_MusaMmaEncoding):
+    """Explicit ``#ttg.musa_sqmma`` encoding for an SQMMA result or accumulator."""
+
+    _builder_method = "get_musa_sqmma_layout"
+
+    def __init__(self, version, warps_per_cta, instr_shape, cga_layout=None):
+        super().__init__(version, warps_per_cta, instr_shape, cga_layout)
+        if self.warps_per_cta[0] % 4 != 0:
+            raise ValueError("MusaSqmmaEncoding warps_per_cta[0] must be a multiple of 4")
+
+    def _validate_instruction_shape(self):
+        m, n, k = self.instr_shape
+        if m < 16 or m % 8 != 0:
+            raise ValueError("MusaSqmmaEncoding instr_shape M must be at least 16 and a multiple of 8")
+        if n % 8 != 0:
+            raise ValueError("MusaSqmmaEncoding instr_shape N must be a non-zero multiple of 8")
+        if k % 8 != 0:
+            raise ValueError("MusaSqmmaEncoding instr_shape K must be a non-zero multiple of 8")
+
+
+class MusaDotOperandEncoding(distributed_encoding):
+    """Explicit ``#ttg.dot_op`` encoding for a MUSA WMMA/SQMMA operand."""
+
+    def __init__(self, operand_index, parent, k_width=0):
+        super().__init__()
+        self.operand_index = tl._unwrap_if_constexpr(operand_index)
+        self.parent = tl._unwrap_if_constexpr(parent)
+        self.k_width = tl._unwrap_if_constexpr(k_width)
+
+        if isinstance(self.operand_index, bool) or not isinstance(self.operand_index, int):
+            raise ValueError("MusaDotOperandEncoding operand_index must be a compile-time integer")
+        if self.operand_index not in (0, 1):
+            raise ValueError("MusaDotOperandEncoding operand_index must be 0 or 1")
+        if not isinstance(self.parent, _MusaMmaEncoding):
+            raise ValueError("MusaDotOperandEncoding parent must be a MusaWmmaEncoding or MusaSqmmaEncoding")
+        if isinstance(self.k_width, bool) or not isinstance(self.k_width, int):
+            raise ValueError("MusaDotOperandEncoding k_width must be a compile-time integer")
+        if self.k_width != 0:
+            raise ValueError("MusaDotOperandEncoding requires k_width=0")
+
+    @property
+    def rank(self):
+        return self.parent.rank
+
+    def to_ir(self, builder):
+        return builder.get_dot_operand_layout(self.operand_index, self.parent.to_ir(builder), self.k_width)
+
+    def __repr__(self):
+        return (f"MusaDotOperandEncoding(operand_index={self.operand_index}, parent={self.parent!r}, "
+                f"k_width={self.k_width})")
+
+    def __eq__(self, other):
+        return (type(self) is type(other) and self.operand_index == other.operand_index and self.parent == other.parent
+                and self.k_width == other.k_width)
+
+    def __hash__(self):
+        return hash((self.operand_index, self.parent, self.k_width))
+
+
+__all__ = ["MusaWmmaEncoding", "MusaSqmmaEncoding", "MusaDotOperandEncoding"]

--- a/python/triton/experimental/tle/language/gpu/mthreads/types.py
+++ b/python/triton/experimental/tle/language/gpu/mthreads/types.py
@@ -17,7 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""mthreads-specific explicit distributed layouts for TLE."""
+"""mthreads-specific TLE types."""
 
 import triton.language.core as tl
 

--- a/third_party/mthreads/backend/compiler.py
+++ b/third_party/mthreads/backend/compiler.py
@@ -835,6 +835,8 @@ class MUSABackend(BaseBackend):
         mthreads.passes.ttgpuir.add_finalize_barriers(pm)
         if hasattr(mthreads.passes.ttgpuir, "add_tle_prepare_warp_specialize"):
             mthreads.passes.ttgpuir.add_tle_prepare_warp_specialize(pm)
+        if hasattr(mthreads.passes.ttgpuir, "add_tle_finalize_explicit_layouts"):
+            mthreads.passes.ttgpuir.add_tle_finalize_explicit_layouts(pm)
         pm.run(mod, "make_ttgir")
         metadata["uses_sqmma"] = _module_uses_sqmma(mod)
         metadata["tensordesc_meta"] = mod.get_tensordesc_metadata()

--- a/third_party/mthreads/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/third_party/mthreads/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -8,6 +8,9 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include <algorithm>
 #include <numeric>
+#ifdef __TLE__
+#include <string>
+#endif
 
 namespace mlir {
 class DominanceInfo;
@@ -60,6 +63,22 @@ bool isView(Operation *op);
 // Returns whether the op is a "noop op", i.e. has one input and one output
 // and lowers to llvm as the identity function (returns the input)
 bool isNoop(Operation *op);
+
+#ifdef __TLE__
+const char *getTleExplicitEncodingAttrPrefix();
+std::string getTleExplicitEncodingAttrName(unsigned resultNumber);
+const char *getTleExplicitMemoryEncodingAttrName();
+Attribute getTleExplicitResultEncoding(Operation *op, unsigned resultNumber);
+void setTleExplicitResultEncoding(Operation *op, unsigned resultNumber,
+                                  Attribute encoding);
+void setTleExplicitResultEncoding(OpResult result, Attribute encoding);
+Attribute getTleExplicitMemoryEncoding(Operation *op);
+void setTleExplicitMemoryEncoding(Operation *op, Attribute encoding);
+Attribute getTleExplicitValueEncoding(Value value);
+LogicalResult inferTleExplicitMemoryEncoding(Operation *op,
+                                             Attribute &encoding);
+bool isTleExplicitConvertLayoutOp(Operation *op);
+#endif // __TLE__
 
 /* Dump Triton IR in graphviz dot format.
  *

--- a/third_party/mthreads/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
+++ b/third_party/mthreads/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
@@ -95,9 +95,10 @@ TritonGPUConversionTarget::TritonGPUConversionTarget(
   addDynamicallyLegalOp<mlir::triton::musa_tle::ExtractTileOp,
                         mlir::triton::musa_tle::InsertTileOp>(
       [&](Operation *op) { return isDynamicallyLegal(op, typeConverter); });
+  addIllegalOp<mlir::triton::musa_tle::SetLayoutOp>();
   addDynamicallyLegalDialect<mlir::triton::musa_tle::MUSATLEDialect>(
       [&](Operation *op) { return isDynamicallyLegal(op, typeConverter); });
-#endif
+#endif // __TLE__
 
   addDynamicallyLegalDialect<arith::ArithDialect, math::MathDialect,
                              triton::TritonDialect, cf::ControlFlowDialect,

--- a/third_party/mthreads/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/third_party/mthreads/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -1,10 +1,14 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #ifdef __TLE__
 #include "Dialect/MUSATLE/IR/Dialect.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/PriorityWorklist.h"
 #endif
 #include "triton/Conversion/TritonToTritonGPU/Passes.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -32,6 +36,645 @@ static void addNamedAttrs(Operation *op, DictionaryAttr dictAttrs) {
     if (!op->hasAttr(attr.getName()))
       op->setAttr(attr.getName(), attr.getValue());
 }
+
+#ifdef __TLE__
+struct MusaTleEncodingInfo {
+  Attribute encoding;
+  // A varying hint may be replaced by a hard hint. Hard hints represent an
+  // explicit set_layout result and must not be silently changed.
+  bool mayVary = false;
+
+  explicit operator bool() const { return bool(encoding); }
+};
+
+static bool musaTleEncodingsMayVary(Operation *op) {
+  return isa<triton::JoinOp, triton::SplitOp, triton::ReshapeOp, triton::CatOp,
+             triton::TransOp>(op);
+}
+
+static LogicalResult mergeMusaTleEncodingInfo(MusaTleEncodingInfo oldInfo,
+                                              MusaTleEncodingInfo newInfo,
+                                              Operation *op,
+                                              MusaTleEncodingInfo &merged) {
+  if (!oldInfo) {
+    merged = newInfo;
+    return success();
+  }
+  if (!newInfo) {
+    merged = oldInfo;
+    return success();
+  }
+  if (oldInfo.encoding == newInfo.encoding) {
+    merged = oldInfo;
+    merged.mayVary = oldInfo.mayVary && newInfo.mayVary;
+    return success();
+  }
+  if (oldInfo.mayVary && !newInfo.mayVary) {
+    merged = newInfo;
+    return success();
+  }
+  if (!oldInfo.mayVary && newInfo.mayVary) {
+    merged = oldInfo;
+    return success();
+  }
+  if (oldInfo.mayVary && newInfo.mayVary) {
+    merged = oldInfo;
+    return success();
+  }
+
+  op->emitOpError("found conflicting MUSA TLE encoding hints for value:\n  ")
+      << oldInfo.encoding << "\nand\n  " << newInfo.encoding;
+  return failure();
+}
+
+using MusaTleEncodingMap = llvm::MapVector<Value, MusaTleEncodingInfo>;
+using MusaTleEncodingWorklist = llvm::PriorityWorklist<Value>;
+
+struct MusaTleLayoutDomainMember {
+  Attribute encoding;
+  Operation *op;
+};
+
+struct MusaTleLayoutProducerFamily {
+  SmallVector<Value> originalOperands;
+  SmallVector<MusaTleLayoutDomainMember> members;
+};
+
+using MusaTleLayoutProducerFamilies =
+    llvm::MapVector<Operation *, MusaTleLayoutProducerFamily>;
+
+static bool isMusaTleLayoutPolymorphicProducer(Operation *op) {
+  if (op->getNumRegions() != 0 || op->getNumSuccessors() != 0 ||
+      op->getNumResults() != 1 || !isPure(op) ||
+      op->hasTrait<OpTrait::IsTerminator>() ||
+      isa<mlir::triton::musa_tle::SetLayoutOp, triton::CallOp>(op) ||
+      getMemAccessPtr(op))
+    return false;
+
+  auto resultType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  return resultType && !resultType.getEncoding();
+}
+
+static Value
+materializeMusaTleLayoutDomain(Value value, Attribute encoding,
+                               MusaTleLayoutProducerFamilies &families) {
+  Operation *producer = value.getDefiningOp();
+  if (!producer || !isMusaTleLayoutPolymorphicProducer(producer))
+    return value;
+
+  auto [it, inserted] = families.insert(
+      {producer, MusaTleLayoutProducerFamily{
+                     llvm::to_vector(producer->getOperands()), {}}});
+  MusaTleLayoutProducerFamily &family = it->second;
+  for (const MusaTleLayoutDomainMember &member : family.members)
+    if (member.encoding == encoding)
+      return member.op->getResult(0);
+
+  Operation *member = producer;
+  if (!family.members.empty()) {
+    OpBuilder builder(producer);
+    builder.setInsertionPointAfter(family.members.back().op);
+    member = builder.clone(*producer);
+    member->setOperands(family.originalOperands);
+  }
+  family.members.push_back({encoding, member});
+  SmallVector<Value> originalOperands = family.originalOperands;
+
+  Attribute operandEncoding = inferSrcEncoding(producer, encoding);
+  if (!operandEncoding)
+    return member->getResult(0);
+
+  for (auto [index, operand] : llvm::enumerate(originalOperands)) {
+    if (!isa<RankedTensorType>(operand.getType()))
+      continue;
+    member->setOperand(index, materializeMusaTleLayoutDomain(
+                                  operand, operandEncoding, families));
+  }
+  return member->getResult(0);
+}
+
+static void mergeMusaTleLayoutProducerDomains(
+    const MusaTleLayoutProducerFamilies &families) {
+  for (const auto &[_, family] : families) {
+    llvm::MapVector<Type, Operation *> representatives;
+    for (const MusaTleLayoutDomainMember &domain : family.members) {
+      Operation *member = domain.op;
+      Type resultType = member->getResult(0).getType();
+      auto [it, inserted] = representatives.insert({resultType, member});
+      if (inserted)
+        continue;
+      member->getResult(0).replaceAllUsesWith(it->second->getResult(0));
+      member->erase();
+    }
+  }
+}
+
+static LogicalResult updateMusaTleEncoding(ArrayRef<Value> values,
+                                           MusaTleEncodingInfo info,
+                                           FuncOp func,
+                                           MusaTleEncodingMap &valueToEncoding,
+                                           MusaTleEncodingWorklist &worklist) {
+  for (Value value : values) {
+    if (!isa<RankedTensorType>(value.getType()))
+      continue;
+
+    auto [it, inserted] = valueToEncoding.insert({value, info});
+    if (!inserted) {
+      Operation *diagOp = value.getDefiningOp();
+      if (!diagOp)
+        if (auto blockArg = dyn_cast<BlockArgument>(value))
+          diagOp = blockArg.getOwner()->getParentOp();
+      if (!diagOp)
+        diagOp = func.getOperation();
+      MusaTleEncodingInfo merged;
+      if (failed(mergeMusaTleEncodingInfo(it->second, info, diagOp, merged)))
+        return failure();
+      if (merged.encoding == it->second.encoding &&
+          merged.mayVary == it->second.mayVary)
+        continue;
+      it->second = merged;
+    }
+    worklist.insert(value);
+  }
+  return success();
+}
+
+static LogicalResult propagateMusaTleEncodingHints(
+    FuncOp func, const MusaTleEncodingMap &boundarySeeds, bool &changed) {
+  SmallVector<mlir::triton::musa_tle::SetLayoutOp> setLayoutOps;
+  func.walk([&](mlir::triton::musa_tle::SetLayoutOp op) {
+    setLayoutOps.push_back(op);
+  });
+  if (setLayoutOps.empty() && boundarySeeds.empty())
+    return success();
+
+  MusaTleLayoutProducerFamilies producerFamilies;
+  for (mlir::triton::musa_tle::SetLayoutOp op : setLayoutOps) {
+    Value source = materializeMusaTleLayoutDomain(
+        op.getSrc(), op.getTargetEncoding(), producerFamilies);
+    op->setOperand(0, source);
+  }
+
+  SmallVector<std::pair<Value, MusaTleEncodingInfo>> seedEncodings;
+  for (mlir::triton::musa_tle::SetLayoutOp op : setLayoutOps) {
+    // The source is allowed to serve multiple explicit layout domains. The
+    // result is the hard user contract introduced by set_layout.
+    seedEncodings.push_back(
+        {op.getSrc(), MusaTleEncodingInfo{op.getTargetEncoding(), true}});
+    seedEncodings.push_back(
+        {op.getResult(), MusaTleEncodingInfo{op.getTargetEncoding(), false}});
+  }
+  for (const auto &[value, info] : boundarySeeds)
+    seedEncodings.push_back({value, info});
+
+  MusaTleEncodingMap valueToEncoding;
+  MusaTleEncodingWorklist worklist;
+  for (auto &[value, info] : seedEncodings) {
+    if (failed(updateMusaTleEncoding({value}, info, func, valueToEncoding,
+                                     worklist)))
+      return failure();
+  }
+
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    MusaTleEncodingInfo info = valueToEncoding[value];
+    assert(info && "worklist value must have a MUSA TLE encoding");
+
+    for (OpOperand &use : value.getUses()) {
+      Operation *op = use.getOwner();
+
+      if (isa<scf::ForOp, scf::WhileOp>(op)) {
+        int offset = 3 * isa<scf::ForOp>(op);
+        int tiedIndex = static_cast<int>(use.getOperandNumber()) - offset;
+        if (tiedIndex < 0)
+          continue;
+        auto tiedArgs = getTiedArgs(op, tiedIndex);
+        if (failed(updateMusaTleEncoding(tiedArgs, info, func, valueToEncoding,
+                                         worklist)))
+          return failure();
+        continue;
+      }
+
+      if (isa<scf::YieldOp, scf::ConditionOp>(op)) {
+        Operation *parentOp = op->getParentOp();
+        if (!isa_and_nonnull<scf::ForOp, scf::WhileOp, scf::IfOp>(parentOp))
+          continue;
+        int offset = isa<scf::ConditionOp>(op);
+        int tiedIndex = static_cast<int>(use.getOperandNumber()) - offset;
+        if (tiedIndex < 0)
+          continue;
+        auto tiedArgs = getTiedArgs(parentOp, tiedIndex);
+        if (failed(updateMusaTleEncoding(tiedArgs, info, func, valueToEncoding,
+                                         worklist)))
+          return failure();
+        continue;
+      }
+
+      if (auto wait = dyn_cast<mlir::triton::musa_tle::SqmmaWaitOp>(op)) {
+        if (failed(updateMusaTleEncoding({wait.getOutput()}, info, func,
+                                         valueToEncoding, worklist)))
+          return failure();
+        continue;
+      }
+
+      if (auto sqmma = dyn_cast<mlir::triton::musa_tle::SqmmaOp>(op)) {
+        if (use.get() == sqmma.getC() &&
+            failed(updateMusaTleEncoding({sqmma.getD()}, info, func,
+                                         valueToEncoding, worklist)))
+          return failure();
+        continue;
+      }
+
+      if (auto dot = dyn_cast<triton::DotOpInterface>(op)) {
+        // A/B use dot-operand encodings, while C and D use the parent MMA
+        // encoding. Only C and D are layout-equivalent across a dot.
+        if (use.getOperandNumber() == 2 &&
+            failed(updateMusaTleEncoding({dot.getD()}, info, func,
+                                         valueToEncoding, worklist)))
+          return failure();
+        continue;
+      }
+
+      if (isa<mlir::triton::musa_tle::SetLayoutOp>(op))
+        continue;
+
+      if (isa<mlir::triton::musa_tle::LocalPointersOp>(op)) {
+        if (failed(updateMusaTleEncoding(
+                llvm::to_vector_of<Value>(op->getResults()), info, func,
+                valueToEncoding, worklist)))
+          return failure();
+        continue;
+      }
+
+      Attribute dstEncoding = inferDstEncoding(op, info.encoding);
+      if (!dstEncoding)
+        continue;
+      MusaTleEncodingInfo dstInfo{dstEncoding,
+                                  info.mayVary || musaTleEncodingsMayVary(op)};
+      if (failed(
+              updateMusaTleEncoding(llvm::to_vector_of<Value>(op->getResults()),
+                                    dstInfo, func, valueToEncoding, worklist)))
+        return failure();
+    }
+
+    if (auto opResult = dyn_cast<OpResult>(value)) {
+      Operation *definingOp = opResult.getOwner();
+      if (isa<scf::ForOp, scf::WhileOp, scf::IfOp>(definingOp)) {
+        auto tiedArgs = getTiedArgs(definingOp, opResult.getResultNumber());
+        if (failed(updateMusaTleEncoding(tiedArgs, info, func, valueToEncoding,
+                                         worklist)))
+          return failure();
+      } else if (auto wait = dyn_cast<mlir::triton::musa_tle::SqmmaWaitOp>(
+                     definingOp)) {
+        if (failed(updateMusaTleEncoding({wait.getInput()}, info, func,
+                                         valueToEncoding, worklist)))
+          return failure();
+      } else if (auto sqmma =
+                     dyn_cast<mlir::triton::musa_tle::SqmmaOp>(definingOp)) {
+        if (failed(updateMusaTleEncoding({sqmma.getC()}, info, func,
+                                         valueToEncoding, worklist)))
+          return failure();
+      } else if (isa<triton::DotOpInterface>(definingOp)) {
+        if (failed(updateMusaTleEncoding({definingOp->getOperand(2)}, info,
+                                         func, valueToEncoding, worklist)))
+          return failure();
+      } else if (auto localPointers =
+                     dyn_cast<mlir::triton::musa_tle::LocalPointersOp>(
+                         definingOp)) {
+        SmallVector<Value> tensorIndices;
+        for (Value index : localPointers.getIndices())
+          if (isa<RankedTensorType>(index.getType()))
+            tensorIndices.push_back(index);
+        if (failed(updateMusaTleEncoding(tensorIndices, info, func,
+                                         valueToEncoding, worklist)))
+          return failure();
+      } else if (!isa<mlir::triton::musa_tle::SetLayoutOp>(definingOp)) {
+        Attribute srcEncoding = inferSrcEncoding(definingOp, info.encoding);
+        if (srcEncoding) {
+          MusaTleEncodingInfo srcInfo{
+              srcEncoding, info.mayVary || musaTleEncodingsMayVary(definingOp)};
+          SmallVector<Value> tensorOperands;
+          for (Value operand : definingOp->getOperands())
+            if (isa<RankedTensorType>(operand.getType()))
+              tensorOperands.push_back(operand);
+          if (failed(updateMusaTleEncoding(tensorOperands, srcInfo, func,
+                                           valueToEncoding, worklist)))
+            return failure();
+        }
+      }
+    } else if (auto blockArg = dyn_cast<BlockArgument>(value)) {
+      Operation *parentOp = blockArg.getOwner()->getParentOp();
+      if (isa<scf::ForOp, scf::WhileOp>(parentOp)) {
+        int offset = isa<scf::ForOp>(parentOp);
+        int tiedIndex = static_cast<int>(blockArg.getArgNumber()) - offset;
+        if (tiedIndex < 0)
+          continue;
+        auto tiedArgs = getTiedArgs(parentOp, tiedIndex);
+        if (failed(updateMusaTleEncoding(tiedArgs, info, func, valueToEncoding,
+                                         worklist)))
+          return failure();
+      }
+    }
+  }
+
+  for (auto &[value, info] : valueToEncoding) {
+    auto existingType = cast<RankedTensorType>(value.getType());
+    if (existingType.getEncoding() != info.encoding) {
+      auto newType = existingType.cloneWithEncoding(info.encoding);
+      value.setType(newType);
+      changed = true;
+      if (auto opResult = dyn_cast<OpResult>(value)) {
+        if (auto constant = dyn_cast<arith::ConstantOp>(opResult.getOwner())) {
+          if (auto elements =
+                  dyn_cast<DenseElementsAttr>(constant.getValueAttr()))
+            constant.setValueAttr(elements.reshape(newType));
+        }
+      }
+    }
+
+    if (auto opResult = dyn_cast<OpResult>(value))
+      setTleExplicitResultEncoding(opResult, info.encoding);
+  }
+
+  mergeMusaTleLayoutProducerDomains(producerFamilies);
+
+  WalkResult memoryWalk = func.walk([&](Operation *op) {
+    if (!getMemAccessPtr(op))
+      return WalkResult::advance();
+
+    Attribute explicitEncoding;
+    if (failed(inferTleExplicitMemoryEncoding(op, explicitEncoding)))
+      return WalkResult::interrupt();
+    if (explicitEncoding)
+      setTleExplicitMemoryEncoding(op, explicitEncoding);
+    return WalkResult::advance();
+  });
+  if (memoryWalk.wasInterrupted())
+    return failure();
+
+  return success();
+}
+
+using MusaTleFunctionSeeds = llvm::MapVector<Operation *, MusaTleEncodingMap>;
+
+struct MusaTleCallSite {
+  triton::CallOp call;
+  FuncOp caller;
+  FuncOp callee;
+};
+
+static LogicalResult addMusaTleBoundarySeed(MusaTleFunctionSeeds &seeds,
+                                            FuncOp func, Value value,
+                                            Attribute encoding) {
+  if (!encoding || !isa<RankedTensorType>(value.getType()))
+    return success();
+
+  auto [funcIt, _] = seeds.insert({func.getOperation(), MusaTleEncodingMap{}});
+  MusaTleEncodingMap &funcSeeds = funcIt->second;
+  MusaTleEncodingInfo info{encoding, false};
+  auto [valueIt, inserted] = funcSeeds.insert({value, info});
+  if (inserted)
+    return success();
+
+  MusaTleEncodingInfo merged;
+  if (failed(mergeMusaTleEncodingInfo(valueIt->second, info,
+                                      func.getOperation(), merged)))
+    return failure();
+  valueIt->second = merged;
+  return success();
+}
+
+static bool hasSameMusaTleAbiTensorType(RankedTensorType lhs,
+                                        RankedTensorType rhs) {
+  return lhs.getShape() == rhs.getShape() &&
+         lhs.getElementType() == rhs.getElementType();
+}
+
+static LogicalResult
+resolveMusaTleAbiSlot(FuncOp callee, StringRef slotKind, unsigned slotIndex,
+                      Type signatureType,
+                      ArrayRef<std::pair<FuncOp, Value>> members,
+                      MusaTleFunctionSeeds &nextSeeds) {
+  auto signatureTensor = dyn_cast<RankedTensorType>(signatureType);
+  if (!signatureTensor) {
+    for (const auto &[_, value] : members) {
+      if (value.getType() != signatureType)
+        return callee.emitOpError()
+               << "found incompatible MUSA TLE " << slotKind << " #"
+               << slotIndex << " ABI type: expected " << signatureType
+               << " but found " << value.getType();
+    }
+    return success();
+  }
+
+  Attribute encoding = signatureTensor.getEncoding();
+  for (const auto &[_, value] : members) {
+    auto valueType = dyn_cast<RankedTensorType>(value.getType());
+    if (!valueType || !hasSameMusaTleAbiTensorType(signatureTensor, valueType))
+      return callee.emitOpError()
+             << "found incompatible MUSA TLE " << slotKind << " #" << slotIndex
+             << " ABI type: expected tensor shape and element "
+                "type "
+             << signatureTensor << " but found " << value.getType();
+
+    Attribute valueEncoding = valueType.getEncoding();
+    if (!valueEncoding)
+      continue;
+    if (encoding && encoding != valueEncoding)
+      return callee.emitOpError()
+             << "found conflicting MUSA TLE ABI encodings for " << slotKind
+             << " #" << slotIndex << ":\n  " << encoding << "\nand\n  "
+             << valueEncoding;
+    encoding = valueEncoding;
+  }
+
+  if (!encoding)
+    return success();
+  for (const auto &[func, value] : members) {
+    auto valueType = cast<RankedTensorType>(value.getType());
+    if (!valueType.getEncoding() &&
+        failed(addMusaTleBoundarySeed(nextSeeds, func, value, encoding)))
+      return failure();
+  }
+  return success();
+}
+
+static LogicalResult
+collectMusaTleCallSites(ModuleOp mod,
+                        SmallVectorImpl<MusaTleCallSite> &callSites) {
+  for (FuncOp caller : mod.getOps<FuncOp>()) {
+    WalkResult result = caller.walk([&](triton::CallOp call) {
+      FuncOp callee = mod.lookupSymbol<FuncOp>(call.getCallee());
+      if (!callee) {
+        call.emitOpError("could not resolve callee while propagating MUSA "
+                         "TLE ABI encodings");
+        return WalkResult::interrupt();
+      }
+      callSites.push_back({call, caller, callee});
+      return WalkResult::advance();
+    });
+    if (result.wasInterrupted())
+      return failure();
+  }
+  return success();
+}
+
+static SmallVector<ReturnOp> collectMusaTleReturns(FuncOp func) {
+  SmallVector<ReturnOp> returns;
+  func.walk([&](ReturnOp op) { returns.push_back(op); });
+  return returns;
+}
+
+static LogicalResult
+resolveMusaTleAbiBoundaries(ArrayRef<FuncOp> funcs,
+                            ArrayRef<MusaTleCallSite> callSites,
+                            MusaTleFunctionSeeds &nextSeeds) {
+  for (FuncOp callee : funcs) {
+    SmallVector<MusaTleCallSite> calleeCalls;
+    for (const MusaTleCallSite &callSite : callSites)
+      if (callSite.callee == callee)
+        calleeCalls.push_back(callSite);
+
+    for (unsigned index = 0; index < callee.getNumArguments(); ++index) {
+      SmallVector<std::pair<FuncOp, Value>> members;
+      if (!callee.isExternal())
+        members.push_back({callee, callee.getArgument(index)});
+      for (MusaTleCallSite callSite : calleeCalls) {
+        if (index >= callSite.call.getNumOperands())
+          return callSite.call.emitOpError()
+                 << "has too few operands for MUSA TLE ABI argument #" << index;
+        members.push_back({callSite.caller, callSite.call.getOperand(index)});
+      }
+      if (failed(resolveMusaTleAbiSlot(callee, "argument", index,
+                                       callee.getArgumentTypes()[index],
+                                       members, nextSeeds)))
+        return failure();
+    }
+
+    SmallVector<ReturnOp> returns = collectMusaTleReturns(callee);
+    for (ReturnOp returnOp : returns)
+      if (returnOp.getNumOperands() != callee.getNumResults())
+        return returnOp.emitOpError()
+               << "has a result count inconsistent with function @"
+               << callee.getName();
+
+    for (unsigned index = 0; index < callee.getNumResults(); ++index) {
+      SmallVector<std::pair<FuncOp, Value>> members;
+      for (ReturnOp returnOp : returns)
+        members.push_back({callee, returnOp.getOperand(index)});
+      for (MusaTleCallSite callSite : calleeCalls) {
+        if (index >= callSite.call.getNumResults())
+          return callSite.call.emitOpError()
+                 << "has too few results for MUSA TLE ABI result #" << index;
+        members.push_back({callSite.caller, callSite.call.getResult(index)});
+      }
+      if (failed(resolveMusaTleAbiSlot(callee, "result", index,
+                                       callee.getResultTypes()[index], members,
+                                       nextSeeds)))
+        return failure();
+    }
+  }
+  return success();
+}
+
+static LogicalResult
+synchronizeMusaTleFunctionTypes(ArrayRef<FuncOp> funcs,
+                                ArrayRef<MusaTleCallSite> callSites) {
+  for (FuncOp func : funcs) {
+    SmallVector<Type> argumentTypes(func.getArgumentTypes());
+    SmallVector<Type> resultTypes(func.getResultTypes());
+    if (!func.isExternal()) {
+      argumentTypes.assign(func.getBlocks().front().getArgumentTypes().begin(),
+                           func.getBlocks().front().getArgumentTypes().end());
+      SmallVector<ReturnOp> returns = collectMusaTleReturns(func);
+      if (!returns.empty()) {
+        resultTypes.assign(returns.front().getOperandTypes().begin(),
+                           returns.front().getOperandTypes().end());
+        for (ReturnOp returnOp : llvm::drop_begin(returns))
+          if (!llvm::equal(returnOp.getOperandTypes(), resultTypes))
+            return returnOp.emitOpError()
+                   << "does not match the converged MUSA TLE result ABI of "
+                      "function @"
+                   << func.getName();
+      }
+    }
+    func.setFunctionType(
+        FunctionType::get(func.getContext(), argumentTypes, resultTypes));
+  }
+
+  for (MusaTleCallSite callSite : callSites) {
+    FunctionType calleeType = callSite.callee.getFunctionType();
+    if (!llvm::equal(callSite.call.getOperandTypes(), calleeType.getInputs()))
+      return callSite.call.emitOpError()
+             << "operands do not match the converged MUSA TLE ABI for @"
+             << callSite.callee.getName();
+    if (callSite.call.getNumResults() != calleeType.getNumResults())
+      return callSite.call.emitOpError()
+             << "result count does not match the converged MUSA TLE ABI for @"
+             << callSite.callee.getName();
+    for (auto [result, type] :
+         llvm::zip(callSite.call.getResults(), calleeType.getResults()))
+      result.setType(type);
+  }
+  return success();
+}
+
+static LogicalResult applyMusaTleEncodingHints(ModuleOp mod) {
+  bool hasSetLayout = false;
+  mod.walk([&](mlir::triton::musa_tle::SetLayoutOp) {
+    hasSetLayout = true;
+    return WalkResult::interrupt();
+  });
+  if (!hasSetLayout)
+    return success();
+
+  SmallVector<FuncOp> funcs(llvm::to_vector(mod.getOps<FuncOp>()));
+  SmallVector<MusaTleCallSite> callSites;
+  if (failed(collectMusaTleCallSites(mod, callSites)))
+    return failure();
+
+  unsigned tensorValueCount = 0;
+  mod.walk([&](Operation *op) {
+    tensorValueCount += llvm::count_if(op->getResults(), [](Value value) {
+      return isa<RankedTensorType>(value.getType());
+    });
+    for (Region &region : op->getRegions())
+      for (Block &block : region)
+        tensorValueCount +=
+            llvm::count_if(block.getArguments(), [](BlockArgument argument) {
+              return isa<RankedTensorType>(argument.getType());
+            });
+  });
+
+  MusaTleFunctionSeeds boundarySeeds;
+  for (unsigned iteration = 0; iteration <= tensorValueCount + 1; ++iteration) {
+    bool changed = false;
+    for (FuncOp func : funcs) {
+      auto it = boundarySeeds.find(func.getOperation());
+      MusaTleEncodingMap emptySeeds;
+      const MusaTleEncodingMap &funcSeeds =
+          it == boundarySeeds.end() ? emptySeeds : it->second;
+      if (failed(propagateMusaTleEncodingHints(func, funcSeeds, changed)))
+        return failure();
+    }
+
+    MusaTleFunctionSeeds nextSeeds;
+    if (failed(resolveMusaTleAbiBoundaries(funcs, callSites, nextSeeds)))
+      return failure();
+    if (nextSeeds.empty())
+      return synchronizeMusaTleFunctionTypes(funcs, callSites);
+    if (!boundarySeeds.empty() && !changed) {
+      mod.emitError("MUSA TLE function ABI propagation did not make "
+                    "progress");
+      return failure();
+    }
+    boundarySeeds = std::move(nextSeeds);
+  }
+
+  mod.emitError("MUSA TLE function ABI propagation did not converge");
+  return failure();
+}
+#endif // __TLE__
 
 template <class Op> struct GenericOpPattern : public OpConversionPattern<Op> {
   using OpConversionPattern<Op>::OpConversionPattern;
@@ -850,17 +1493,46 @@ struct MUSATLEInsertTilePattern
   }
 };
 
+struct MUSATLESetLayoutPattern
+    : public OpConversionPattern<mlir::triton::musa_tle::SetLayoutOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::triton::musa_tle::SetLayoutOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type convertedType = getTypeConverter()->convertType(op.getResult());
+    auto resultType = dyn_cast<RankedTensorType>(convertedType);
+    if (!resultType)
+      return rewriter.notifyMatchFailure(op, "expected ranked tensor result");
+
+    Value src = adaptor.getSrc();
+    if (src.getType() == resultType) {
+      if (auto srcResult = dyn_cast<OpResult>(src))
+        setTleExplicitResultEncoding(srcResult, op.getTargetEncoding());
+      rewriter.replaceOp(op, src);
+      return success();
+    }
+
+    auto convert = rewriter.replaceOpWithNewOp<triton::gpu::ConvertLayoutOp>(
+        op, resultType, src);
+    setTleExplicitResultEncoding(convert.getOperation(), 0,
+                                 op.getTargetEncoding());
+    return success();
+  }
+};
+
 void populateMUSATlePatterns(TritonGPUTypeConverter &typeConverter,
                              RewritePatternSet &patterns) {
   MLIRContext *context = patterns.getContext();
-  patterns.add<GenericOpPattern<mlir::triton::musa_tle::LocalPointersOp>,
+  patterns.add<MUSATLESetLayoutPattern,
+               GenericOpPattern<mlir::triton::musa_tle::LocalPointersOp>,
                GenericOpPattern<mlir::triton::musa_tle::ExclusiveCumsumOp>,
                GenericOpPattern<mlir::triton::musa_tle::SqmmaOp>,
                GenericOpPattern<mlir::triton::musa_tle::SqmmaWaitOp>,
                MUSATLEExtractTilePattern, MUSATLEInsertTilePattern>(
       typeConverter, context);
 }
-#endif
+#endif // __TLE__
 
 class ConvertTritonToTritonGPU
     : public triton::impl::ConvertTritonToTritonGPUBase<
@@ -903,8 +1575,15 @@ public:
     mod->setAttr(AttrNumCTAsName, b.getI32IntegerAttr(numCTAs));
     mod->setAttr(AttrTargetName, b.getStringAttr(this->target.getValue()));
 
+#ifdef __TLE__
+    if (failed(applyMusaTleEncodingHints(mod)))
+      return signalPassFailure();
     if (failed(applyPartialConversion(mod, target, std::move(patterns))))
       return signalPassFailure();
+#else
+    if (failed(applyPartialConversion(mod, target, std::move(patterns))))
+      return signalPassFailure();
+#endif // __TLE__
   }
 };
 

--- a/third_party/mthreads/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/third_party/mthreads/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -82,8 +82,13 @@ struct CanonicalizeConvertFromTMEMStore
   matchAndRewrite(nvidia_gpu::TMEMStoreOp op,
                   PatternRewriter &rewriter) const override {
     auto convert = op.getSrc().getDefiningOp<ConvertLayoutOp>();
+#ifdef __TLE__
+    if (!convert || isTleExplicitConvertLayoutOp(convert))
+      return failure();
+#else
     if (!convert)
       return failure();
+#endif // __TLE__
 
     // bail for incompatible layouts
     auto cvtSrcType = convert.getSrc().getType();
@@ -107,8 +112,13 @@ struct CanonicalizeConvertFromReshape
   matchAndRewrite(triton::ReshapeOp op,
                   PatternRewriter &rewriter) const override {
     auto convert = op.getSrc().getDefiningOp<ConvertLayoutOp>();
+#ifdef __TLE__
+    if (!convert || isTleExplicitConvertLayoutOp(convert))
+      return failure();
+#else
     if (!convert)
       return failure();
+#endif // __TLE__
     // If the layouts are structurally the same, the convert is trivial
     if (isConvertTrivial(convert)) {
       rewriter.replaceOpWithNewOp<triton::ReshapeOp>(
@@ -151,8 +161,14 @@ struct CanonicalizeConvertFromTranspose
 
     // If the layouts are structurally the same, the convert is trivial
     auto convert = op.getSrc().getDefiningOp<ConvertLayoutOp>();
+#ifdef __TLE__
+    if (!convert || isTleExplicitConvertLayoutOp(convert) ||
+        !isConvertTrivial(convert))
+      return failure();
+#else
     if (!convert || !isConvertTrivial(convert))
       return failure();
+#endif // __TLE__
 
     rewriter.replaceOpWithNewOp<triton::TransOp>(
         op, op.getType(), convert.getSrc(), op.getOrder());
@@ -170,9 +186,15 @@ struct CanonicalizeConvertFromHistogram
                   PatternRewriter &rewriter) const override {
     auto src = op.getSrc();
     auto convert = src.getDefiningOp<ConvertLayoutOp>();
+#ifdef __TLE__
+    if (!convert || isTleExplicitConvertLayoutOp(convert)) {
+      return failure();
+    }
+#else
     if (!convert) {
       return failure();
     }
+#endif // __TLE__
     src = convert.getSrc();
 
     // If mask is present, convert the layout of mask to match new src layout
@@ -205,8 +227,13 @@ struct CanonicalizeConvertFromGatherSource : public OpRewritePattern<GatherOp> {
       return failure();
 
     auto convert = op.getSrc().getDefiningOp<ConvertLayoutOp>();
+#ifdef __TLE__
+    if (!convert || isTleExplicitConvertLayoutOp(convert))
+      return failure();
+#else
     if (!convert)
       return failure();
+#endif // __TLE__
 
     rewriter.replaceOpWithNewOp<GatherOp>(op, convert.getSrc(), op.getIndices(),
                                           op.getAxis());
@@ -225,8 +252,13 @@ struct CanonicalizeConvertFromAlloc
     if (!op.getSrc())
       return failure();
     auto convert = op.getSrc().getDefiningOp<ConvertLayoutOp>();
+#ifdef __TLE__
+    if (!convert || isTleExplicitConvertLayoutOp(convert))
+      return failure();
+#else
     if (!convert)
       return failure();
+#endif // __TLE__
     SmallVector<NamedAttribute> attrs(op->getAttrs().begin(),
                                       op->getAttrs().end());
     auto newAlloc = triton::gpu::LocalAllocOp::create(
@@ -246,8 +278,13 @@ struct CanonicalizeConvertFromLocalStore
   matchAndRewrite(triton::gpu::LocalStoreOp op,
                   PatternRewriter &rewriter) const override {
     auto convert = op.getSrc().getDefiningOp<ConvertLayoutOp>();
+#ifdef __TLE__
+    if (!convert || isTleExplicitConvertLayoutOp(convert))
+      return failure();
+#else
     if (!convert)
       return failure();
+#endif // __TLE__
     rewriter.replaceOpWithNewOp<triton::gpu::LocalStoreOp>(op, convert.getSrc(),
                                                            op.getDst());
     return mlir::success();
@@ -262,8 +299,13 @@ struct CanonicalizeConvertFromSplit
   matchAndRewrite(triton::SplitOp op,
                   PatternRewriter &rewriter) const override {
     auto convert = op.getSrc().getDefiningOp<ConvertLayoutOp>();
+#ifdef __TLE__
+    if (!convert || isTleExplicitConvertLayoutOp(convert))
+      return failure();
+#else
     if (!convert)
       return failure();
+#endif // __TLE__
     auto srcEncoding = convert.getSrc().getType().getEncoding();
     // Multiple source layout can give the same output layout, if the source
     // layout of the convert gives the same destination layout we can skip the
@@ -283,6 +325,12 @@ struct CanonicalizeConvertFromConvert
   mlir::LogicalResult
   matchAndRewrite(ConvertLayoutOp op,
                   PatternRewriter &rewriter) const override {
+#ifdef __TLE__
+    if (isTleExplicitConvertLayoutOp(op))
+      return failure();
+#else
+    // Preserve the original non-TLE convert canonicalization entry.
+#endif // __TLE__
     // Convert to the same layout is redundant.
     if (op->getResultTypes() == op->getOperandTypes()) {
       rewriter.replaceOp(op, op->getOperands());
@@ -359,6 +407,12 @@ struct CanonicalizeConvertFromConvert
 
     // cvt(cvt(x, type1), type2) -> cvt(x, type2)
     if (auto cvt = dyn_cast<ConvertLayoutOp>(arg)) {
+#ifdef __TLE__
+      if (isTleExplicitConvertLayoutOp(cvt))
+        return failure();
+#else
+      // Preserve the original non-TLE nested-convert folding.
+#endif // __TLE__
       rewriter.replaceOpWithNewOp<triton::gpu::ConvertLayoutOp>(
           op, op->getResultTypes().front(), cvt.getSrc());
       return success();

--- a/third_party/mthreads/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/third_party/mthreads/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -83,6 +83,56 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
     // the pointers should have for best memory coalescing
     llvm::MapVector<Operation *, Attribute> layoutMap;
     int threadsPerWarp = TritonGPUDialect::getThreadsPerWarp(moduleOp);
+#ifdef __TLE__
+    bool failedExplicitEncoding = false;
+    moduleOp.walk([&](Operation *curr) {
+      if (failedExplicitEncoding)
+        return;
+      Value ptr = getMemAccessPtr(curr);
+      if (!ptr)
+        return;
+      // We only convert `tensor<tt.ptr<>>` load/store
+      bool isPtrTensor = false;
+      if (auto tensorType = dyn_cast<RankedTensorType>(ptr.getType()))
+        isPtrTensor = isa<PointerType>(tensorType.getElementType());
+      if (!isPtrTensor)
+        return;
+
+      Attribute explicitEncoding;
+      if (failed(inferTleExplicitMemoryEncoding(curr, explicitEncoding))) {
+        failedExplicitEncoding = true;
+        return;
+      }
+      auto tensorType = cast<RankedTensorType>(ptr.getType());
+      if (explicitEncoding) {
+        if (tensorType.getEncoding() != explicitEncoding) {
+          curr->emitOpError(
+              "has explicit MUSA TLE memory encoding that does not match "
+              "the pointer tensor encoding:\n  pointer: ")
+              << tensorType.getEncoding()
+              << "\n  explicit memory: " << explicitEncoding;
+          failedExplicitEncoding = true;
+          return;
+        }
+        LDBG(
+            "skip coalescing memory op with hard MUSA TLE encoding: " << *curr);
+        return;
+      }
+
+      int numWarps = lookupNumWarps(curr);
+      CGAEncodingAttr cgaLayout = getCGALayout(tensorType.getEncoding());
+      SmallVector<int64_t> shapePerCTA = getShapePerCTA(tensorType);
+      auto layout =
+          buildCoalescedEncoding(axisInfoAnalysis, curr, numWarps,
+                                 threadsPerWarp, cgaLayout, shapePerCTA);
+      layoutMap[curr] = layout;
+    });
+
+    if (failedExplicitEncoding) {
+      signalPassFailure();
+      return;
+    }
+#else
     moduleOp.walk([&](Operation *curr) {
       Value ptr = getMemAccessPtr(curr);
       if (!ptr)
@@ -103,6 +153,7 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
                                  threadsPerWarp, cgaLayout, shapePerCTA);
       layoutMap[curr] = layout;
     });
+#endif // __TLE__
 
     // Also pick a layout for descriptor load/store ops.
     pickDescriptorLoadStoreLayout(moduleOp, layoutMap);

--- a/third_party/mthreads/lib/Dialect/TritonGPU/Transforms/CoalesceAsyncCopy.cpp
+++ b/third_party/mthreads/lib/Dialect/TritonGPU/Transforms/CoalesceAsyncCopy.cpp
@@ -21,6 +21,26 @@ static Value convertValueLayout(Value src, Attribute enc,
   return cvt.getResult();
 }
 
+#ifdef __TLE__
+static FailureOr<bool>
+hasTleExplicitAsyncCopyEncoding(AsyncCopyGlobalToLocalOp copyOp) {
+  Attribute explicitEncoding;
+  if (failed(inferTleExplicitMemoryEncoding(copyOp, explicitEncoding)))
+    return failure();
+  if (!explicitEncoding)
+    return false;
+
+  auto srcTy = cast<RankedTensorType>(copyOp.getSrc().getType());
+  if (srcTy.getEncoding() != explicitEncoding) {
+    copyOp.emitOpError("has explicit MUSA TLE memory encoding that conflicts "
+                       "with the async-copy source encoding:\n  ")
+        << explicitEncoding << "\nand\n  " << srcTy.getEncoding();
+    return failure();
+  }
+  return true;
+}
+#endif // __TLE__
+
 static void retargetCopyOperandsToEncoding(
     AsyncCopyGlobalToLocalOp copyOp, Attribute newEncoding,
     ModuleAxisInfoAnalysis &axisInfoAnalysis, PatternRewriter &rewriter) {
@@ -79,6 +99,11 @@ struct ClipAsyncCopySizePerThread
 
   LogicalResult matchAndRewrite(AsyncCopyGlobalToLocalOp copyOp,
                                 PatternRewriter &rewriter) const override {
+#ifdef __TLE__
+    FailureOr<bool> explicitEncoding = hasTleExplicitAsyncCopyEncoding(copyOp);
+    if (failed(explicitEncoding) || *explicitEncoding)
+      return failure();
+#endif // __TLE__
     Value src = copyOp.getSrc();
     Value mask = copyOp.getMask();
     Value other = copyOp.getOther();
@@ -147,6 +172,11 @@ struct CoalesceCheapAsyncCopyGlobalToLocal
 
   LogicalResult matchAndRewrite(AsyncCopyGlobalToLocalOp copyOp,
                                 PatternRewriter &rewriter) const override {
+#ifdef __TLE__
+    FailureOr<bool> explicitEncoding = hasTleExplicitAsyncCopyEncoding(copyOp);
+    if (failed(explicitEncoding) || *explicitEncoding)
+      return failure();
+#endif // __TLE__
     Value src = copyOp.getSrc();
     Value mask = copyOp.getMask();
     Value other = copyOp.getOther();
@@ -185,7 +215,22 @@ struct CoalesceAsyncCopyPass
     // Collect the coalesced encoding first as changing the IR invalidates the
     // axis analysis.
     DenseMap<AsyncCopyGlobalToLocalOp, Attribute> coalescedAsyncCopyMap;
+#ifdef __TLE__
+    bool failedExplicitEncoding = false;
+#endif // __TLE__
     m.walk([&](AsyncCopyGlobalToLocalOp copyOp) {
+#ifdef __TLE__
+      if (failedExplicitEncoding)
+        return;
+      FailureOr<bool> explicitEncoding =
+          hasTleExplicitAsyncCopyEncoding(copyOp);
+      if (failed(explicitEncoding)) {
+        failedExplicitEncoding = true;
+        return;
+      }
+      if (*explicitEncoding)
+        return;
+#endif // __TLE__
       auto dstTy = cast<MemDescType>(copyOp.getResult().getType());
       int numWarps = triton::gpu::lookupNumWarps(copyOp);
       int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(m);
@@ -196,6 +241,12 @@ struct CoalesceAsyncCopyPass
           buildCoalescedEncoding(axisInfoAnalysis, copyOp, numWarps,
                                  threadsPerWarp, cgaLayout, shapePerCTA);
     });
+#ifdef __TLE__
+    if (failedExplicitEncoding) {
+      signalPassFailure();
+      return;
+    }
+#endif // __TLE__
 
     MLIRContext *context = &getContext();
 

--- a/third_party/mthreads/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/third_party/mthreads/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -22,6 +22,14 @@ namespace gpu {
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
 
 namespace {
+#ifdef __TLE__
+static bool hasTleExplicitResultEncoding(Operation *op) {
+  return llvm::any_of(op->getResults(), [&](OpResult result) {
+    return getTleExplicitResultEncoding(op, result.getResultNumber());
+  });
+}
+#endif // __TLE__
+
 // Change the destination layout of reshape ops allowing reorder when used by a
 // reduction in order to minimize the amount of cross thread communication for
 // the reduction.
@@ -33,6 +41,10 @@ struct OptimizeReshapeLayoutPattern : public OpRewritePattern<ReshapeOp> {
                                 PatternRewriter &rewriter) const override {
     if (!viewOp.getAllowReorder())
       return failure();
+#ifdef __TLE__
+    if (hasTleExplicitResultEncoding(viewOp))
+      return failure();
+#endif // __TLE__
     std::optional<int> reductionAxis;
     for (Operation *user : viewOp.getResult().getUsers()) {
       if (auto reduceOp = dyn_cast<triton::ReduceOp>(user)) {
@@ -230,6 +242,10 @@ struct OptimizeGatherLayoutPattern : public mlir::OpRewritePattern<GatherOp> {
                                 PatternRewriter &rewriter) const override {
     if (op.getEfficientLayout())
       return failure();
+#ifdef __TLE__
+    if (hasTleExplicitResultEncoding(op))
+      return failure();
+#endif // __TLE__
     return setOptimizedGatherLayout(op, rewriter);
   }
 };
@@ -281,6 +297,11 @@ class TritonGPUOptimizeThreadLocalityPass
       if (!reduce->hasOneUse())
         return;
       Operation *user = *(reduce->getUsers().begin());
+#ifdef __TLE__
+      if (hasTleExplicitResultEncoding(reduce) ||
+          hasTleExplicitResultEncoding(user))
+        return;
+#endif // __TLE__
       if (!user->hasOneUse())
         return;
       OpOperand &yieldOpOperand = *(user->getUses().begin());

--- a/third_party/mthreads/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/third_party/mthreads/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -66,8 +66,25 @@ public:
   // Structure to keep track of the layout associated to a value.
   struct LayoutInfo {
     LayoutInfo(Attribute encoding) { encodings.insert(encoding); }
+#ifdef __TLE__
+    LayoutInfo(Attribute encoding, bool hard) { add(encoding, hard); }
+#endif
     LayoutInfo() {}
+    void add(Attribute encoding) { encodings.insert(encoding); }
+#ifdef __TLE__
+    void add(Attribute encoding, bool hard) {
+      encodings.insert(encoding);
+      if (hard)
+        hardEncodings.insert(encoding);
+    }
+    bool isHard(Attribute encoding) const {
+      return hardEncodings.contains(encoding);
+    }
+#endif
     llvm::SmallSetVector<Attribute, 8> encodings;
+#ifdef __TLE__
+    llvm::SmallSetVector<Attribute, 8> hardEncodings;
+#endif
   };
   LayoutPropagation(FuncOp F) : funcOp(F) {}
   // Find the anchor ops and set their layout in the data structure.
@@ -189,6 +206,10 @@ void LayoutRematerialization::cleanup() {
 // Return true if the op is an op with a layout we don't want to change. We will
 // propagate the layout starting from anchor ops.
 bool isLayoutAnchor(Operation *op) {
+#ifdef __TLE__
+  if (isTleExplicitConvertLayoutOp(op))
+    return true;
+#endif // __TLE__
   if (isa<DescriptorOpInterface>(op))
     return true;
   if (isa<LoadOp, StoreOp>(op))
@@ -211,11 +232,21 @@ bool isLayoutAnchor(Operation *op) {
 }
 
 void LayoutPropagation::initAnchorLayout() {
+#ifdef __TLE__
+  auto addAnchor = [&](Value v, Attribute encoding = nullptr,
+                       bool hard = false) {
+    if (auto tensorType = dyn_cast<RankedTensorType>(v.getType())) {
+      Attribute anchorEncoding = encoding ? encoding : tensorType.getEncoding();
+      layouts[v].add(anchorEncoding, hard);
+    }
+  };
+#else
   auto addAnchor = [&](Value v) {
     if (auto tensorType = dyn_cast<RankedTensorType>(v.getType())) {
       layouts.insert({v, LayoutInfo(tensorType.getEncoding())});
     }
   };
+#endif // __TLE__
 
   // Consider function args as anchors.  This makes it easier to write tests --
   // you can pass a tensor with an encoding as an arg, instead of explicitly
@@ -227,7 +258,15 @@ void LayoutPropagation::initAnchorLayout() {
   funcOp.walk([&](Operation *op) {
     if (isLayoutAnchor(op)) {
       for (auto result : op->getResults()) {
+#ifdef __TLE__
+        bool hard = isTleExplicitConvertLayoutOp(op);
+        Attribute explicitEncoding =
+            hard ? getTleExplicitResultEncoding(op, result.getResultNumber())
+                 : nullptr;
+        addAnchor(result, explicitEncoding, hard);
+#else
         addAnchor(result);
+#endif // __TLE__
       }
     }
   });
@@ -249,8 +288,17 @@ void LayoutPropagation::setEncoding(ValueRange values, LayoutInfo &info,
       } else {
         dstEncoding = inferDstEncoding(op, encoding);
       }
+#ifdef __TLE__
+      if (dstEncoding) {
+        auto &layoutInfo = layouts[value];
+        hasChanged |= layoutInfo.encodings.insert(dstEncoding);
+        if (info.isHard(encoding))
+          hasChanged |= layoutInfo.hardEncodings.insert(dstEncoding);
+      }
+#else
       if (dstEncoding)
         hasChanged |= layouts[value].encodings.insert(dstEncoding);
+#endif // __TLE__
     }
     if (hasChanged)
       changed.push_back(value);
@@ -352,6 +400,16 @@ void LayoutPropagation::resolveConflicts() {
     LayoutInfo &info = it.second;
     if (info.encodings.size() <= 1)
       continue;
+#ifdef __TLE__
+    if (!info.hardEncodings.empty()) {
+      Attribute encoding = *info.hardEncodings.begin();
+      info.encodings.clear();
+      info.encodings.insert(encoding);
+      info.hardEncodings.clear();
+      info.hardEncodings.insert(encoding);
+      continue;
+    }
+#endif // __TLE__
     // Hacky resolve, prefer block encoding.
     // TODO: add a proper heuristic.
     Attribute encoding = *info.encodings.begin();
@@ -378,6 +436,10 @@ void LayoutPropagation::dump() {
     llvm::errs() << " \n encoding:\n";
     for (auto encoding : it.second.encodings) {
       encoding.print(llvm::errs());
+#ifdef __TLE__
+      if (it.second.hardEncodings.contains(encoding))
+        llvm::errs() << " [hard]";
+#endif // __TLE__
       llvm::errs() << "\n";
     }
     llvm::errs() << "--\n";
@@ -728,6 +790,10 @@ Operation *LayoutPropagation::rewriteOp(Operation *op) {
     auto tensorType = cast<RankedTensorType>(op->getResult(0).getType());
     auto newType = tensorType.cloneWithEncoding(encoding);
     auto cvt = ConvertLayoutOp::create(rewriter, op->getLoc(), newType, src);
+#ifdef __TLE__
+    if (Attribute explicitEncoding = getTleExplicitResultEncoding(op, 0))
+      setTleExplicitResultEncoding(cvt.getOperation(), 0, explicitEncoding);
+#endif // __TLE__
     map(op->getResult(0), cvt.getResult());
     return cvt.getOperation();
   }
@@ -761,6 +827,10 @@ Operation *LayoutPropagation::rewriteOp(Operation *op) {
 }
 
 bool canBeRemat(Operation *op) {
+#ifdef __TLE__
+  if (isTleExplicitConvertLayoutOp(op))
+    return false;
+#endif // __TLE__
   if (isa<LoadOp, StoreOp>(op))
     return !isExpensiveLoadOrStore(op);
   if (isa<AtomicRMWOp, AtomicCASOp, DotOp>(op))
@@ -1121,6 +1191,10 @@ static int64_t getByteCount(Value result, int64_t minElementCount = 0,
 
 void LayoutRematerialization::backwardRematerialization(
     ConvertLayoutOp convertOp) {
+#ifdef __TLE__
+  if (isTleExplicitConvertLayoutOp(convertOp))
+    return;
+#endif // __TLE__
   // DotOperand is hoisted by hoistDotOperand
   RankedTensorType targetType = convertOp.getType();
   if (isa<DotOperandEncodingAttr>(targetType.getEncoding()))
@@ -1291,6 +1365,10 @@ void LayoutRematerialization::hoistConvertDotOperand() {
 
 void LayoutRematerialization::hoistConvertDotOperand(
     ConvertLayoutOp convertOp) {
+#ifdef __TLE__
+  if (isTleExplicitConvertLayoutOp(convertOp))
+    return;
+#endif // __TLE__
   auto targetType = convertOp.getType();
   // The pass is targeted to MMA dot operands
 
@@ -1331,6 +1409,10 @@ void LayoutRematerialization::hoistConvertDotOperand(
   // We hoist over any operation that can be done without data movement between
   // threads We do views and elementwise pure ops for now
   auto noDataMovement = [](Operation *op) {
+#ifdef __TLE__
+    if (isTleExplicitConvertLayoutOp(op))
+      return false;
+#endif // __TLE__
     return (op->hasTrait<OpTrait::Elementwise>() && isMemoryEffectFree(op)) ||
            isa<BroadcastOp, Fp4ToFpOp, ConvertLayoutOp, UpcastFpOpInterface>(
                op) ||
@@ -1401,6 +1483,10 @@ void LayoutRematerialization::hoistConvertDotOperand(
 // of the convert.
 void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
     ConvertLayoutOp convertOp) {
+#ifdef __TLE__
+  if (isTleExplicitConvertLayoutOp(convertOp))
+    return;
+#endif // __TLE__
   // DotOperand is hoisted by hoistDotOperand
   RankedTensorType targetType = convertOp.getType();
   if (isa<DotOperandEncodingAttr>(targetType.getEncoding()))
@@ -1482,6 +1568,10 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
 
 void LayoutRematerialization::hoistConvertIntoConditionals(
     ConvertLayoutOp convertOp) {
+#ifdef __TLE__
+  if (isTleExplicitConvertLayoutOp(convertOp))
+    return;
+#endif // __TLE__
   // Take the backward slice of tensor dependencies rooted at the conversion,
   // stopping at conditionals. This subslice is used to initialize the analysis.
   SetVector<Value> slice;
@@ -1612,6 +1702,8 @@ bool retargetTleSqmmaStores(ModuleOp module) {
     auto valueConvert = store.getValue().getDefiningOp<ConvertLayoutOp>();
     if (!valueConvert)
       continue;
+    if (isTleExplicitConvertLayoutOp(valueConvert))
+      continue;
     auto targetTy = dyn_cast<RankedTensorType>(valueConvert.getSrc().getType());
     if (!targetTy || !targetTy.getEncoding())
       continue;
@@ -1719,8 +1811,6 @@ public:
         changed |= retargetTleSqmmaStores(m);
         cleanupConvertOps();
       }
-#else
-      // Preserve the original non-TLE fixed-point behavior.
 #endif // __TLE__
     } while (changed);
     // 3. For remaining converts, try to hoist them above cast generating larger

--- a/third_party/mthreads/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/third_party/mthreads/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -26,6 +26,105 @@ namespace mlir {
 
 using namespace triton;
 
+#ifdef __TLE__
+static constexpr const char *kTleExplicitEncodingAttrPrefix =
+    "tle.explicit_encoding.";
+static constexpr const char *kTleExplicitMemoryEncodingAttrName =
+    "tle.explicit_memory_encoding";
+
+const char *getTleExplicitEncodingAttrPrefix() {
+  return kTleExplicitEncodingAttrPrefix;
+}
+
+std::string getTleExplicitEncodingAttrName(unsigned resultNumber) {
+  return std::string(kTleExplicitEncodingAttrPrefix) +
+         std::to_string(resultNumber);
+}
+
+const char *getTleExplicitMemoryEncodingAttrName() {
+  return kTleExplicitMemoryEncodingAttrName;
+}
+
+Attribute getTleExplicitResultEncoding(Operation *op, unsigned resultNumber) {
+  return op->getAttr(getTleExplicitEncodingAttrName(resultNumber));
+}
+
+void setTleExplicitResultEncoding(Operation *op, unsigned resultNumber,
+                                  Attribute encoding) {
+  op->setAttr(getTleExplicitEncodingAttrName(resultNumber), encoding);
+}
+
+void setTleExplicitResultEncoding(OpResult result, Attribute encoding) {
+  setTleExplicitResultEncoding(result.getOwner(), result.getResultNumber(),
+                               encoding);
+}
+
+Attribute getTleExplicitMemoryEncoding(Operation *op) {
+  return op->getAttr(kTleExplicitMemoryEncodingAttrName);
+}
+
+void setTleExplicitMemoryEncoding(Operation *op, Attribute encoding) {
+  op->setAttr(kTleExplicitMemoryEncodingAttrName, encoding);
+}
+
+Attribute getTleExplicitValueEncoding(Value value) {
+  if (auto result = dyn_cast<OpResult>(value))
+    return getTleExplicitResultEncoding(result.getOwner(),
+                                        result.getResultNumber());
+  return nullptr;
+}
+
+static LogicalResult mergeTleExplicitMemoryEncoding(Operation *op, Value value,
+                                                    Attribute candidate,
+                                                    Attribute &encoding) {
+  if (!candidate)
+    return success();
+
+  if (auto tensorType = dyn_cast<RankedTensorType>(value.getType())) {
+    if (tensorType.getEncoding() != candidate)
+      return op->emitOpError(
+          "has explicit MUSA TLE encoding that does not match the tensor "
+          "type encoding");
+  }
+
+  if (!encoding) {
+    encoding = candidate;
+    return success();
+  }
+  if (encoding == candidate)
+    return success();
+
+  op->emitOpError("has conflicting explicit MUSA TLE memory encodings:\n  ")
+      << encoding << "\nand\n  " << candidate;
+  return failure();
+}
+
+LogicalResult inferTleExplicitMemoryEncoding(Operation *op,
+                                             Attribute &encoding) {
+  encoding = getTleExplicitMemoryEncoding(op);
+
+  for (OpResult result : op->getResults()) {
+    if (failed(mergeTleExplicitMemoryEncoding(
+            op, result,
+            getTleExplicitResultEncoding(op, result.getResultNumber()),
+            encoding)))
+      return failure();
+  }
+
+  for (OpOperand &operand : op->getOpOperands()) {
+    if (failed(mergeTleExplicitMemoryEncoding(
+            op, operand.get(), getTleExplicitValueEncoding(operand.get()),
+            encoding)))
+      return failure();
+  }
+  return success();
+}
+
+bool isTleExplicitConvertLayoutOp(Operation *op) {
+  return isa<ttg::ConvertLayoutOp>(op) && getTleExplicitResultEncoding(op, 0);
+}
+#endif // __TLE__
+
 static bool isPassthroughWaitLikeOp(Operation *op) {
   return op->hasTrait<mlir::OpTrait::PassthroughWaitLike>();
 }
@@ -1257,8 +1356,22 @@ Operation *convertDistributedOpEncoding(Attribute encoding, Operation *op) {
   for (size_t i = 0; i < op->getNumResults(); i++) {
     Value newResult = newOp->getResult(i);
     if (newTypes[i] != op->getResultTypes()[i]) {
+#ifdef __TLE__
+      auto convert = triton::gpu::ConvertLayoutOp::create(
+          builder, op->getLoc(), op->getResult(i).getType(), newResult);
+      newResult = convert.getResult();
+      if (Attribute explicitEncoding = getTleExplicitResultEncoding(op, i)) {
+        // The rebuilt op uses the optimized encoding while the bridge restores
+        // the original hard encoding. Transfer ownership result by result so
+        // the explicit marker always matches the type of its owning result.
+        newOp->removeAttr(getTleExplicitEncodingAttrName(i));
+        setTleExplicitResultEncoding(convert.getOperation(), 0,
+                                     explicitEncoding);
+      }
+#else
       newResult = triton::gpu::ConvertLayoutOp::create(
           builder, op->getLoc(), op->getResult(i).getType(), newResult);
+#endif // __TLE__
     }
     op->getResult(i).replaceAllUsesWith(newResult);
   }

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/AccelerateMUSAMatmul.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/AccelerateMUSAMatmul.cpp
@@ -1,5 +1,9 @@
 #include "Dialect/MUSA/IR/Dialect.h"
 #include "TritonMUSACommon/MMAContractUtils.h"
+#ifdef __TLE__
+#include "TritonMUSACommon/MMAEncodingUtils.h"
+#include "TritonMUSACommon/MMAOperandUtils.h"
+#endif // __TLE__
 #include "TritonMUSACommon/MemDescUtils.h"
 #include "TritonMUSACommon/SqmmaAttrUtils.h"
 #include "TritonMUSAGPUTransforms/Passes.h"
@@ -115,6 +119,112 @@ struct SelectedConfig {
   SmallVector<unsigned, 2> warpsPerCTA;
 };
 
+#ifdef __TLE__
+static bool isSupportedSqmmaOperandType(Type elemTy, bool allowTF32);
+
+enum class MusaMmaValidationFailure {
+  None,
+  InvalidDotShape,
+  MismatchedOperandType,
+  UnsupportedOperandType,
+  TF32PrecisionRequired,
+  UnsupportedEncodingVersion,
+  InvalidInstructionShape,
+  UnsupportedInstruction,
+  InvalidWarpLayout,
+  InvalidSquadLayout,
+  UnsupportedAccumulatorType,
+  UnsupportedTransposeOperand,
+  UnsupportedTarget,
+  MismatchedExplicitResultEncoding,
+  InvalidDotOperandEncoding,
+  InvalidDotOperandIndex,
+  InvalidDotOperandKWidth,
+  MismatchedDotOperandParent,
+  MismatchedAccumulatorEncoding,
+  ExplicitWmmaDisabled,
+  ExplicitSqmmaDisabled,
+};
+
+struct MusaMmaValidationResult {
+  MusaMmaValidationFailure failure = MusaMmaValidationFailure::None;
+
+  bool succeeded() const { return failure == MusaMmaValidationFailure::None; }
+};
+
+[[maybe_unused]] static StringRef
+getMusaMmaValidationMessage(MusaMmaValidationFailure failure) {
+  switch (failure) {
+  case MusaMmaValidationFailure::None:
+    return "";
+  case MusaMmaValidationFailure::InvalidDotShape:
+    return "dot operands and result must form a rank-2 or rank-3 MxK, KxN, "
+           "MxN contract";
+  case MusaMmaValidationFailure::MismatchedOperandType:
+    return "MUSA MMA operands A and B must use the same element type";
+  case MusaMmaValidationFailure::UnsupportedOperandType:
+    return "MUSA MMA operand element type is unsupported";
+  case MusaMmaValidationFailure::TF32PrecisionRequired:
+    return "MUSA MMA f32 operands require TF32 input precision";
+  case MusaMmaValidationFailure::UnsupportedEncodingVersion:
+    return "MUSA MMA encoding version is unsupported by the mthreads backend";
+  case MusaMmaValidationFailure::InvalidInstructionShape:
+    return "MUSA MMA instruction shape must contain logical M, N and K and "
+           "divide the dot shape";
+  case MusaMmaValidationFailure::UnsupportedInstruction:
+    return "MUSA MMA instruction shape and element types are unsupported";
+  case MusaMmaValidationFailure::InvalidWarpLayout:
+    return "MUSA MMA warp layout must match the module warp count";
+  case MusaMmaValidationFailure::InvalidSquadLayout:
+    return "MUSA SQMMA warp layout must form complete four-warp squad tiles";
+  case MusaMmaValidationFailure::UnsupportedAccumulatorType:
+    return "MUSA SQMMA accumulator element type is unsupported";
+  case MusaMmaValidationFailure::UnsupportedTransposeOperand:
+    return "MUSA SQMMA operand cannot be materialized in shared memory";
+  case MusaMmaValidationFailure::UnsupportedTarget:
+    return "explicit MUSA MMA requires the PH1 compute capability";
+  case MusaMmaValidationFailure::MismatchedExplicitResultEncoding:
+    return "the explicit result encoding does not match the MUSA MMA result "
+           "type";
+  case MusaMmaValidationFailure::InvalidDotOperandEncoding:
+    return "explicit MUSA MMA operands A and B must use "
+           "DotOperandEncodingAttr";
+  case MusaMmaValidationFailure::InvalidDotOperandIndex:
+    return "explicit MUSA MMA operands A and B must use dot operand indices 0 "
+           "and 1";
+  case MusaMmaValidationFailure::InvalidDotOperandKWidth:
+    return "explicit MUSA MMA operands do not support a non-zero kWidth";
+  case MusaMmaValidationFailure::MismatchedDotOperandParent:
+    return "explicit MUSA MMA operand layouts must use the result encoding as "
+           "their parent";
+  case MusaMmaValidationFailure::MismatchedAccumulatorEncoding:
+    return "explicit MUSA MMA accumulator and result must use the same "
+           "encoding";
+  case MusaMmaValidationFailure::ExplicitWmmaDisabled:
+    return "DISABLE_WMMA conflicts with an explicit MUSA WMMA layout";
+  case MusaMmaValidationFailure::ExplicitSqmmaDisabled:
+    return "DISABLE_SQMMA conflicts with an explicit MUSA SQMMA layout";
+  }
+  llvm_unreachable("unknown MUSA MMA validation failure");
+}
+
+static bool isValidMusaMmaWarpLayout(ArrayRef<unsigned> warpsPerCTA,
+                                     unsigned numWarps) {
+  if (warpsPerCTA.size() != 2 && warpsPerCTA.size() != 3)
+    return false;
+  if (warpsPerCTA.size() == 3 && warpsPerCTA.back() != 1)
+    return false;
+
+  unsigned warpProduct = 1;
+  for (unsigned warps : warpsPerCTA) {
+    if (!llvm::isPowerOf2_32(warps))
+      return false;
+    warpProduct *= warps;
+  }
+  return warpProduct == numWarps;
+}
+#endif // __TLE__
+
 struct DotMatrixShape {
   unsigned rank;
   unsigned batch;
@@ -153,6 +263,186 @@ static FailureOr<DotMatrixShape> getDotMatrixShape(tt::DotOp dotOp) {
                         static_cast<unsigned>(m), static_cast<unsigned>(n),
                         static_cast<unsigned>(k)};
 }
+
+#ifdef __TLE__
+enum class SqmmaTransLoadKind {
+  None,       // No transpose exists on the operand load chain.
+  PlainLoad,  // A LSU-fed load chain contains a tt.trans.
+  Descriptor, // A descriptor-fed load chain contains a tt.trans.
+};
+
+static SqmmaTransLoadKind classifySqmmaTransLoad(Value value);
+
+struct MusaDotProblem {
+  Value a;
+  Value b;
+  RankedTensorType aType;
+  RankedTensorType bType;
+  RankedTensorType cType;
+  RankedTensorType dType;
+  DotMatrixShape matrixShape;
+  Type aElemType;
+  Type bElemType;
+  Type dElemType;
+  bool allowTF32;
+  unsigned numWarps;
+  SqmmaTransLoadKind transLoadKindA;
+  SqmmaTransLoadKind transLoadKindB;
+};
+
+static FailureOr<MusaDotProblem> getMusaDotProblem(tt::DotOp dotOp) {
+  auto aType = dyn_cast<RankedTensorType>(dotOp.getA().getType());
+  auto bType = dyn_cast<RankedTensorType>(dotOp.getB().getType());
+  auto cType = dyn_cast<RankedTensorType>(dotOp.getC().getType());
+  auto dType = dyn_cast<RankedTensorType>(dotOp.getType());
+  auto matrixShape = getDotMatrixShape(dotOp);
+  if (!aType || !bType || !cType || !dType || failed(matrixShape))
+    return failure();
+  unsigned rank = matrixShape->rank;
+  if (cType.getRank() != rank || dType.getRank() != rank ||
+      aType.getShape()[rank - 1] != bType.getShape()[rank - 2] ||
+      aType.getShape()[rank - 2] != cType.getShape()[rank - 2] ||
+      bType.getShape()[rank - 1] != cType.getShape()[rank - 1] ||
+      cType.getShape() != dType.getShape())
+    return failure();
+  if (rank == 3 && (aType.getShape()[0] != bType.getShape()[0] ||
+                    aType.getShape()[0] != cType.getShape()[0]))
+    return failure();
+
+  return MusaDotProblem{
+      dotOp.getA(),
+      dotOp.getB(),
+      aType,
+      bType,
+      cType,
+      dType,
+      *matrixShape,
+      aType.getElementType(),
+      bType.getElementType(),
+      dType.getElementType(),
+      dotOp.getInputPrecision() == tt::InputPrecision::TF32,
+      static_cast<unsigned>(ttg::lookupNumWarps(dotOp)),
+      classifySqmmaTransLoad(dotOp.getA()),
+      classifySqmmaTransLoad(dotOp.getB()),
+  };
+}
+
+static MusaMmaValidationResult
+validateMusaDotProblem(const MusaDotProblem &problem, bool useSqmma) {
+  if (problem.aElemType != problem.bElemType)
+    return {MusaMmaValidationFailure::MismatchedOperandType};
+  if (problem.aElemType.isF32() && !problem.allowTF32)
+    return {MusaMmaValidationFailure::TF32PrecisionRequired};
+  bool supported =
+      useSqmma
+          ? isSupportedSqmmaOperandType(problem.aElemType, problem.allowTF32)
+          : isSupportedWmmaOperandType(problem.aElemType, problem.allowTF32);
+  if (!supported)
+    return {MusaMmaValidationFailure::UnsupportedOperandType};
+  return {};
+}
+
+static MusaMmaValidationResult
+validateWmmaConfig(const MusaDotProblem &problem, const SelectedConfig &config,
+                   ttg::MUSAWmmaEncodingAttr encoding = {}) {
+  if (encoding && !triton::musa::supportsMusaWmmaEncoding(encoding))
+    return {MusaMmaValidationFailure::UnsupportedEncodingVersion};
+  if (!isValidMusaMmaWarpLayout(config.warpsPerCTA, problem.numWarps))
+    return {MusaMmaValidationFailure::InvalidWarpLayout};
+  if (config.instrShape.size() != 3)
+    return {MusaMmaValidationFailure::InvalidInstructionShape};
+  unsigned m = problem.matrixShape.m;
+  unsigned n = problem.matrixShape.n;
+  unsigned k = problem.matrixShape.k;
+  if (config.instrShape[0] == 0 || config.instrShape[1] == 0 ||
+      config.instrShape[2] == 0 || m % config.instrShape[0] != 0 ||
+      n % config.instrShape[1] != 0 || k % config.instrShape[2] != 0)
+    return {MusaMmaValidationFailure::InvalidInstructionShape};
+  if (!triton::musa::lookupWmmaIntrinsic(problem.aElemType, config.instrShape))
+    return {MusaMmaValidationFailure::UnsupportedInstruction};
+  return {};
+}
+
+static SelectedConfig
+getExplicitWmmaConfig(ttg::MUSAWmmaEncodingAttr encoding) {
+  SelectedConfig config;
+  llvm::append_range(config.instrShape, encoding.getInstrShape());
+  llvm::append_range(config.warpsPerCTA, encoding.getWarpsPerCTA());
+  return config;
+}
+
+static MusaMmaValidationResult
+validateExplicitWmmaContract(tt::DotOp dotOp, const MusaDotProblem &problem,
+                             ttg::MUSAWmmaEncodingAttr encoding) {
+  Attribute explicitEncoding =
+      getTleExplicitResultEncoding(dotOp.getOperation(), 0);
+  if (explicitEncoding && explicitEncoding != encoding)
+    return {MusaMmaValidationFailure::MismatchedExplicitResultEncoding};
+
+  auto aEncoding = dyn_cast_or_null<ttg::DotOperandEncodingAttr>(
+      problem.aType.getEncoding());
+  auto bEncoding = dyn_cast_or_null<ttg::DotOperandEncodingAttr>(
+      problem.bType.getEncoding());
+  if (!aEncoding || !bEncoding)
+    return {MusaMmaValidationFailure::InvalidDotOperandEncoding};
+  if (aEncoding.getOpIdx() != 0 || bEncoding.getOpIdx() != 1)
+    return {MusaMmaValidationFailure::InvalidDotOperandIndex};
+  if (aEncoding.getKWidth() != 0 || bEncoding.getKWidth() != 0)
+    return {MusaMmaValidationFailure::InvalidDotOperandKWidth};
+  if (aEncoding.getParent() != encoding || bEncoding.getParent() != encoding)
+    return {MusaMmaValidationFailure::MismatchedDotOperandParent};
+  if (problem.cType.getEncoding() != encoding ||
+      problem.dType.getEncoding() != encoding)
+    return {MusaMmaValidationFailure::MismatchedAccumulatorEncoding};
+
+  MusaMmaValidationResult problemValidation =
+      validateMusaDotProblem(problem, false);
+  if (!problemValidation.succeeded())
+    return problemValidation;
+  return validateWmmaConfig(problem, getExplicitWmmaConfig(encoding), encoding);
+}
+
+static LogicalResult emitExplicitWmmaError(tt::DotOp dotOp,
+                                           MusaMmaValidationFailure failure) {
+  return dotOp.emitOpError("cannot lower explicit MUSA WMMA dot: ")
+         << getMusaMmaValidationMessage(failure);
+}
+
+static LogicalResult validateExplicitWmmaDots(ModuleOp module,
+                                              int computeCapability,
+                                              bool disableWmma) {
+  WalkResult result = module.walk([&](tt::DotOp dotOp) -> WalkResult {
+    auto resultType = dyn_cast<RankedTensorType>(dotOp.getType());
+    auto encoding = resultType ? dyn_cast_or_null<ttg::MUSAWmmaEncodingAttr>(
+                                     resultType.getEncoding())
+                               : ttg::MUSAWmmaEncodingAttr{};
+    if (!encoding)
+      return WalkResult::advance();
+    if (computeCapability != 31) {
+      emitExplicitWmmaError(dotOp, MusaMmaValidationFailure::UnsupportedTarget);
+      return WalkResult::interrupt();
+    }
+    if (disableWmma) {
+      emitExplicitWmmaError(dotOp,
+                            MusaMmaValidationFailure::ExplicitWmmaDisabled);
+      return WalkResult::interrupt();
+    }
+    auto problem = getMusaDotProblem(dotOp);
+    if (failed(problem)) {
+      emitExplicitWmmaError(dotOp, MusaMmaValidationFailure::InvalidDotShape);
+      return WalkResult::interrupt();
+    }
+    MusaMmaValidationResult validation =
+        validateExplicitWmmaContract(dotOp, *problem, encoding);
+    if (!validation.succeeded()) {
+      emitExplicitWmmaError(dotOp, validation.failure);
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return failure(result.wasInterrupted());
+}
+#endif // __TLE__
 
 static bool isKnownBrokenSqmmaConfig(Type elemTy, bool allowTF32,
                                      ArrayRef<unsigned> instrShape) {
@@ -251,8 +541,18 @@ static SqmmaAccumulationContract selectSqmmaAccumulationContract(
 }
 
 static std::optional<SelectedConfig>
+#ifdef __TLE__
+selectWmmaConfig(const MusaDotProblem &problem) {
+  unsigned m = problem.matrixShape.m;
+  unsigned n = problem.matrixShape.n;
+  unsigned k = problem.matrixShape.k;
+  unsigned numWarps = problem.numWarps;
+  Type elemTy = problem.aElemType;
+  bool allowTF32 = problem.allowTF32;
+#else
 selectWmmaConfig(unsigned m, unsigned n, unsigned k, unsigned numWarps,
                  Type elemTy, bool allowTF32) {
+#endif // __TLE__
   if (numWarps == 0 || (numWarps & (numWarps - 1)) != 0)
     return std::nullopt;
 
@@ -263,13 +563,21 @@ selectWmmaConfig(unsigned m, unsigned n, unsigned k, unsigned numWarps,
   unsigned bestInstCount = 0;
 
   for (const auto &shape : candidates) {
+#ifdef __TLE__
+    SelectedConfig candidate;
+    candidate.instrShape = shape;
+    candidate.warpsPerCTA = selectWmmaWarpsPerCTAForPH1(m, n, numWarps, shape);
+    if (!validateWmmaConfig(problem, candidate).succeeded())
+      continue;
+#else
     if (!triton::musa::lookupWmmaIntrinsic(elemTy, shape))
       continue;
+    if (m % shape[0] != 0 || n % shape[1] != 0 || k % shape[2] != 0)
+      continue;
+#endif // __TLE__
     unsigned instM = shape[0];
     unsigned instN = shape[1];
     unsigned instK = shape[2];
-    if (m % instM != 0 || n % instN != 0 || k % instK != 0)
-      continue;
     unsigned instCount = (m / instM) * (n / instN) * (k / instK);
     if (!found || instCount < bestInstCount) {
       bestInstCount = instCount;
@@ -317,11 +625,13 @@ static SmallVector<unsigned> getSqmmaCandidateK(Type elemTy, bool allowTF32) {
   return {};
 }
 
+#ifndef __TLE__
 enum class SqmmaTransLoadKind {
   None,       // No transpose exists on the operand load chain.
   PlainLoad,  // A LSU-fed load chain contains a tt.trans.
   Descriptor, // A descriptor-fed load chain contains a tt.trans.
 };
+#endif // __TLE__
 
 static SqmmaTransLoadKind classifySqmmaTransLoad(Value v) {
   Value cur = v;
@@ -346,6 +656,181 @@ static SqmmaTransLoadKind classifySqmmaTransLoad(Value v) {
                : SqmmaTransLoadKind::PlainLoad;
   }
 }
+
+#ifdef __TLE__
+static MusaMmaValidationResult
+validateSqmmaOperandMaterialization(Value operand) {
+  auto operandType = dyn_cast<RankedTensorType>(operand.getType());
+  if (!operandType)
+    return {MusaMmaValidationFailure::UnsupportedTransposeOperand};
+  bool needTranspose =
+      classifySqmmaTransLoad(operand) != SqmmaTransLoadKind::None;
+  if (auto dotEncoding = dyn_cast_or_null<ttg::DotOperandEncodingAttr>(
+          operandType.getEncoding());
+      dotEncoding && isa<ttg::MUSASqmmaEncodingAttr>(dotEncoding.getParent())) {
+    auto sharedLayout = triton::musa::composeMusaOperandSharedLayout(
+        dotEncoding, operandType.getShape(),
+        ttg::getOrderForMemory(operandType),
+        ttg::getCGALayout(dotEncoding.getParent()),
+        operandType.getElementType(), needTranspose);
+    if (!sharedLayout)
+      return {MusaMmaValidationFailure::UnsupportedTransposeOperand};
+  }
+
+  Value current = operand;
+  while (true) {
+    if (auto convert = current.getDefiningOp<ttg::ConvertLayoutOp>()) {
+      current = convert.getSrc();
+      continue;
+    }
+    if (auto bitcast = current.getDefiningOp<tt::BitcastOp>()) {
+      current = bitcast.getSrc();
+      continue;
+    }
+    break;
+  }
+
+  if (auto trans = current.getDefiningOp<tt::TransOp>())
+    current = trans.getSrc();
+  while (auto bitcast = current.getDefiningOp<tt::BitcastOp>())
+    current = bitcast.getSrc();
+
+  auto tensorType = dyn_cast<RankedTensorType>(current.getType());
+  if (!tensorType || !tensorType.getEncoding() ||
+      (tensorType.getRank() != 2 && tensorType.getRank() != 3))
+    return {MusaMmaValidationFailure::UnsupportedTransposeOperand};
+  return {};
+}
+
+static MusaMmaValidationResult
+validateSqmmaConfig(const MusaDotProblem &problem, const SelectedConfig &config,
+                    ttg::MUSASqmmaEncodingAttr encoding = {}) {
+  if (encoding && !triton::musa::supportsMusaSqmmaEncoding(encoding))
+    return {MusaMmaValidationFailure::UnsupportedEncodingVersion};
+  if (!isValidMusaMmaWarpLayout(config.warpsPerCTA, problem.numWarps))
+    return {MusaMmaValidationFailure::InvalidWarpLayout};
+  if (config.instrShape.size() != 3)
+    return {MusaMmaValidationFailure::InvalidInstructionShape};
+
+  unsigned m = problem.matrixShape.m;
+  unsigned n = problem.matrixShape.n;
+  unsigned k = problem.matrixShape.k;
+  unsigned instM = config.instrShape[0];
+  unsigned instN = config.instrShape[1];
+  unsigned instK = config.instrShape[2];
+  if (instM == 0 || instN == 0 || instK == 0 || m % instM != 0 ||
+      n % instN != 0 || k % instK != 0)
+    return {MusaMmaValidationFailure::InvalidInstructionShape};
+
+  unsigned warpsM = config.warpsPerCTA[0];
+  unsigned warpsN = config.warpsPerCTA[1];
+  if (warpsM < 4 || warpsM % 4 != 0 || m % (instM * (warpsM / 4)) != 0 ||
+      n % (instN * warpsN) != 0)
+    return {MusaMmaValidationFailure::InvalidSquadLayout};
+
+  auto eltTypeA = toSqmmaOperandEltType(problem.aElemType, problem.allowTF32);
+  auto eltTypeB = toSqmmaOperandEltType(problem.bElemType, problem.allowTF32);
+  bool useFp32Carrier = problem.dElemType.isF16() &&
+                        problem.aElemType.isF16() && problem.bElemType.isF16();
+  Type carrierElemType = useFp32Carrier
+                             ? Float32Type::get(problem.dType.getContext())
+                             : problem.dElemType;
+  auto eltTypeC = toSqmmaEltType(carrierElemType);
+  if (!eltTypeC)
+    return {MusaMmaValidationFailure::UnsupportedAccumulatorType};
+  if (!eltTypeA || !eltTypeB ||
+      !triton::musa::isSupportedSqmma(*eltTypeA, *eltTypeB, *eltTypeC, instM,
+                                      instN, instK))
+    return {MusaMmaValidationFailure::UnsupportedInstruction};
+
+  if (!validateSqmmaOperandMaterialization(problem.a).succeeded() ||
+      !validateSqmmaOperandMaterialization(problem.b).succeeded())
+    return {MusaMmaValidationFailure::UnsupportedTransposeOperand};
+  return {};
+}
+
+static SelectedConfig
+getExplicitSqmmaConfig(ttg::MUSASqmmaEncodingAttr encoding) {
+  SelectedConfig config;
+  llvm::append_range(config.instrShape, encoding.getInstrShape());
+  llvm::append_range(config.warpsPerCTA, encoding.getWarpsPerCTA());
+  return config;
+}
+
+static MusaMmaValidationResult
+validateExplicitSqmmaContract(tt::DotOp dotOp, const MusaDotProblem &problem,
+                              ttg::MUSASqmmaEncodingAttr encoding) {
+  Attribute explicitEncoding =
+      getTleExplicitResultEncoding(dotOp.getOperation(), 0);
+  if (explicitEncoding && explicitEncoding != encoding)
+    return {MusaMmaValidationFailure::MismatchedExplicitResultEncoding};
+
+  auto aEncoding = dyn_cast_or_null<ttg::DotOperandEncodingAttr>(
+      problem.aType.getEncoding());
+  auto bEncoding = dyn_cast_or_null<ttg::DotOperandEncodingAttr>(
+      problem.bType.getEncoding());
+  if (!aEncoding || !bEncoding)
+    return {MusaMmaValidationFailure::InvalidDotOperandEncoding};
+  if (aEncoding.getOpIdx() != 0 || bEncoding.getOpIdx() != 1)
+    return {MusaMmaValidationFailure::InvalidDotOperandIndex};
+  if (aEncoding.getKWidth() != 0 || bEncoding.getKWidth() != 0)
+    return {MusaMmaValidationFailure::InvalidDotOperandKWidth};
+  if (aEncoding.getParent() != encoding || bEncoding.getParent() != encoding)
+    return {MusaMmaValidationFailure::MismatchedDotOperandParent};
+  if (problem.cType.getEncoding() != encoding ||
+      problem.dType.getEncoding() != encoding)
+    return {MusaMmaValidationFailure::MismatchedAccumulatorEncoding};
+
+  MusaMmaValidationResult problemValidation =
+      validateMusaDotProblem(problem, true);
+  if (!problemValidation.succeeded())
+    return problemValidation;
+  return validateSqmmaConfig(problem, getExplicitSqmmaConfig(encoding),
+                             encoding);
+}
+
+static LogicalResult emitExplicitSqmmaError(tt::DotOp dotOp,
+                                            MusaMmaValidationFailure failure) {
+  return dotOp.emitOpError("cannot lower explicit MUSA SQMMA dot: ")
+         << getMusaMmaValidationMessage(failure);
+}
+
+static LogicalResult validateExplicitSqmmaDots(ModuleOp module,
+                                               int computeCapability,
+                                               bool disableSqmma) {
+  WalkResult result = module.walk([&](tt::DotOp dotOp) -> WalkResult {
+    auto resultType = dyn_cast<RankedTensorType>(dotOp.getType());
+    auto encoding = resultType ? dyn_cast_or_null<ttg::MUSASqmmaEncodingAttr>(
+                                     resultType.getEncoding())
+                               : ttg::MUSASqmmaEncodingAttr{};
+    if (!encoding)
+      return WalkResult::advance();
+    if (computeCapability != 31) {
+      emitExplicitSqmmaError(dotOp,
+                             MusaMmaValidationFailure::UnsupportedTarget);
+      return WalkResult::interrupt();
+    }
+    if (disableSqmma) {
+      emitExplicitSqmmaError(dotOp,
+                             MusaMmaValidationFailure::ExplicitSqmmaDisabled);
+      return WalkResult::interrupt();
+    }
+    auto problem = getMusaDotProblem(dotOp);
+    if (failed(problem)) {
+      emitExplicitSqmmaError(dotOp, MusaMmaValidationFailure::InvalidDotShape);
+      return WalkResult::interrupt();
+    }
+    MusaMmaValidationResult validation =
+        validateExplicitSqmmaContract(dotOp, *problem, encoding);
+    if (!validation.succeeded()) {
+      emitExplicitSqmmaError(dotOp, validation.failure);
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return failure(result.wasInterrupted());
+}
+#endif // __TLE__
 
 static Value promoteDotOperand(OpBuilder &builder, Location loc, Value operand,
                                Type promoteElemTy) {
@@ -598,13 +1083,25 @@ static Value getSharedMemorySqmmaOperand(Value v, PatternRewriter &rewriter,
 }
 
 static std::optional<SelectedConfig>
+#ifdef __TLE__
+selectSqmmaConfig(const MusaDotProblem &problem) {
+  unsigned m = problem.matrixShape.m;
+  unsigned n = problem.matrixShape.n;
+  unsigned k = problem.matrixShape.k;
+  unsigned numWarps = problem.numWarps;
+  Type elemTy = problem.aElemType;
+  bool allowTF32 = problem.allowTF32;
+#else
 selectSqmmaConfig(unsigned m, unsigned n, unsigned k, unsigned numWarps,
                   Type elemTy, bool allowTF32) {
+#endif // __TLE__
   if (numWarps < 4 || (numWarps % 4) != 0)
     return std::nullopt;
+#ifndef __TLE__
   auto sqmmaEltType = toSqmmaOperandEltType(elemTy, allowTF32);
   if (!sqmmaEltType)
     return std::nullopt;
+#endif // __TLE__
 
   auto candidateM = getSqmmaCandidateM(elemTy, allowTF32);
   auto candidateN = getSqmmaCandidateN(elemTy, allowTF32);
@@ -620,20 +1117,26 @@ selectSqmmaConfig(unsigned m, unsigned n, unsigned k, unsigned numWarps,
   unsigned bestRepN = std::numeric_limits<unsigned>::max();
 
   for (unsigned instM : candidateM) {
+#ifndef __TLE__
     if (m < instM || (m % instM) != 0)
       continue;
+#endif // __TLE__
     for (unsigned instN : candidateN) {
+#ifndef __TLE__
       if (n < instN || (n % instN) != 0)
         continue;
       if (!triton::musa::isSupportedSqmmaInstrMN(*sqmmaEltType, instM, instN))
         continue;
+#endif // __TLE__
       for (unsigned instK : candidateK) {
+#ifndef __TLE__
         if (k < instK || (k % instK) != 0)
           continue;
         if ((instM % 4) != 0)
           continue;
         if (isKnownBrokenSqmmaConfig(elemTy, allowTF32, {instM, instN, instK}))
           continue;
+#endif // __TLE__
 
         for (unsigned warpsM = 4; warpsM <= numWarps; warpsM *= 2) {
           if (numWarps % warpsM != 0)
@@ -643,8 +1146,14 @@ selectSqmmaConfig(unsigned m, unsigned n, unsigned k, unsigned numWarps,
           unsigned squadsM = warpsM / 4;
           unsigned tileM = instM * squadsM;
           unsigned tileN = instN * warpsN;
+#ifdef __TLE__
+          SelectedConfig candidate{{instM, instN, instK}, {warpsM, warpsN}};
+          if (!validateSqmmaConfig(problem, candidate).succeeded())
+            continue;
+#else
           if ((m % tileM) != 0 || (n % tileN) != 0)
             continue;
+#endif // __TLE__
 
           unsigned instCount = (m / tileM) * (n / tileN) * (k / instK);
           unsigned repM = m / tileM;
@@ -674,6 +1183,215 @@ selectSqmmaConfig(unsigned m, unsigned n, unsigned k, unsigned numWarps,
   return best;
 }
 
+#ifdef __TLE__
+class ExplicitToMUSAWmma : public RewritePattern {
+public:
+  explicit ExplicitToMUSAWmma(MLIRContext *context, int computeCapability)
+      : RewritePattern(tt::DotOp::getOperationName(), 4, context),
+        computeCapability(computeCapability) {}
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    if (computeCapability != 31)
+      return failure();
+
+    auto dotOp = dyn_cast<tt::DotOp>(op);
+    if (!dotOp)
+      return failure();
+    auto oldRetType = dyn_cast<RankedTensorType>(dotOp.getType());
+    auto mmaEnc = oldRetType ? dyn_cast_or_null<ttg::MUSAWmmaEncodingAttr>(
+                                   oldRetType.getEncoding())
+                             : ttg::MUSAWmmaEncodingAttr{};
+    if (!mmaEnc)
+      return failure();
+
+    auto problem = getMusaDotProblem(dotOp);
+    if (failed(problem) ||
+        !validateExplicitWmmaContract(dotOp, *problem, mmaEnc).succeeded())
+      return failure();
+
+    SelectedConfig config = getExplicitWmmaConfig(mmaEnc);
+    Type aElemTy = problem->aElemType;
+    Type bElemTy = problem->bElemType;
+    bool useFp32Carrier = oldRetType.getElementType().isF16() &&
+                          aElemTy.isF16() && bElemTy.isF16();
+    Type carrierElemTy =
+        useFp32Carrier ? rewriter.getF32Type() : oldRetType.getElementType();
+    auto nativeRetType =
+        RankedTensorType::get(oldRetType.getShape(), carrierElemTy, mmaEnc);
+
+    Value oldAcc = dotOp.getC();
+    Value promotedAcc =
+        useFp32Carrier
+            ? promoteDotOperand(rewriter, dotOp.getLoc(), oldAcc, carrierElemTy)
+            : oldAcc;
+    bool accIsZero = isZeroConst(oldAcc);
+    Value nativeAcc;
+    if (accIsZero) {
+      auto zeroElem = rewriter.getZeroAttr(nativeRetType.getElementType());
+      auto zeroTensor = DenseElementsAttr::get(nativeRetType, zeroElem);
+      nativeAcc = arith::ConstantOp::create(rewriter, oldAcc.getLoc(),
+                                            nativeRetType, zeroTensor);
+    } else if (promotedAcc.getType() == nativeRetType) {
+      nativeAcc = promotedAcc;
+    } else {
+      nativeAcc = ttg::ConvertLayoutOp::create(rewriter, oldAcc.getLoc(),
+                                               nativeRetType, promotedAcc);
+    }
+
+    auto wmmaEltTypeA = toSqmmaOperandEltType(aElemTy, problem->allowTF32);
+    auto wmmaEltTypeB = toSqmmaOperandEltType(bElemTy, problem->allowTF32);
+    if (!wmmaEltTypeA || !wmmaEltTypeB)
+      return failure();
+    Value useC = arith::ConstantIntOp::create(rewriter, dotOp.getLoc(), 1, 1);
+    auto newDot = triton::musa::WmmaDotOp::create(
+        rewriter, dotOp.getLoc(), nativeRetType, dotOp.getA(), dotOp.getB(),
+        nativeAcc, useC, static_cast<int32_t>(config.instrShape[0]),
+        static_cast<int32_t>(config.instrShape[1]),
+        static_cast<int32_t>(config.instrShape[2]), *wmmaEltTypeA,
+        *wmmaEltTypeB, triton::musa::getDefaultWmmaFragmentLayout(0),
+        triton::musa::getDefaultWmmaFragmentLayout(1),
+        static_cast<int32_t>(dotOp.getInputPrecision()),
+        /*maxNumImpreciseAcc=*/0);
+    newDot->setAttr(kDisableGenericDotPipelineAttr, rewriter.getBoolAttr(true));
+
+    Attribute explicitResultEncoding =
+        getTleExplicitResultEncoding(dotOp.getOperation(), 0);
+    if (!useFp32Carrier) {
+      if (explicitResultEncoding)
+        setTleExplicitResultEncoding(newDot.getOperation(), 0,
+                                     explicitResultEncoding);
+      rewriter.replaceOp(dotOp, newDot.getResult());
+      return success();
+    }
+
+    Value truncated = arith::TruncFOp::create(rewriter, dotOp.getLoc(),
+                                              oldRetType, newDot.getResult());
+    if (explicitResultEncoding)
+      setTleExplicitResultEncoding(truncated.getDefiningOp(), 0,
+                                   explicitResultEncoding);
+    rewriter.replaceOp(dotOp, truncated);
+    return success();
+  }
+
+private:
+  int computeCapability;
+};
+
+class ExplicitToMUSASqmma : public RewritePattern {
+public:
+  explicit ExplicitToMUSASqmma(MLIRContext *context, int computeCapability)
+      : RewritePattern(tt::DotOp::getOperationName(), 5, context),
+        computeCapability(computeCapability) {}
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    if (computeCapability != 31)
+      return failure();
+
+    auto dotOp = dyn_cast<tt::DotOp>(op);
+    if (!dotOp)
+      return failure();
+    auto oldRetType = dyn_cast<RankedTensorType>(dotOp.getType());
+    auto mmaEnc = oldRetType ? dyn_cast_or_null<ttg::MUSASqmmaEncodingAttr>(
+                                   oldRetType.getEncoding())
+                             : ttg::MUSASqmmaEncodingAttr{};
+    if (!mmaEnc)
+      return failure();
+
+    auto problem = getMusaDotProblem(dotOp);
+    if (failed(problem) ||
+        !validateExplicitSqmmaContract(dotOp, *problem, mmaEnc).succeeded())
+      return failure();
+
+    SelectedConfig config = getExplicitSqmmaConfig(mmaEnc);
+    Type aElemTy = problem->aElemType;
+    Type bElemTy = problem->bElemType;
+    bool useFp32Carrier = oldRetType.getElementType().isF16() &&
+                          aElemTy.isF16() && bElemTy.isF16();
+    Type carrierElemTy =
+        useFp32Carrier ? rewriter.getF32Type() : oldRetType.getElementType();
+    auto eltTypeC = toSqmmaEltType(carrierElemTy);
+    auto eltTypeA = toSqmmaOperandEltType(aElemTy, problem->allowTF32);
+    auto eltTypeB = toSqmmaOperandEltType(bElemTy, problem->allowTF32);
+    if (!eltTypeC || !eltTypeA || !eltTypeB)
+      return failure();
+
+    auto nativeRetType =
+        RankedTensorType::get(oldRetType.getShape(), carrierElemTy, mmaEnc);
+    Value oldAcc = dotOp.getC();
+    Value promotedAcc =
+        useFp32Carrier
+            ? promoteDotOperand(rewriter, dotOp.getLoc(), oldAcc, carrierElemTy)
+            : oldAcc;
+    bool accIsZero = isZeroConst(oldAcc);
+    Value nativeAcc;
+    if (accIsZero) {
+      auto zeroElem = rewriter.getZeroAttr(nativeRetType.getElementType());
+      auto zeroTensor = DenseElementsAttr::get(nativeRetType, zeroElem);
+      nativeAcc = arith::ConstantOp::create(rewriter, oldAcc.getLoc(),
+                                            nativeRetType, zeroTensor);
+    } else if (promotedAcc.getType() == nativeRetType) {
+      nativeAcc = promotedAcc;
+    } else {
+      nativeAcc = ttg::ConvertLayoutOp::create(rewriter, oldAcc.getLoc(),
+                                               nativeRetType, promotedAcc);
+    }
+
+    bool allowTransposeA = problem->transLoadKindA != SqmmaTransLoadKind::None;
+    bool allowTransposeB = problem->transLoadKindB != SqmmaTransLoadKind::None;
+    Value newA = getSharedMemorySqmmaOperand(dotOp.getA(), rewriter, 0, mmaEnc,
+                                             allowTransposeA);
+    Value newB = getSharedMemorySqmmaOperand(dotOp.getB(), rewriter, 1, mmaEnc,
+                                             allowTransposeB);
+    if (!newA || !newB)
+      return failure();
+
+    auto accumulationContract = selectSqmmaAccumulationContract(
+        aElemTy, nativeRetType.getElementType(), problem->matrixShape.m,
+        problem->matrixShape.n, problem->matrixShape.k, accIsZero,
+        static_cast<uint32_t>(dotOp.getMaxNumImpreciseAcc()), config);
+    Value useC = arith::ConstantIntOp::create(
+        rewriter, dotOp.getLoc(), accumulationContract.useCOperand, 1);
+    auto newDot = triton::musa::SquadDotOp::create(
+        rewriter, dotOp.getLoc(), nativeRetType, newA, newB, nativeAcc, useC,
+        static_cast<int32_t>(config.instrShape[0]),
+        static_cast<int32_t>(config.instrShape[1]),
+        static_cast<int32_t>(config.instrShape[2]), *eltTypeC, *eltTypeA,
+        *eltTypeB, inferSqmmaLayout(newA), inferSqmmaLayout(newB), false,
+        accumulationContract.mode,
+        static_cast<int32_t>(dotOp.getInputPrecision()),
+        accumulationContract.mode ==
+                triton::musa::SQMMAAccumulationMode::partial
+            ? static_cast<int32_t>(dotOp.getMaxNumImpreciseAcc())
+            : 0);
+    newDot->setAttr(kDisableGenericDotPipelineAttr, rewriter.getBoolAttr(true));
+    newDot->setAttr("isAsync", rewriter.getBoolAttr(false));
+
+    Attribute explicitResultEncoding =
+        getTleExplicitResultEncoding(dotOp.getOperation(), 0);
+    if (!useFp32Carrier) {
+      if (explicitResultEncoding)
+        setTleExplicitResultEncoding(newDot.getOperation(), 0,
+                                     explicitResultEncoding);
+      rewriter.replaceOp(dotOp, newDot.getResult());
+      return success();
+    }
+
+    Value truncated = arith::TruncFOp::create(rewriter, dotOp.getLoc(),
+                                              oldRetType, newDot.getResult());
+    if (explicitResultEncoding)
+      setTleExplicitResultEncoding(truncated.getDefiningOp(), 0,
+                                   explicitResultEncoding);
+    rewriter.replaceOp(dotOp, truncated);
+    return success();
+  }
+
+private:
+  int computeCapability;
+};
+#endif // __TLE__
+
 class BlockedToMUSAWmma : public RewritePattern {
 public:
   explicit BlockedToMUSAWmma(MLIRContext *context, int computeCapability)
@@ -689,11 +1407,26 @@ public:
     if (!dotOp)
       return failure();
     auto oldRetType = cast<RankedTensorType>(dotOp.getType());
+#ifdef __TLE__
+    Attribute explicitResultEncoding =
+        getTleExplicitResultEncoding(dotOp.getOperation(), 0);
+#endif // __TLE__
     auto oldEncoding = oldRetType.getEncoding();
     if (!oldEncoding || !isa<ttg::BlockedEncodingAttr>(oldEncoding))
       return failure();
     if (isa<ttg::MUSAWmmaEncodingAttr, ttg::MUSASqmmaEncodingAttr>(oldEncoding))
       return failure();
+#ifdef __TLE__
+    auto problem = getMusaDotProblem(dotOp);
+    if (failed(problem) || !validateMusaDotProblem(*problem, false).succeeded())
+      return failure();
+    auto aTy = problem->aType;
+    auto bTy = problem->bType;
+    auto aElemTy = problem->aElemType;
+    auto bElemTy = problem->bElemType;
+    bool allowTF32 = problem->allowTF32;
+    auto config = selectWmmaConfig(*problem);
+#else
     auto aTy = cast<RankedTensorType>(dotOp.getA().getType());
     auto bTy = cast<RankedTensorType>(dotOp.getB().getType());
     auto aElemTy = aTy.getElementType();
@@ -714,6 +1447,7 @@ public:
     unsigned numWarps = ttg::lookupNumWarps(dotOp);
 
     auto config = selectWmmaConfig(m, n, k, numWarps, aElemTy, allowTF32);
+#endif // __TLE__
     if (!config)
       return failure();
 
@@ -774,8 +1508,16 @@ public:
         /*maxNumImpreciseAcc=*/0);
     newDot->setAttr(kDisableGenericDotPipelineAttr, rewriter.getBoolAttr(true));
     if (!useFp32Carrier) {
+#ifdef __TLE__
+      auto resultCvt = rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(
+          dotOp, oldRetType, newDot.getResult());
+      if (explicitResultEncoding)
+        setTleExplicitResultEncoding(resultCvt.getOperation(), 0,
+                                     explicitResultEncoding);
+#else
       rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(dotOp, oldRetType,
                                                         newDot.getResult());
+#endif // __TLE__
       return success();
     }
 
@@ -784,6 +1526,11 @@ public:
         rewriter, dotOp.getLoc(), blockedCarrierTy, newDot.getResult());
     Value truncated = arith::TruncFOp::create(rewriter, dotOp.getLoc(),
                                               oldRetType, blockedCarrier);
+#ifdef __TLE__
+    if (explicitResultEncoding)
+      setTleExplicitResultEncoding(truncated.getDefiningOp(), 0,
+                                   explicitResultEncoding);
+#endif // __TLE__
     rewriter.replaceOp(dotOp, truncated);
     return success();
   }
@@ -807,11 +1554,29 @@ public:
     if (!dotOp)
       return failure();
     auto oldRetType = cast<RankedTensorType>(dotOp.getType());
+#ifdef __TLE__
+    Attribute explicitResultEncoding =
+        getTleExplicitResultEncoding(dotOp.getOperation(), 0);
+#endif // __TLE__
     auto oldEncoding = oldRetType.getEncoding();
     if (!oldEncoding || !isa<ttg::BlockedEncodingAttr>(oldEncoding))
       return failure();
     if (isa<ttg::MUSAWmmaEncodingAttr, ttg::MUSASqmmaEncodingAttr>(oldEncoding))
       return failure();
+#ifdef __TLE__
+    auto problem = getMusaDotProblem(dotOp);
+    if (failed(problem) || !validateMusaDotProblem(*problem, true).succeeded())
+      return failure();
+    auto aTy = problem->aType;
+    auto bTy = problem->bType;
+    auto aElemTy = problem->aElemType;
+    auto bElemTy = problem->bElemType;
+    bool allowTF32 = problem->allowTF32;
+    unsigned m = problem->matrixShape.m;
+    unsigned n = problem->matrixShape.n;
+    unsigned k = problem->matrixShape.k;
+    auto config = selectSqmmaConfig(*problem);
+#else
     auto aTy = dyn_cast<RankedTensorType>(dotOp.getA().getType());
     auto bTy = dyn_cast<RankedTensorType>(dotOp.getB().getType());
     if (!aTy || !bTy)
@@ -838,6 +1603,7 @@ public:
     unsigned k = matrixShape->k;
     unsigned numWarps = ttg::lookupNumWarps(dotOp);
     auto config = selectSqmmaConfig(m, n, k, numWarps, aElemTy, allowTF32);
+#endif // __TLE__
     if (!config)
       return failure();
 
@@ -851,10 +1617,12 @@ public:
     auto eltTypeB = toSqmmaOperandEltType(bElemTy, allowTF32);
     if (!eltTypeC || !eltTypeA || !eltTypeB)
       return failure();
+#ifndef __TLE__
     if (!triton::musa::isSupportedSqmma(
             *eltTypeA, *eltTypeB, *eltTypeC, config->instrShape[0],
             config->instrShape[1], config->instrShape[2]))
       return failure();
+#endif // __TLE__
 
     auto cgaLayout = ttg::getCGALayout(oldEncoding);
     auto mmaEnc = ttg::MUSASqmmaEncodingAttr::get(
@@ -879,8 +1647,13 @@ public:
                                             newRetType, acc);
     }
 
+#ifdef __TLE__
+    SqmmaTransLoadKind transLoadKindA = problem->transLoadKindA;
+    SqmmaTransLoadKind transLoadKindB = problem->transLoadKindB;
+#else
     SqmmaTransLoadKind transLoadKindA = classifySqmmaTransLoad(dotOp.getA());
     SqmmaTransLoadKind transLoadKindB = classifySqmmaTransLoad(dotOp.getB());
+#endif // __TLE__
     bool allowTransposeA = transLoadKindA != SqmmaTransLoadKind::None;
     bool allowTransposeB = transLoadKindB != SqmmaTransLoadKind::None;
     Value newA = getSharedMemorySqmmaOperand(dotOp.getA(), rewriter, 0, mmaEnc,
@@ -910,8 +1683,16 @@ public:
     newDot->setAttr(kDisableGenericDotPipelineAttr, rewriter.getBoolAttr(true));
     newDot->setAttr("isAsync", rewriter.getBoolAttr(false));
     if (!useFp32Carrier) {
+#ifdef __TLE__
+      auto resultCvt = rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(
+          dotOp, oldRetType, newDot.getResult());
+      if (explicitResultEncoding)
+        setTleExplicitResultEncoding(resultCvt.getOperation(), 0,
+                                     explicitResultEncoding);
+#else
       rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(dotOp, oldRetType,
                                                         newDot.getResult());
+#endif // __TLE__
       return success();
     }
 
@@ -920,6 +1701,11 @@ public:
         rewriter, dotOp.getLoc(), blockedCarrierTy, newDot.getResult());
     Value truncated = arith::TruncFOp::create(rewriter, dotOp.getLoc(),
                                               oldRetType, blockedCarrier);
+#ifdef __TLE__
+    if (explicitResultEncoding)
+      setTleExplicitResultEncoding(truncated.getDefiningOp(), 0,
+                                   explicitResultEncoding);
+#endif // __TLE__
     rewriter.replaceOp(dotOp, truncated);
     return success();
   }
@@ -953,6 +1739,18 @@ struct TritonMUSAGPUAccelerateMatmulPass
     bool disableSqmma = ::triton::tools::getBoolEnv("DISABLE_SQMMA");
     bool disableWmma = ::triton::tools::getBoolEnv("DISABLE_WMMA");
 
+#ifdef __TLE__
+    if (failed(validateExplicitWmmaDots(mod, computeCapability, disableWmma))) {
+      signalPassFailure();
+      return;
+    }
+    if (failed(
+            validateExplicitSqmmaDots(mod, computeCapability, disableSqmma))) {
+      signalPassFailure();
+      return;
+    }
+#endif // __TLE__
+
     bool sqmmaCandidate = computeCapability >= 31 && !disableSqmma;
     // Preserve the 3.6 fallback behavior: descriptor/TME modules may still
     // fall back to WMMA when SQMMA predicate matching rejects a dot.
@@ -961,14 +1759,42 @@ struct TritonMUSAGPUAccelerateMatmulPass
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
     ttg::populateDecomposeScaledBlockedPatterns(patterns, /*benefit=*/1);
+#ifdef __TLE__
+    patterns.add<ExplicitToMUSASqmma>(context, computeCapability);
+    patterns.add<ExplicitToMUSAWmma>(context, computeCapability);
+#endif // __TLE__
     // Keep 3.2-aligned rewrite precedence: SQMMA first, then WMMA.
     if (sqmmaCandidate)
       patterns.add<BlockedToMUSASqmma>(context, computeCapability);
     if (wmmaCandidate)
       patterns.add<BlockedToMUSAWmma>(context, computeCapability);
 
-    if (applyPatternsGreedily(mod, std::move(patterns)).failed())
+    if (applyPatternsGreedily(mod, std::move(patterns)).failed()) {
       signalPassFailure();
+      return;
+    }
+
+#ifdef __TLE__
+    WalkResult residualExplicitMma =
+        mod.walk([&](tt::DotOp dotOp) -> WalkResult {
+          auto resultType = dyn_cast<RankedTensorType>(dotOp.getType());
+          if (!resultType || !isa_and_nonnull<ttg::MUSAWmmaEncodingAttr,
+                                              ttg::MUSASqmmaEncodingAttr>(
+                                 resultType.getEncoding()))
+            return WalkResult::advance();
+          StringRef kind =
+              isa<ttg::MUSASqmmaEncodingAttr>(resultType.getEncoding())
+                  ? "SQMMA"
+                  : "WMMA";
+          dotOp.emitOpError("failed to rewrite validated explicit MUSA ")
+              << kind << " dot";
+          return WalkResult::interrupt();
+        });
+    if (residualExplicitMma.wasInterrupted()) {
+      signalPassFailure();
+      return;
+    }
+#endif // __TLE__
 
     promoteResidualDotForFma(mod);
   }

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/CanonicalizeSqmmaResultConversions.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/CanonicalizeSqmmaResultConversions.cpp
@@ -6,6 +6,9 @@
 #include "mlir/IR/PatternMatch.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#ifdef __TLE__
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#endif // __TLE__
 
 using namespace mlir;
 namespace tt = mlir::triton;
@@ -23,6 +26,10 @@ static bool preservesSqmmaOperandBoundary(arith::TruncFOp trunc) {
 
 static bool sinkTruncAfterMmaConvert(ttg::ConvertLayoutOp cvt,
                                      RewriterBase &rewriter) {
+#ifdef __TLE__
+  if (isTleExplicitConvertLayoutOp(cvt))
+    return false;
+#endif // __TLE__
   auto srcTy = dyn_cast<RankedTensorType>(cvt.getSrc().getType());
   auto dstTy = dyn_cast<RankedTensorType>(cvt.getType());
   if (!srcTy || !dstTy)
@@ -47,6 +54,10 @@ static bool sinkTruncAfterMmaConvert(ttg::ConvertLayoutOp cvt,
 
   bool changed = false;
   for (arith::TruncFOp trunc : truncUsers) {
+#ifdef __TLE__
+    if (getTleExplicitValueEncoding(trunc.getResult()))
+      continue;
+#endif // __TLE__
     if (preservesSqmmaOperandBoundary(trunc))
       continue;
     auto truncDstTy = dyn_cast<RankedTensorType>(trunc.getType());

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/OptimizeAccumulatorInit.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/OptimizeAccumulatorInit.cpp
@@ -134,6 +134,14 @@ struct TritonMUSAGPUOptimizeAccumulatorInitPass
       Value accUse = getAccumulatorValue(dotOp);
       if (!accUse)
         continue;
+#ifdef __TLE__
+      bool hasExplicitResult = false;
+      for (Value result : dotOp->getResults())
+        hasExplicitResult |=
+            static_cast<bool>(getTleExplicitValueEncoding(result));
+      if (getTleExplicitValueEncoding(accUse) || hasExplicitResult)
+        continue;
+#endif // __TLE__
 
       Value useCValue = getUseCValue(dotOp);
       if (useCValue) {
@@ -152,6 +160,11 @@ struct TritonMUSAGPUOptimizeAccumulatorInitPass
           findZeroInitOp(accUse, forOp, loopArgIsZero);
       if (!zeroInitOp && !loopArgIsZero)
         continue;
+#ifdef __TLE__
+      if (zeroInitOp &&
+          getTleExplicitResultEncoding(zeroInitOp->first, zeroInitOp->second))
+        continue;
+#endif // __TLE__
 
       Value loopArgFlagValue = loopArgIsZero ? vFalse : vTrue;
       forOp = addIterArgsToLoop(rewriter, forOp, {loopArgFlagValue});

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/OptimizeDescriptorEncoding.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/OptimizeDescriptorEncoding.cpp
@@ -515,6 +515,10 @@ public:
 
   LogicalResult matchAndRewrite(ttg::ConvertLayoutOp cvt,
                                 PatternRewriter &rewriter) const override {
+#ifdef __TLE__
+    if (isTleExplicitConvertLayoutOp(cvt))
+      return failure();
+#endif // __TLE__
     auto dstTy = dyn_cast<RankedTensorType>(cvt.getType());
     if (!dstTy)
       return failure();
@@ -524,6 +528,10 @@ public:
     auto fpToFp = cvt.getSrc().getDefiningOp<tt::FpToFpOp>();
     if (!fpToFp)
       return failure();
+#ifdef __TLE__
+    if (getTleExplicitValueEncoding(fpToFp.getResult()))
+      return failure();
+#endif // __TLE__
 
     auto midTy = dyn_cast<RankedTensorType>(fpToFp.getType());
     auto srcTy = dyn_cast<RankedTensorType>(fpToFp.getSrc().getType());

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/OptimizeDotOperands.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/OptimizeDotOperands.cpp
@@ -126,6 +126,10 @@ public:
 
   LogicalResult matchAndRewrite(ttg::ConvertLayoutOp cvtOp,
                                 PatternRewriter &rewriter) const override {
+#ifdef __TLE__
+    if (isTleExplicitConvertLayoutOp(cvtOp))
+      return failure();
+#endif // __TLE__
     if (!cvtOp->hasOneUse() ||
         !isDotLikeUserForSwizzle(cvtOp->use_begin()->getOwner()))
       return failure();
@@ -156,6 +160,10 @@ public:
 
   LogicalResult matchAndRewrite(tt::TransOp trans,
                                 PatternRewriter &rewriter) const override {
+#ifdef __TLE__
+    if (getTleExplicitValueEncoding(trans.getResult()))
+      return failure();
+#endif // __TLE__
     if (!trans->hasOneUse() ||
         !isDotLikeUserForSwizzle(trans->use_begin()->getOwner()))
       return failure();
@@ -205,6 +213,10 @@ public:
         continue;
       }
       if (auto cvtOp = dyn_cast<ttg::ConvertLayoutOp>(defOp)) {
+#ifdef __TLE__
+        if (isTleExplicitConvertLayoutOp(cvtOp))
+          return failure();
+#endif // __TLE__
         reverseChain.push_back(
             {triton::musa::SqmmaTensorViewKind::ConvertLayout, defOp});
         base = cvtOp.getSrc();

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/OptimizeSqmmaAccumulatorLayout.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/OptimizeSqmmaAccumulatorLayout.cpp
@@ -82,6 +82,14 @@ static bool sinkLoopCarriedSqmmaAccumulatorConvert(scf::ForOp &forOp,
       continue;
     if (!isSqmmaAccumulatorLoopArg(forOp.getRegionIterArg(*mmaIdx)))
       continue;
+#ifdef __TLE__
+    if (getTleExplicitValueEncoding(cvt.getResult()) ||
+        getTleExplicitValueEncoding(cvt.getSrc()) ||
+        getTleExplicitValueEncoding(mmaValue) ||
+        getTleExplicitValueEncoding(forOp.getResult(blockedIdx)) ||
+        getTleExplicitValueEncoding(forOp.getResult(*mmaIdx)))
+      continue;
+#endif // __TLE__
 
     blockedIdxSeen.set(blockedIdx);
     Operation *waitToCleanup = nullptr;

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/Pipeline.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/Pipeline.cpp
@@ -1133,6 +1133,13 @@ lowerLoads(scf::ForOp forOp, tt::CoarseSchedule &schedule,
   for (auto &op : forOp.getBody()->without_terminator()) {
     if (!isa<tt::LoadOp, tt::DescriptorLoadOp, tt::DescriptorGatherOp>(op))
       continue;
+#ifdef __TLE__
+    Attribute explicitMemoryEncoding;
+    if (failed(inferTleExplicitMemoryEncoding(&op, explicitMemoryEncoding)))
+      return failure();
+    if (explicitMemoryEncoding || getTleExplicitResultEncoding(&op, 0))
+      continue;
+#endif // __TLE__
 
     if (isa<tt::DescriptorGatherOp>(op)) {
       op.emitOpError("pipelined descriptor_gather is not supported on MUSA");

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/TMELowering.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/TMELowering.cpp
@@ -98,9 +98,19 @@ static LogicalResult lowerDescriptorLoad(tt::DescriptorLoadOp op,
   Value localLoadValue;
   auto getLocalLoadValue = [&]() -> Value {
     if (!localLoadValue) {
+#ifdef __TLE__
+      auto localLoad =
+          ttg::LocalLoadOp::create(rewriter, loc, op.getType(), alloc);
+      if (Attribute explicitEncoding =
+              getTleExplicitValueEncoding(op.getResult()))
+        setTleExplicitResultEncoding(localLoad.getOperation(), 0,
+                                     explicitEncoding);
+      localLoadValue = localLoad.getResult();
+#else
       localLoadValue =
           ttg::LocalLoadOp::create(rewriter, loc, op.getType(), alloc)
               .getResult();
+#endif // __TLE__
     }
     return localLoadValue;
   };

--- a/third_party/mthreads/python/test/unit/tle/test_tle_mthreads_layout.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_mthreads_layout.py
@@ -6,7 +6,7 @@ import sys
 import pytest
 import triton.language as tl
 import triton.experimental.tle.language as tle
-from triton.experimental.tle.language.gpu.mthreads.layout import (
+from triton.experimental.tle.language.gpu.mthreads import (
     MusaDotOperandEncoding,
     MusaSqmmaEncoding,
     MusaWmmaEncoding,
@@ -35,33 +35,35 @@ class _FakeBuilder:
         return "dot_operand_attr"
 
 
-def test_mthreads_layout_is_available_only_from_explicit_submodule():
-    assert MusaWmmaEncoding is tle.gpu.mthreads.layout.MusaWmmaEncoding
-    assert MusaSqmmaEncoding is tle.gpu.mthreads.layout.MusaSqmmaEncoding
-    assert MusaDotOperandEncoding is tle.gpu.mthreads.layout.MusaDotOperandEncoding
+def test_mthreads_layout_is_reexported_from_backend_namespace():
+    assert MusaWmmaEncoding is tle.gpu.mthreads.MusaWmmaEncoding
+    assert MusaSqmmaEncoding is tle.gpu.mthreads.MusaSqmmaEncoding
+    assert MusaDotOperandEncoding is tle.gpu.mthreads.MusaDotOperandEncoding
+    assert MusaWmmaEncoding is tle.gpu.mthreads.types.MusaWmmaEncoding
+    assert MusaSqmmaEncoding is tle.gpu.mthreads.types.MusaSqmmaEncoding
+    assert MusaDotOperandEncoding is tle.gpu.mthreads.types.MusaDotOperandEncoding
     assert not hasattr(tle.gpu, "MusaWmmaEncoding")
     assert not hasattr(tle.gpu, "MusaSqmmaEncoding")
     assert not hasattr(tle.gpu, "MusaDotOperandEncoding")
-    assert not hasattr(tle.gpu.mthreads, "MusaWmmaEncoding")
-    assert not hasattr(tle.gpu.mthreads, "MusaSqmmaEncoding")
-    assert not hasattr(tle.gpu.mthreads, "MusaDotOperandEncoding")
+    assert {"MusaWmmaEncoding", "MusaSqmmaEncoding", "MusaDotOperandEncoding"} <= set(tle.gpu.mthreads.__all__)
 
 
-def test_generic_gpu_import_does_not_load_mthreads_layout():
+def test_generic_gpu_import_does_not_reexport_mthreads_types():
     env = os.environ.copy()
     env["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
-    script = ("import sys; "
-              "import triton.experimental.tle.language as tle; "
-              "assert 'triton.experimental.tle.language.gpu.mthreads.layout' not in sys.modules")
+    script = ("import triton.experimental.tle.language as tle; "
+              "assert not hasattr(tle.gpu, 'MusaWmmaEncoding'); "
+              "assert not hasattr(tle.gpu, 'MusaSqmmaEncoding'); "
+              "assert not hasattr(tle.gpu, 'MusaDotOperandEncoding')")
     subprocess.run([sys.executable, "-c", script], env=env, check=True, capture_output=True, text=True)
 
 
-def test_explicit_mthreads_layout_import_does_not_load_torch_musa():
+def test_explicit_mthreads_types_import_does_not_load_torch_musa():
     env = os.environ.copy()
     env["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
     script = ("import sys; "
-              "from triton.experimental.tle.language.gpu.mthreads.layout import MusaWmmaEncoding; "
-              "assert MusaWmmaEncoding; "
+              "from triton.experimental.tle.language.gpu import mthreads; "
+              "assert mthreads.MusaWmmaEncoding; "
               "assert 'torch_musa' not in sys.modules")
     subprocess.run([sys.executable, "-c", script], env=env, check=True, capture_output=True, text=True)
 

--- a/third_party/mthreads/python/test/unit/tle/test_tle_mthreads_layout.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_mthreads_layout.py
@@ -1,0 +1,186 @@
+import os
+import re
+import subprocess
+import sys
+
+import pytest
+import triton.language as tl
+import triton.experimental.tle.language as tle
+from triton.experimental.tle.language.gpu.mthreads.layout import (
+    MusaDotOperandEncoding,
+    MusaSqmmaEncoding,
+    MusaWmmaEncoding,
+)
+
+
+class _FakeBuilder:
+
+    def __init__(self):
+        self.calls = []
+
+    def get_musa_wmma_layout(self, version, warps_per_cta, cga_layout, instr_shape):
+        self.calls.append(("wmma", version, warps_per_cta, cga_layout, instr_shape))
+        return "wmma_attr"
+
+    def get_musa_sqmma_layout(self, version, warps_per_cta, cga_layout, instr_shape):
+        self.calls.append(("sqmma", version, warps_per_cta, cga_layout, instr_shape))
+        return "sqmma_attr"
+
+    def get_mma_layout(self, version, warps_per_cta, cga_layout, instr_shape):
+        self.calls.append(("nvidia", version, warps_per_cta, cga_layout, instr_shape))
+        return "nvidia_attr"
+
+    def get_dot_operand_layout(self, operand_index, parent, k_width):
+        self.calls.append(("dot_operand", operand_index, parent, k_width))
+        return "dot_operand_attr"
+
+
+def test_mthreads_layout_is_available_only_from_explicit_submodule():
+    assert MusaWmmaEncoding is tle.gpu.mthreads.layout.MusaWmmaEncoding
+    assert MusaSqmmaEncoding is tle.gpu.mthreads.layout.MusaSqmmaEncoding
+    assert MusaDotOperandEncoding is tle.gpu.mthreads.layout.MusaDotOperandEncoding
+    assert not hasattr(tle.gpu, "MusaWmmaEncoding")
+    assert not hasattr(tle.gpu, "MusaSqmmaEncoding")
+    assert not hasattr(tle.gpu, "MusaDotOperandEncoding")
+    assert not hasattr(tle.gpu.mthreads, "MusaWmmaEncoding")
+    assert not hasattr(tle.gpu.mthreads, "MusaSqmmaEncoding")
+    assert not hasattr(tle.gpu.mthreads, "MusaDotOperandEncoding")
+
+
+def test_generic_gpu_import_does_not_load_mthreads_layout():
+    env = os.environ.copy()
+    env["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
+    script = ("import sys; "
+              "import triton.experimental.tle.language as tle; "
+              "assert 'triton.experimental.tle.language.gpu.mthreads.layout' not in sys.modules")
+    subprocess.run([sys.executable, "-c", script], env=env, check=True, capture_output=True, text=True)
+
+
+def test_explicit_mthreads_layout_import_does_not_load_torch_musa():
+    env = os.environ.copy()
+    env["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
+    script = ("import sys; "
+              "from triton.experimental.tle.language.gpu.mthreads.layout import MusaWmmaEncoding; "
+              "assert MusaWmmaEncoding; "
+              "assert 'torch_musa' not in sys.modules")
+    subprocess.run([sys.executable, "-c", script], env=env, check=True, capture_output=True, text=True)
+
+
+@pytest.mark.parametrize(
+    "encoding_type,warps_per_cta,instr_shape,expected_kind",
+    [
+        (MusaWmmaEncoding, (4, 1), (16, 16, 16), "wmma"),
+        (MusaSqmmaEncoding, (4, 1), (64, 64, 32), "sqmma"),
+        (MusaWmmaEncoding, (2, 2, 1), (16, 8, 8), "wmma"),
+        (MusaSqmmaEncoding, (4, 2, 1), (32, 64, 16), "sqmma"),
+    ],
+)
+def test_mthreads_layout_construction_and_builder_contract(encoding_type, warps_per_cta, instr_shape, expected_kind):
+    encoding = encoding_type(
+        tl.tuple((tl.constexpr(3), tl.constexpr(1))),
+        tl.tuple(tuple(tl.constexpr(value) for value in warps_per_cta)),
+        tl.tuple(tuple(tl.constexpr(value) for value in instr_shape)),
+    )
+    assert encoding.version == [3, 1]
+    assert encoding.warps_per_cta == list(warps_per_cta)
+    assert encoding.instr_shape == list(instr_shape)
+    assert encoding.cga_layout == []
+    assert encoding.rank == len(warps_per_cta)
+
+    builder = _FakeBuilder()
+    assert encoding.to_ir(builder) == f"{expected_kind}_attr"
+    assert builder.calls == [(expected_kind, [3, 1], list(warps_per_cta), [], list(instr_shape))]
+
+
+def test_mthreads_layout_cga_repr_equality_and_hash():
+    lhs = MusaWmmaEncoding([3, 1], [2, 2, 1], [16, 16, 16], [[0, 1, 0]])
+    rhs = MusaWmmaEncoding((3, 1), (2, 2, 1), (16, 16, 16), ((0, 1, 0), ))
+    other = MusaSqmmaEncoding([3, 1], [4, 1, 1], [16, 16, 16], [[0, 1, 0]])
+    assert lhs == rhs
+    assert hash(lhs) == hash(rhs)
+    assert lhs != other
+    assert repr(lhs) == ("MusaWmmaEncoding(version=[3, 1], warps_per_cta=[2, 2, 1], "
+                         "instr_shape=[16, 16, 16], cga_layout=[[0, 1, 0]])")
+
+
+@pytest.mark.parametrize(
+    "encoding_type,args,error",
+    [
+        (MusaWmmaEncoding, ([3], [4, 1], [16, 16, 16]), "must contain major and minor"),
+        (MusaWmmaEncoding, ([3, 0], [4, 1], [16, 16, 16]), "must be positive"),
+        (MusaWmmaEncoding, ([3, 2], [4, 1], [16, 16, 16]), "only MUSA PH1 version"),
+        (MusaWmmaEncoding, ([3, True], [4, 1], [16, 16, 16]), "compile-time integer"),
+        (MusaWmmaEncoding, ([3, 1], [4], [16, 16, 16]), "rank must be 2 or 3"),
+        (MusaWmmaEncoding, ([3, 1], [3, 1], [16, 16, 16]), "positive powers of two"),
+        (MusaWmmaEncoding, ([3, 1], [2, 2, 2], [16, 16, 16]), "must be [warps_m, warps_n, 1]"),
+        (MusaWmmaEncoding, ([3, 1], [4, 1], [16, 16]), "logical (M, N, K)"),
+        (MusaWmmaEncoding, ([3, 1], [4, 1], [12, 16, 16]), "M must be"),
+        (MusaWmmaEncoding, ([3, 1], [4, 1], [16, 12, 16]), "N must be"),
+        (MusaWmmaEncoding, ([3, 1], [4, 1], [16, 16, 6]), "K must be"),
+        (MusaSqmmaEncoding, ([3, 1], [2, 2], [16, 16, 16]), "multiple of 4"),
+        (MusaSqmmaEncoding, ([3, 1], [4, 1], [8, 16, 16]), "M must be at least 16"),
+        (MusaSqmmaEncoding, ([3, 1], [4, 1], [16, 12, 16]), "N must be"),
+        (MusaSqmmaEncoding, ([3, 1], [4, 1], [16, 16, 4]), "K must be"),
+    ],
+)
+def test_mthreads_layout_rejects_invalid_mma_configuration(encoding_type, args, error):
+    with pytest.raises(ValueError, match=re.escape(error)):
+        encoding_type(*args)
+
+
+@pytest.mark.parametrize(
+    "cga_layout,error",
+    [
+        (1, "static sequence of basis vectors"),
+        ([[0]], "rank must match layout rank 2"),
+        ([[0, -1]], "entries must be non-negative"),
+        ([[0, 1.0]], "compile-time integer"),
+    ],
+)
+def test_mthreads_layout_rejects_invalid_cga_layout(cga_layout, error):
+    with pytest.raises(ValueError, match=re.escape(error)):
+        MusaWmmaEncoding([3, 1], [4, 1], [16, 16, 16], cga_layout)
+
+
+def test_nvidia_mma_encoding_builder_contract_is_unchanged():
+    encoding = tle.gpu.MmaEncoding([2, 0], [4, 1], [16, 8])
+    builder = _FakeBuilder()
+    assert encoding.to_ir(builder) == "nvidia_attr"
+    assert builder.calls == [("nvidia", [2, 0], [4, 1], [], [16, 8])]
+
+
+@pytest.mark.parametrize("parent_type", [MusaWmmaEncoding, MusaSqmmaEncoding])
+def test_mthreads_dot_operand_encoding_accepts_musa_parent_and_zero_k_width(parent_type):
+    parent = parent_type([3, 1], [4, 1], [16, 16, 16])
+    encoding = MusaDotOperandEncoding(0, parent)
+    builder = _FakeBuilder()
+
+    assert encoding.to_ir(builder) == "dot_operand_attr"
+    assert builder.calls[-1] == ("dot_operand", 0,
+                                 f"{parent_type.__name__.removeprefix('Musa').removesuffix('Encoding').lower()}_attr",
+                                 0)
+
+
+def test_mthreads_dot_operand_encoding_rejects_invalid_contracts():
+    parent = MusaWmmaEncoding([3, 1], [4, 1], [16, 16, 16])
+    nvidia_parent = tle.gpu.MmaEncoding([2, 0], [4, 1], [16, 8])
+
+    with pytest.raises(ValueError, match="operand_index must be 0 or 1"):
+        MusaDotOperandEncoding(2, parent)
+    with pytest.raises(ValueError, match="parent must be a MusaWmmaEncoding or MusaSqmmaEncoding"):
+        MusaDotOperandEncoding(0, nvidia_parent)
+    with pytest.raises(ValueError, match="requires k_width=0"):
+        MusaDotOperandEncoding(0, parent, 1)
+
+
+def test_nvidia_dot_operand_k_width_contract_is_unchanged():
+    parent = tle.gpu.MmaEncoding([2, 0], [4, 1], [16, 8])
+    assert tle.gpu.DotOperandEncoding(0, parent, 2).k_width == 2
+    with pytest.raises(ValueError, match="DotOperandEncoding k_width must be positive"):
+        tle.gpu.DotOperandEncoding(0, parent, 0)
+
+
+def test_generic_dot_operand_does_not_absorb_mthreads_k_width_contract():
+    parent = MusaWmmaEncoding([3, 1], [4, 1], [16, 16, 16])
+    with pytest.raises(ValueError, match="DotOperandEncoding k_width must be positive"):
+        tle.gpu.DotOperandEncoding(0, parent, 0)

--- a/third_party/mthreads/python/test/unit/tle/test_tle_set_layout.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_set_layout.py
@@ -12,7 +12,7 @@ from triton._C.libtriton import ir, passes
 from triton.compiler.errors import CompilationError
 
 from test_tle_utils import compile_musa, compile_to_ttir, mthreads_backend
-from triton.experimental.tle.language.gpu.mthreads.layout import (
+from triton.experimental.tle.language.gpu.mthreads import (
     MusaDotOperandEncoding,
     MusaSqmmaEncoding,
     MusaWmmaEncoding,

--- a/third_party/mthreads/python/test/unit/tle/test_tle_set_layout.py
+++ b/third_party/mthreads/python/test/unit/tle/test_tle_set_layout.py
@@ -1,0 +1,3203 @@
+import re
+
+import pytest
+import torch
+import triton
+import triton.language as tl
+import triton.language.core as tl_core
+import triton.experimental.tle.language as tle
+
+from triton._C import libtriton
+from triton._C.libtriton import ir, passes
+from triton.compiler.errors import CompilationError
+
+from test_tle_utils import compile_musa, compile_to_ttir, mthreads_backend
+from triton.experimental.tle.language.gpu.mthreads.layout import (
+    MusaDotOperandEncoding,
+    MusaSqmmaEncoding,
+    MusaWmmaEncoding,
+)
+
+
+def _make_mthreads_builder():
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    return context, ir.builder(context)
+
+
+def _make_mthreads_function_argument(shape=None):
+    context, builder = _make_mthreads_builder()
+    value_type = builder.get_float_ty()
+    if shape is not None:
+        value_type = builder.get_block_ty(value_type, shape)
+    module = builder.create_module()
+    function_type = builder.get_function_ty([value_type], [])
+    function = builder.get_or_insert_function(module, "set_layout_binding_test", function_type, "public", False)
+    entry = function.add_entry_block()
+    builder.set_insertion_point_to_start(entry)
+    return context, builder, module, function.args(0)
+
+
+_CONVERSION_LAYOUTS = """
+#layout_a = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#layout_b = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+#slice_a = #ttg.slice<{dim = 0, parent = #layout_a}>
+#slice_b = #ttg.slice<{dim = 0, parent = #layout_b}>
+#slice_dim1_a = #ttg.slice<{dim = 1, parent = #layout_a}>
+#reshape_layout = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [2, 1], order = [1, 0]}>
+#reshape_slice = #ttg.slice<{dim = 1, parent = #reshape_layout}>
+#mma = #ttg.musa_wmma<{versionMajor = 3, versionMinor = 1, warpsPerCTA = [4, 1], instrShape = [16, 16, 16]}>
+#sqmma = #ttg.musa_sqmma<{versionMajor = 3, versionMinor = 1, warpsPerCTA = [4, 1], instrShape = [64, 64, 32]}>
+#lhs = #ttg.dot_op<{opIdx = 0, parent = #mma}>
+#rhs = #ttg.dot_op<{opIdx = 1, parent = #mma}>
+#wmma_explicit = #ttg.musa_wmma<{versionMajor = 3, versionMinor = 1, warpsPerCTA = [2, 2], instrShape = [16, 8, 16]}>
+#wmma_unsupported = #ttg.musa_wmma<{versionMajor = 3, versionMinor = 1, warpsPerCTA = [4, 1], instrShape = [8, 8, 8]}>
+#lhs_unsupported = #ttg.dot_op<{opIdx = 0, parent = #wmma_unsupported}>
+#rhs_unsupported = #ttg.dot_op<{opIdx = 1, parent = #wmma_unsupported}>
+#wmma_bad_warps = #ttg.musa_wmma<{versionMajor = 3, versionMinor = 1, warpsPerCTA = [2, 1], instrShape = [16, 16, 16]}>
+#lhs_bad_warps = #ttg.dot_op<{opIdx = 0, parent = #wmma_bad_warps}>
+#rhs_bad_warps = #ttg.dot_op<{opIdx = 1, parent = #wmma_bad_warps}>
+#sqmma_explicit = #ttg.musa_sqmma<{versionMajor = 3, versionMinor = 1, warpsPerCTA = [4, 1], instrShape = [32, 64, 16]}>
+#sqmma_lhs_explicit = #ttg.dot_op<{opIdx = 0, parent = #sqmma_explicit}>
+#sqmma_rhs_explicit = #ttg.dot_op<{opIdx = 1, parent = #sqmma_explicit}>
+#sqmma_unsupported = #ttg.musa_sqmma<{versionMajor = 3, versionMinor = 1, warpsPerCTA = [4, 1], instrShape = [8, 8, 8]}>
+#sqmma_lhs_unsupported = #ttg.dot_op<{opIdx = 0, parent = #sqmma_unsupported}>
+#sqmma_rhs_unsupported = #ttg.dot_op<{opIdx = 1, parent = #sqmma_unsupported}>
+#layout_1d_a = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#layout_1d_b = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#layout_3d_a = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 32, 1], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+#layout_3d_b = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 1, 4], order = [2, 1, 0]}>
+#shared_1d = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared_a = #ttg.swizzled_shared<{vec = 8, perPhase = 2, maxPhase = 8, order = [1, 0]}>
+#shared_b = #ttg.swizzled_shared<{vec = 8, perPhase = 2, maxPhase = 8, order = [1, 0]}>
+#smem = #ttg.shared_memory
+"""
+
+
+def _convert_set_layout_to_ttgir(tmp_path, body):
+    fixture = tmp_path / "mthreads_tle_set_layout_conversion.mlir"
+    fixture.write_text(f"{_CONVERSION_LAYOUTS}\nmodule {{\n{body}\n}}\n")
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    module = ir.parse_mlir_module(str(fixture), context)
+
+    pm = ir.pass_manager(context)
+    passes.ttir.add_convert_to_ttgpuir(pm, "musa:ph1", 4, 32, 1)
+    pm.run(module, "mthreads_tle_set_layout_conversion")
+    ttgir = module.str_nodebug()
+    _assert_set_layout_lowered(ttgir)
+    return ttgir
+
+
+def _run_ttgir_coalesce(tmp_path, body):
+    fixture = tmp_path / "mthreads_tle_set_layout_coalesce.mlir"
+    fixture.write_text(f"{_CONVERSION_LAYOUTS}\n"
+                       "module attributes {\"ttg.num-ctas\" = 1 : i32, \"ttg.num-warps\" = 4 : i32, "
+                       "\"ttg.threads-per-warp\" = 32 : i32} {\n"
+                       f"{body}\n"
+                       "}\n")
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    module = ir.parse_mlir_module(str(fixture), context)
+
+    pm = ir.pass_manager(context)
+    passes.ttgpuir.add_coalesce(pm)
+    pm.run(module, "mthreads_tle_set_layout_coalesce")
+    return module.str_nodebug()
+
+
+def _run_ttgir_coalesce_and_finalize_explicit_layouts(tmp_path, body):
+    fixture = tmp_path / "mthreads_tle_set_layout_coalesce_finalize.mlir"
+    fixture.write_text(f"{_CONVERSION_LAYOUTS}\n"
+                       "module attributes {\"ttg.num-ctas\" = 1 : i32, \"ttg.num-warps\" = 4 : i32, "
+                       "\"ttg.threads-per-warp\" = 32 : i32} {\n"
+                       f"{body}\n"
+                       "}\n")
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    module = ir.parse_mlir_module(str(fixture), context)
+
+    pm = ir.pass_manager(context)
+    passes.ttgpuir.add_coalesce(pm)
+    pm.run(module, "mthreads_tle_set_layout_coalesce")
+    after_coalesce = module.str_nodebug()
+
+    pm = ir.pass_manager(context)
+    libtriton.mthreads.passes.ttgpuir.add_tle_finalize_explicit_layouts(pm)
+    pm.run(module, "mthreads_tle_finalize_explicit_layouts")
+    return after_coalesce, module.str_nodebug()
+
+
+def _run_ttgir_remove_layout_conversions(tmp_path, body, repeat=1, extra_module_attrs=""):
+    fixture = tmp_path / "mthreads_tle_set_layout_remove_conversions.mlir"
+    module_attrs = ('"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, '
+                    '"ttg.threads-per-warp" = 32 : i32')
+    if extra_module_attrs:
+        module_attrs += f", {extra_module_attrs}"
+    fixture.write_text(f"{_CONVERSION_LAYOUTS}\nmodule attributes {{{module_attrs}}} {{\n{body}\n}}\n")
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    module = ir.parse_mlir_module(str(fixture), context)
+
+    pm = ir.pass_manager(context)
+    for _ in range(repeat):
+        passes.ttgpuir.add_remove_layout_conversions(pm)
+    pm.run(module, "mthreads_tle_set_layout_remove_conversions")
+    return module.str_nodebug()
+
+
+def _run_ttgir_finalize_explicit_layouts(tmp_path, body, finalize_repeat=1, run_cse=False):
+    fixture = tmp_path / "mthreads_tle_finalize_explicit_layouts.mlir"
+    fixture.write_text(f"{_CONVERSION_LAYOUTS}\n"
+                       "module attributes {\"ttg.num-ctas\" = 1 : i32, \"ttg.num-warps\" = 4 : i32, "
+                       "\"ttg.threads-per-warp\" = 32 : i32} {\n"
+                       f"{body}\n"
+                       "}\n")
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    module = ir.parse_mlir_module(str(fixture), context)
+
+    if run_cse:
+        pm = ir.pass_manager(context)
+        passes.common.add_cse(pm)
+        pm.run(module, "mthreads_tle_explicit_layout_cse")
+    before_finalize = module.str_nodebug()
+
+    pm = ir.pass_manager(context)
+    for _ in range(finalize_repeat):
+        libtriton.mthreads.passes.ttgpuir.add_tle_finalize_explicit_layouts(pm)
+    pm.run(module, "mthreads_tle_finalize_explicit_layouts")
+    return before_finalize, module.str_nodebug()
+
+
+def _run_ttgir_select_encodings(tmp_path, body):
+    fixture = tmp_path / "mthreads_tle_set_layout_select_encodings.mlir"
+    fixture.write_text(f"{_CONVERSION_LAYOUTS}\n"
+                       "module attributes {\"ttg.num-ctas\" = 1 : i32, \"ttg.num-warps\" = 4 : i32, "
+                       "\"ttg.threads-per-warp\" = 32 : i32} {\n"
+                       f"{body}\n"
+                       "}\n")
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    module = ir.parse_mlir_module(str(fixture), context)
+
+    pm = ir.pass_manager(context)
+    libtriton.mthreads.passes.ttgpuir.add_tle_select_encodings(pm)
+    pm.run(module, "mthreads_tle_set_layout_select_encodings")
+    return module.str_nodebug()
+
+
+def _run_ttgir_optimize_thread_locality(tmp_path, body, num_warps=4):
+    fixture = tmp_path / "mthreads_tle_set_layout_optimize_thread_locality.mlir"
+    fixture.write_text(f"{_CONVERSION_LAYOUTS}\n"
+                       f"module attributes {{\"ttg.num-ctas\" = 1 : i32, \"ttg.num-warps\" = {num_warps} : i32, "
+                       "\"ttg.threads-per-warp\" = 32 : i32} {\n"
+                       f"{body}\n"
+                       "}\n")
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    module = ir.parse_mlir_module(str(fixture), context)
+
+    pm = ir.pass_manager(context)
+    passes.ttgpuir.add_optimize_thread_locality(pm)
+    pm.run(module, "mthreads_tle_set_layout_optimize_thread_locality")
+    return module.str_nodebug()
+
+
+def _run_ttgir_musa_pass(tmp_path, body, pass_name):
+    fixture = tmp_path / f"mthreads_tle_set_layout_{pass_name}.mlir"
+    fixture.write_text(f"{_CONVERSION_LAYOUTS}\n"
+                       "module attributes {\"ttg.num-ctas\" = 1 : i32, \"ttg.num-warps\" = 4 : i32, "
+                       "ttg.target = \"musa:ph1\", \"ttg.threads-per-warp\" = 32 : i32} {\n"
+                       f"{body}\n"
+                       "}\n")
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    module = ir.parse_mlir_module(str(fixture), context)
+
+    pm = ir.pass_manager(context)
+    musa_passes = libtriton.mthreads.passes.ttgpuir
+    pass_module = musa_passes if hasattr(musa_passes, pass_name) else passes.ttgpuir
+    getattr(pass_module, pass_name)(pm)
+    pm.run(module, f"mthreads_tle_set_layout_{pass_name}")
+    return module.str_nodebug()
+
+
+def _assert_set_layout_lowered(ttgir):
+    assert "musa_tle.set_layout" not in ttgir
+    assert "tle.gpu.set_layout" not in ttgir
+
+
+def _explicit_result_encoding(line):
+    match = re.search(r"tle\.explicit_encoding\.0 = (#\w+)", line)
+    assert match is not None, line
+    return match.group(1)
+
+
+def _type_encoding_aliases(line):
+    return re.findall(r", (#\w+)>", line)
+
+
+def _convert_layout_encodings(line):
+    attr_prefix = "tle.explicit_encoding.0 = "
+    assert attr_prefix in line, line
+    explicit = line.split(attr_prefix, 1)[1].split("} : tensor", 1)[0]
+    type_pair = line.split("} : ", 1)[1]
+    source, result = type_pair.split(" -> ", 1)
+    return explicit, source, result
+
+
+def _assert_direct_native_dot_chain(ttgir, mnemonic):
+    dot_lines = [line for line in ttgir.splitlines() if mnemonic in line]
+    assert len(dot_lines) == 2, ttgir
+    first_result = re.match(r"\s*(%\w+)\s*=", dot_lines[0])
+    assert first_result is not None, dot_lines[0]
+    assert re.search(rf"{re.escape(first_result.group(1))}(?=[,\s])", dot_lines[1]), dot_lines
+
+
+def _musa_runtime_available():
+    return hasattr(torch, "musa") and torch.musa.is_available()
+
+
+requires_musa_runtime = pytest.mark.skipif(
+    not _musa_runtime_available(),
+    reason="MUSA runtime is not available",
+)
+
+
+def _warmup_and_run(kernel, *args, grid=(1, ), **kwargs):
+    compiled = kernel.warmup(*args, grid=grid, **kwargs)
+    kernel[grid](*args, **kwargs)
+    return compiled
+
+
+def _assert_runtime_pipeline_ir(compiled, mnemonic=None, native_dot_count=1):
+    ttir = compiled.asm["ttir"]
+    ttgir = compiled.asm["ttgir"]
+    llir = compiled.asm["llir"]
+
+    assert "musa_tle.set_layout" in ttir
+    assert "tle.gpu.set_layout" not in ttir
+    _assert_set_layout_lowered(ttgir)
+    assert "tle.explicit_encoding." not in ttgir
+    assert "tle.explicit_memory_encoding" not in ttgir
+    assert "tle.explicit_encoding." not in llir
+    assert "tle.explicit_memory_encoding" not in llir
+    assert "nvvm" not in llir.lower()
+    if mnemonic:
+        assert ttgir.count(mnemonic) == native_dot_count
+        assert " tt.dot " not in ttgir
+
+
+@tl_core.builtin
+def _ensure_ttg_layout_attrs(num_warps: tl.constexpr, warp_size: tl.constexpr, num_ctas: tl.constexpr, _semantic=None):
+    _semantic.builder.ensure_ttg_layout_attrs(
+        int(tl_core._unwrap_if_constexpr(num_warps)),
+        int(tl_core._unwrap_if_constexpr(warp_size)),
+        int(tl_core._unwrap_if_constexpr(num_ctas)),
+    )
+
+
+@triton.jit
+def _valid_layout_attrs_kernel():
+    _ensure_ttg_layout_attrs(4, 32, 1)
+    _ensure_ttg_layout_attrs(4, 32, 1)
+
+
+@triton.jit
+def _num_warps_conflict_kernel():
+    _ensure_ttg_layout_attrs(4, 32, 1)
+    _ensure_ttg_layout_attrs(8, 32, 1)
+
+
+@triton.jit
+def _num_ctas_conflict_kernel():
+    _ensure_ttg_layout_attrs(4, 32, 1)
+    _ensure_ttg_layout_attrs(4, 32, 2)
+
+
+@triton.jit
+def _invalid_layout_attrs_kernel(num_warps: tl.constexpr, warp_size: tl.constexpr, num_ctas: tl.constexpr):
+    _ensure_ttg_layout_attrs(num_warps, warp_size, num_ctas)
+
+
+@triton.jit
+def _set_layout_block_numeric_kernel(src, out, BLOCK: tl.constexpr, LAYOUT: tl.constexpr):
+    rows = tl.arange(0, BLOCK)[:, None]
+    cols = tl.arange(0, BLOCK)[None, :]
+    offsets = rows * BLOCK + cols
+    values = tle.gpu.set_layout(tl.load(src + offsets), LAYOUT)
+    pointers = tle.gpu.set_layout(out + offsets, LAYOUT)
+    tl.store(pointers, values)
+
+
+@triton.jit
+def _set_layout_slice_numeric_kernel(src, out, BLOCK: tl.constexpr, LAYOUT: tl.constexpr):
+    offsets = tl.arange(0, BLOCK)
+    values = tle.gpu.set_layout(tl.load(src + offsets), LAYOUT)
+    pointers = tle.gpu.set_layout(out + offsets, LAYOUT)
+    tl.store(pointers, values)
+
+
+@triton.jit
+def _set_layout_transpose_numeric_kernel(
+    src,
+    out,
+    BLOCK: tl.constexpr,
+    SRC_LAYOUT: tl.constexpr,
+    DST_LAYOUT: tl.constexpr,
+):
+    rows = tl.arange(0, BLOCK)[:, None]
+    cols = tl.arange(0, BLOCK)[None, :]
+    offsets = rows * BLOCK + cols
+    src_offsets = tle.gpu.set_layout(offsets, SRC_LAYOUT)
+    dst_offsets = tle.gpu.set_layout(offsets, DST_LAYOUT)
+    values = tle.gpu.set_layout(tl.load(src + src_offsets), SRC_LAYOUT)
+    values = tl.trans(values) * 2.0 + 1.0
+    tl.store(out + dst_offsets, values)
+
+
+@triton.jit
+def _set_layout_dual_domain_numeric_kernel(
+    out_a,
+    out_b,
+    BLOCK: tl.constexpr,
+    LAYOUT_A: tl.constexpr,
+    LAYOUT_B: tl.constexpr,
+):
+    rows = tl.arange(0, BLOCK)[:, None]
+    cols = tl.arange(0, BLOCK)[None, :]
+    offsets = rows * BLOCK + cols
+    root = tl.full((BLOCK, BLOCK), 3.25, tl.float32)
+    values_a = tle.gpu.set_layout(root, LAYOUT_A)
+    values_b = tle.gpu.set_layout(root, LAYOUT_B)
+    offsets_a = tle.gpu.set_layout(offsets, LAYOUT_A)
+    offsets_b = tle.gpu.set_layout(offsets, LAYOUT_B)
+    pointers_a = out_a + offsets_a
+    pointers_b = out_b + offsets_b
+    tl.store(pointers_a, values_a)
+    tl.store(pointers_b, values_b)
+
+
+@triton.jit
+def _set_layout_shared_rank3_slice_numeric_kernel(
+    out_rows,
+    out_cols,
+    BLOCK: tl.constexpr,
+    ROW_LAYOUT: tl.constexpr,
+    COL_LAYOUT: tl.constexpr,
+):
+    values = tl.arange(0, BLOCK)
+    rows = tle.gpu.set_layout(values[None, :, None], ROW_LAYOUT)
+    cols = tle.gpu.set_layout(values[None, None, :], COL_LAYOUT)
+    tl.store(out_rows + rows, rows.to(tl.float32))
+    tl.store(out_cols + cols, cols.to(tl.float32))
+
+
+@triton.jit(noinline=True)
+def _set_layout_noinline_return_helper(BLOCK: tl.constexpr, LAYOUT: tl.constexpr):
+    values = tl.arange(0, BLOCK)
+    return tle.gpu.set_layout(values, LAYOUT)
+
+
+@triton.jit(noinline=True)
+def _set_layout_noinline_bridge_helper(BLOCK: tl.constexpr, LAYOUT: tl.constexpr):
+    return _set_layout_noinline_return_helper(BLOCK, LAYOUT)
+
+
+@triton.jit
+def _set_layout_noinline_numeric_kernel(out, BLOCK: tl.constexpr, LAYOUT: tl.constexpr):
+    values = _set_layout_noinline_bridge_helper(BLOCK, LAYOUT)
+    tl.store(out + values, values.to(tl.float32))
+
+
+@triton.jit
+def _set_layout_sqmma_pipeline_kernel(out, LAYOUT: tl.constexpr):
+    block_m: tl.constexpr = 128
+    block_n: tl.constexpr = 128
+    block_k: tl.constexpr = 64
+    a = tle.gpu.alloc((block_m, block_k), dtype=tl.float16, layout=None)
+    b = tle.gpu.alloc((block_k, block_n), dtype=tl.float16, layout=None)
+    acc = tle.gpu.wgmma(a, b, tl.zeros((block_m, block_n), dtype=tl.float32))
+    acc = tle.gpu.wgmma_wait(0, acc)
+    acc = tle.gpu.set_layout(acc, LAYOUT)
+    offsets = tl.arange(0, block_m)[:, None] * block_n + tl.arange(0, block_n)[None, :]
+    ptrs = tle.gpu.set_layout(out + offsets, LAYOUT)
+    tl.store(ptrs, acc)
+
+
+@triton.jit
+def _ordinary_ttgir_pipeline_kernel(out):
+    offsets = tl.arange(0, 128)
+    tl.store(out + offsets, offsets.to(tl.float32))
+
+
+@triton.jit
+def _automatic_musa_mma_numeric_kernel(
+    a_base,
+    b_base,
+    out,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    rows = tl.arange(0, BLOCK_M)[:, None]
+    cols = tl.arange(0, BLOCK_N)[None, :]
+    reduction = tl.arange(0, BLOCK_K)
+    lhs = tl.load(a_base + rows * BLOCK_K + reduction[None, :])
+    rhs = tl.load(b_base + reduction[:, None] * BLOCK_N + cols)
+    result = tl.dot(lhs, rhs, out_dtype=tl.float32)
+    tl.store(out + rows * BLOCK_N + cols, result)
+
+
+@triton.jit
+def _explicit_musa_wmma_kernel(
+    out,
+    MMA_LAYOUT: tl.constexpr,
+    LHS_LAYOUT: tl.constexpr,
+    RHS_LAYOUT: tl.constexpr,
+):
+    size: tl.constexpr = 16
+    lhs = tl.full((size, size), 1.0, tl.bfloat16)
+    rhs = tl.full((size, size), 2.0, tl.bfloat16)
+    lhs = tle.gpu.set_layout(lhs, LHS_LAYOUT)
+    rhs = tle.gpu.set_layout(rhs, RHS_LAYOUT)
+    acc = tle.gpu.set_layout(tl.zeros((size, size), tl.float32), MMA_LAYOUT)
+    result = tl.dot(lhs, rhs, acc=acc, out_dtype=tl.float32)
+    rows = tl.arange(0, size)[:, None]
+    cols = tl.arange(0, size)[None, :]
+    ptrs = tle.gpu.set_layout(out + rows * size + cols, MMA_LAYOUT)
+    tl.store(ptrs, result)
+
+
+@triton.jit
+def _explicit_musa_sqmma_kernel(
+    out,
+    MMA_LAYOUT: tl.constexpr,
+    LHS_LAYOUT: tl.constexpr,
+    RHS_LAYOUT: tl.constexpr,
+):
+    block_m: tl.constexpr = 64
+    block_n: tl.constexpr = 64
+    block_k: tl.constexpr = 32
+    lhs = tl.full((block_m, block_k), 1.0, tl.float16)
+    rhs = tl.full((block_k, block_n), 2.0, tl.float16)
+    lhs = tle.gpu.set_layout(lhs, LHS_LAYOUT)
+    rhs = tle.gpu.set_layout(rhs, RHS_LAYOUT)
+    acc = tle.gpu.set_layout(tl.zeros((block_m, block_n), tl.float32), MMA_LAYOUT)
+    result = tl.dot(lhs, rhs, acc=acc, out_dtype=tl.float32)
+    rows = tl.arange(0, block_m)[:, None]
+    cols = tl.arange(0, block_n)[None, :]
+    ptrs = tle.gpu.set_layout(out + rows * block_n + cols, MMA_LAYOUT)
+    tl.store(ptrs, result)
+
+
+@triton.jit
+def _explicit_musa_wmma_chained_kernel(
+    out,
+    MMA_LAYOUT: tl.constexpr,
+    LHS_LAYOUT: tl.constexpr,
+    RHS_LAYOUT: tl.constexpr,
+):
+    size: tl.constexpr = 16
+    lhs = tle.gpu.set_layout(tl.full((size, size), 1.0, tl.bfloat16), LHS_LAYOUT)
+    rhs = tle.gpu.set_layout(tl.full((size, size), 2.0, tl.bfloat16), RHS_LAYOUT)
+    acc = tle.gpu.set_layout(tl.zeros((size, size), tl.float32), MMA_LAYOUT)
+    first = tl.dot(lhs, rhs, acc=acc, out_dtype=tl.float32)
+    first = tle.gpu.set_layout(first, MMA_LAYOUT)
+    result = tl.dot(lhs, rhs, acc=first, out_dtype=tl.float32)
+    rows = tl.arange(0, size)[:, None]
+    cols = tl.arange(0, size)[None, :]
+    ptrs = tle.gpu.set_layout(out + rows * size + cols, MMA_LAYOUT)
+    tl.store(ptrs, result)
+
+
+@triton.jit
+def _explicit_musa_sqmma_chained_kernel(
+    out,
+    MMA_LAYOUT: tl.constexpr,
+    LHS_LAYOUT: tl.constexpr,
+    RHS_LAYOUT: tl.constexpr,
+):
+    block_m: tl.constexpr = 64
+    block_n: tl.constexpr = 64
+    block_k: tl.constexpr = 32
+    lhs = tle.gpu.set_layout(tl.full((block_m, block_k), 1.0, tl.float16), LHS_LAYOUT)
+    rhs = tle.gpu.set_layout(tl.full((block_k, block_n), 2.0, tl.float16), RHS_LAYOUT)
+    acc = tle.gpu.set_layout(tl.zeros((block_m, block_n), tl.float32), MMA_LAYOUT)
+    first = tl.dot(lhs, rhs, acc=acc, out_dtype=tl.float32)
+    first = tle.gpu.set_layout(first, MMA_LAYOUT)
+    result = tl.dot(lhs, rhs, acc=first, out_dtype=tl.float32)
+    rows = tl.arange(0, block_m)[:, None]
+    cols = tl.arange(0, block_n)[None, :]
+    ptrs = tle.gpu.set_layout(out + rows * block_n + cols, MMA_LAYOUT)
+    tl.store(ptrs, result)
+
+
+def test_mthreads_tle_layout_attr_builder_is_backend_local():
+    _, builder = _make_mthreads_builder()
+
+    assert hasattr(builder, "ensure_ttg_layout_attrs")
+    assert hasattr(builder, "get_blocked_encoding")
+    assert hasattr(builder, "get_sliced_encoding")
+    assert hasattr(builder, "get_dot_operand_layout")
+    assert hasattr(builder, "clone_tensor_type_with_encoding")
+    with pytest.raises(
+            ValueError,
+            match="mthreads TLE cannot set ttg layout attributes without an insertion block",
+    ):
+        builder.ensure_ttg_layout_attrs(4, 32, 1)
+
+
+def test_mthreads_tle_musa_mma_layout_builders_are_backend_local():
+    _, builder = _make_mthreads_builder()
+
+    assert hasattr(builder, "get_musa_wmma_layout")
+    assert hasattr(builder, "get_musa_sqmma_layout")
+
+
+def test_mthreads_tle_set_layout_builder_is_backend_local():
+    _, builder = _make_mthreads_builder()
+
+    assert hasattr(builder, "create_tle_gpu_set_layout")
+
+
+@pytest.mark.parametrize(
+    "layout,expected_type,expected_rank,parent_type",
+    [
+        (tle.gpu.BlockEncoding([1, 1], [1, 32], [4, 1], [1, 0]), tle.gpu.BlockEncoding, 2, None),
+        (
+            tle.gpu.SlicedEncoding(0, tle.gpu.BlockEncoding([1, 1], [1, 32], [4, 1], [1, 0])),
+            tle.gpu.SlicedEncoding,
+            1,
+            tle.gpu.BlockEncoding,
+        ),
+        (MusaWmmaEncoding([3, 1], [4, 1], [16, 16, 16]), MusaWmmaEncoding, 2, None),
+        (MusaSqmmaEncoding([3, 1], [4, 1], [64, 64, 32]), MusaSqmmaEncoding, 2, None),
+        (
+            MusaDotOperandEncoding(0, MusaWmmaEncoding([3, 1], [4, 1], [16, 16, 16])),
+            MusaDotOperandEncoding,
+            2,
+            MusaWmmaEncoding,
+        ),
+        (
+            MusaDotOperandEncoding(1, MusaSqmmaEncoding([3, 1], [4, 1], [64, 64, 32])),
+            MusaDotOperandEncoding,
+            2,
+            MusaSqmmaEncoding,
+        ),
+    ],
+)
+def test_mthreads_tle_python_layout_type_matrix(layout, expected_type, expected_rank, parent_type):
+    assert isinstance(layout, tle.gpu.distributed_encoding)
+    assert type(layout) is expected_type
+    assert layout.rank == expected_rank
+    assert isinstance(hash(layout), int)
+    assert expected_type.__name__ in repr(layout)
+    if parent_type is not None:
+        assert type(layout.parent) is parent_type
+
+
+def test_mthreads_tle_distributed_layout_builders_create_native_attrs():
+    _, builder = _make_mthreads_builder()
+    blocked = builder.get_blocked_encoding([1, 1], [1, 32], [4, 1], [1, 0], [])
+    sliced = builder.get_sliced_encoding(0, blocked)
+    wmma = builder.get_musa_wmma_layout([3, 1], [4, 1], [], [16, 16, 16])
+    sqmma = builder.get_musa_sqmma_layout([3, 1], [4, 1], [], [64, 64, 32])
+    wmma_lhs = builder.get_dot_operand_layout(0, wmma, 0)
+    wmma_rhs = builder.get_dot_operand_layout(1, wmma, 0)
+    sqmma_lhs = builder.get_dot_operand_layout(0, sqmma, 0)
+    sqmma_rhs = builder.get_dot_operand_layout(1, sqmma, 0)
+
+    module = builder.create_module()
+    module.set_attr("test.blocked", blocked)
+    module.set_attr("test.sliced", sliced)
+    module.set_attr("test.wmma_lhs", wmma_lhs)
+    module.set_attr("test.wmma_rhs", wmma_rhs)
+    module.set_attr("test.sqmma_lhs", sqmma_lhs)
+    module.set_attr("test.sqmma_rhs", sqmma_rhs)
+    printed = str(module)
+
+    assert "#ttg.blocked" in printed
+    assert "#ttg.slice" in printed
+    wmma_alias = re.search(r"(#mma\d*) = #ttg\.musa_wmma", printed)
+    sqmma_alias = re.search(r"(#mma\d*) = #ttg\.musa_sqmma", printed)
+    assert wmma_alias is not None, printed
+    assert sqmma_alias is not None, printed
+    for operand_index in (0, 1):
+        assert f"#ttg.dot_op<{{opIdx = {operand_index}, parent = {wmma_alias.group(1)}}}>" in printed
+        assert f"#ttg.dot_op<{{opIdx = {operand_index}, parent = {sqmma_alias.group(1)}}}>" in printed
+    assert "nvidia_mma" not in printed
+
+
+def test_mthreads_tle_clone_tensor_type_with_distributed_encoding():
+    _, builder = _make_mthreads_builder()
+    blocked = builder.get_blocked_encoding([1, 1], [1, 32], [4, 1], [1, 0], [])
+    element_type = builder.get_float_ty()
+    tensor_type = builder.get_block_ty(element_type, [16, 16])
+
+    cloned = builder.clone_tensor_type_with_encoding(tensor_type, blocked)
+
+    assert str(cloned).startswith("tensor<16x16xf32, #ttg.blocked")
+
+
+@pytest.mark.parametrize(
+    "method,args,diagnostic",
+    [
+        (
+            "get_blocked_encoding",
+            ([], [], [], [], []),
+            "mthreads TLE blocked encoding rank must be positive",
+        ),
+        (
+            "get_blocked_encoding",
+            ([1, 1], [1, 32], [4], [1, 0], []),
+            "mthreads TLE blocked encoding fields must have the same rank",
+        ),
+        (
+            "get_blocked_encoding",
+            ([1, 1], [1, 32], [4, 1], [0, 0], []),
+            "mthreads TLE blocked encoding order must be a permutation of 0..rank-1",
+        ),
+        (
+            "get_blocked_encoding",
+            ([3, 1], [1, 32], [4, 1], [1, 0], []),
+            "mthreads TLE blocked encoding size_per_thread entries must be positive powers of two",
+        ),
+        (
+            "get_blocked_encoding",
+            ([1, 1], [2, 8], [4, 1], [1, 0], []),
+            "mthreads TLE PH1 blocked encoding requires product(threads_per_warp) == 32",
+        ),
+        (
+            "get_blocked_encoding",
+            ([1, 1], [1, 32], [3, 1], [1, 0], []),
+            "mthreads TLE blocked encoding warps_per_cta entries must be positive powers of two",
+        ),
+        (
+            "get_blocked_encoding",
+            ([1, 1], [1, 32], [4, 1], [1, 0], [[0]]),
+            "mthreads TLE CGA layout basis 0 has rank 1, expected 2",
+        ),
+        (
+            "get_blocked_encoding",
+            ([1, 1], [1, 32], [4, 1], [1, 0], [[0, -1]]),
+            "mthreads TLE CGA layout basis 0 contains a negative value",
+        ),
+    ],
+)
+def test_mthreads_tle_blocked_layout_builder_rejects_invalid_contracts(method, args, diagnostic):
+    _, builder = _make_mthreads_builder()
+    with pytest.raises(ValueError, match=re.escape(diagnostic)):
+        getattr(builder, method)(*args)
+
+
+def test_mthreads_tle_sliced_layout_builder_rejects_invalid_contracts():
+    _, builder = _make_mthreads_builder()
+    not_distributed = builder.get_string_attr("not-a-layout")
+    rank_one = builder.get_blocked_encoding([1], [32], [4], [0], [])
+    rank_two = builder.get_blocked_encoding([1, 1], [1, 32], [4, 1], [1, 0], [])
+
+    with pytest.raises(ValueError, match="parent must be a distributed encoding"):
+        builder.get_sliced_encoding(0, not_distributed)
+    with pytest.raises(ValueError, match="parent rank must be at least 2"):
+        builder.get_sliced_encoding(0, rank_one)
+    with pytest.raises(ValueError, match="dim must be less than parent rank"):
+        builder.get_sliced_encoding(2, rank_two)
+
+
+def test_mthreads_tle_dot_operand_layout_builder_rejects_invalid_contracts():
+    _, builder = _make_mthreads_builder()
+    blocked = builder.get_blocked_encoding([1, 1], [1, 32], [4, 1], [1, 0], [])
+    wmma = builder.get_musa_wmma_layout([3, 1], [4, 1], [], [16, 16, 16])
+
+    with pytest.raises(ValueError, match="dot operand index must be 0 or 1"):
+        builder.get_dot_operand_layout(2, wmma, 0)
+    with pytest.raises(ValueError, match="parent must be a MUSA WMMA or SQMMA encoding"):
+        builder.get_dot_operand_layout(0, blocked, 0)
+    with pytest.raises(ValueError, match="MUSA dot operand requires k_width=0"):
+        builder.get_dot_operand_layout(0, wmma, 1)
+
+
+def test_mthreads_tle_clone_tensor_type_rejects_invalid_contracts():
+    _, builder = _make_mthreads_builder()
+    scalar_type = builder.get_float_ty()
+    tensor_type = builder.get_block_ty(scalar_type, [16, 16])
+    not_distributed = builder.get_string_attr("not-a-layout")
+    rank_one = builder.get_blocked_encoding([1], [32], [4], [0], [])
+
+    with pytest.raises(TypeError, match="only clone a ranked tensor type"):
+        builder.clone_tensor_type_with_encoding(scalar_type, rank_one)
+    with pytest.raises(TypeError, match="encoding must be a distributed encoding"):
+        builder.clone_tensor_type_with_encoding(tensor_type, not_distributed)
+    with pytest.raises(ValueError, match="tensor rank must match distributed encoding rank"):
+        builder.clone_tensor_type_with_encoding(tensor_type, rank_one)
+
+
+def test_mthreads_tle_set_layout_binding_rejects_invalid_contracts():
+    _scalar_context, scalar_builder, _scalar_module, scalar = _make_mthreads_function_argument()
+    rank_one = scalar_builder.get_blocked_encoding([1], [32], [4], [0], [])
+    with pytest.raises(TypeError, match="set_layout source must be a ranked tensor"):
+        scalar_builder.create_tle_gpu_set_layout(scalar, rank_one)
+
+    _tensor_context, tensor_builder, _tensor_module, tensor = _make_mthreads_function_argument([16, 16])
+    not_distributed = tensor_builder.get_string_attr("not-a-layout")
+    with pytest.raises(TypeError, match="target_encoding must be a distributed encoding"):
+        tensor_builder.create_tle_gpu_set_layout(tensor, not_distributed)
+
+    shared = tensor_builder.make_swizzled_shared_encoding_attr(1, 1, 1, [1, 0], [1, 1], [1, 1], [1, 0])
+    with pytest.raises(TypeError, match="target_encoding must be a distributed encoding"):
+        tensor_builder.create_tle_gpu_set_layout(tensor, shared)
+
+    rank_one = tensor_builder.get_blocked_encoding([1], [32], [4], [0], [])
+    with pytest.raises(ValueError, match="target encoding rank 1 must match source tensor rank 2"):
+        tensor_builder.create_tle_gpu_set_layout(tensor, rank_one)
+
+
+@pytest.mark.parametrize(
+    "method,args,expected_mnemonic",
+    [
+        ("get_musa_wmma_layout", ([3, 1], [4, 1], [], [16, 16, 16]), "#ttg.musa_wmma"),
+        ("get_musa_sqmma_layout", ([3, 1], [4, 1], [], [64, 64, 32]), "#ttg.musa_sqmma"),
+        ("get_musa_wmma_layout", ([3, 1], [2, 2, 1], [[0, 1, 0]], [16, 8, 8]), "#ttg.musa_wmma"),
+        ("get_musa_sqmma_layout", ([3, 1], [4, 2, 1], [[0, 1, 0]], [32, 64, 16]), "#ttg.musa_sqmma"),
+    ],
+)
+def test_mthreads_tle_musa_mma_layout_builders_create_native_attrs(method, args, expected_mnemonic):
+    _, builder = _make_mthreads_builder()
+    attr = getattr(builder, method)(*args)
+    module = builder.create_module()
+    module.set_attr("test.layout", attr)
+    printed = str(module)
+
+    assert expected_mnemonic in printed
+    assert "versionMajor = 3" in printed
+    assert "versionMinor = 1" in printed
+    assert "instrShape" in printed
+    assert "nvidia_mma" not in printed
+
+
+@pytest.mark.parametrize(
+    "method,args,diagnostic",
+    [
+        (
+            "get_musa_wmma_layout",
+            ([3], [4, 1], [], [16, 16, 16]),
+            "mthreads TLE WMMA version must contain major and minor",
+        ),
+        (
+            "get_musa_wmma_layout",
+            ([3, 2], [4, 1], [], [16, 16, 16]),
+            "mthreads TLE WMMA currently supports only MUSA PH1 version [3, 1]",
+        ),
+        (
+            "get_musa_wmma_layout",
+            ([3, 1], [4], [], [16, 16, 16]),
+            "mthreads TLE WMMA warps_per_cta rank must be 2 or 3",
+        ),
+        (
+            "get_musa_wmma_layout",
+            ([3, 1], [3, 1], [], [16, 16, 16]),
+            "mthreads TLE WMMA warps_per_cta entries must be positive powers of two",
+        ),
+        (
+            "get_musa_wmma_layout",
+            ([3, 1], [2, 2, 2], [], [16, 16, 16]),
+            "mthreads TLE WMMA rank-3 warps_per_cta must end in 1",
+        ),
+        (
+            "get_musa_wmma_layout",
+            ([3, 1], [4, 1], [], [16, 16]),
+            "mthreads TLE WMMA instr_shape must contain logical (M, N, K)",
+        ),
+        (
+            "get_musa_wmma_layout",
+            ([3, 1], [4, 1], [], [8, 8, 8]),
+            "mthreads TLE WMMA instr_shape is not supported by any PH1 WMMA intrinsic",
+        ),
+        (
+            "get_musa_sqmma_layout",
+            ([3, 1], [2, 2], [], [64, 64, 32]),
+            "mthreads TLE SQMMA warps_per_cta[0] must be a multiple of 4",
+        ),
+        (
+            "get_musa_sqmma_layout",
+            ([3, 1], [4, 1], [], [32, 128, 8]),
+            "mthreads TLE SQMMA instr_shape is not supported by any PH1 SQMMA type contract",
+        ),
+        (
+            "get_musa_wmma_layout",
+            ([3, 1], [2, 2, 1], [[0, 1]], [16, 16, 16]),
+            "mthreads TLE WMMA CGA layout basis 0 has rank 2, expected 3",
+        ),
+        (
+            "get_musa_sqmma_layout",
+            ([3, 1], [4, 1], [[0, -1]], [64, 64, 32]),
+            "mthreads TLE SQMMA CGA layout basis 0 contains a negative value",
+        ),
+    ],
+)
+def test_mthreads_tle_musa_mma_layout_builders_reject_invalid_contracts(method, args, diagnostic):
+    _, builder = _make_mthreads_builder()
+    with pytest.raises(ValueError, match=re.escape(diagnostic)):
+        getattr(builder, method)(*args)
+
+
+def test_mthreads_tle_set_layout_dialect_round_trip(tmp_path):
+    fixture = tmp_path / "mthreads_tle_set_layout.mlir"
+    fixture.write_text("""
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#slice = #ttg.slice<{dim = 0, parent = #blocked}>
+#wmma = #ttg.musa_wmma<{versionMajor = 3, versionMinor = 1, warpsPerCTA = [4, 1], instrShape = [16, 16, 16]}>
+#sqmma = #ttg.musa_sqmma<{versionMajor = 3, versionMinor = 1, warpsPerCTA = [4, 1], instrShape = [64, 64, 32]}>
+#wmma_lhs = #ttg.dot_op<{opIdx = 0, parent = #wmma}>
+#sqmma_rhs = #ttg.dot_op<{opIdx = 1, parent = #sqmma}>
+module {
+  tt.func public @blocked(%arg0: tensor<16x16xf32>) {
+    %0 = musa_tle.set_layout %arg0 {target_encoding = #blocked} : tensor<16x16xf32> -> tensor<16x16xf32>
+    tt.return
+  }
+  tt.func public @slice(%arg0: tensor<16xf32>) {
+    %0 = musa_tle.set_layout %arg0 {target_encoding = #slice} : tensor<16xf32> -> tensor<16xf32>
+    tt.return
+  }
+  tt.func public @wmma(%arg0: tensor<16x16xf32>) {
+    %0 = musa_tle.set_layout %arg0 {target_encoding = #wmma} : tensor<16x16xf32> -> tensor<16x16xf32>
+    tt.return
+  }
+  tt.func public @sqmma(%arg0: tensor<64x64xf32>) {
+    %0 = musa_tle.set_layout %arg0 {target_encoding = #sqmma} : tensor<64x64xf32> -> tensor<64x64xf32>
+    tt.return
+  }
+  tt.func public @wmma_lhs(%arg0: tensor<16x16xf32>) {
+    %0 = musa_tle.set_layout %arg0 {target_encoding = #wmma_lhs} : tensor<16x16xf32> -> tensor<16x16xf32>
+    tt.return
+  }
+  tt.func public @sqmma_rhs(%arg0: tensor<64x64xf32>) {
+    %0 = musa_tle.set_layout %arg0 {target_encoding = #sqmma_rhs} : tensor<64x64xf32> -> tensor<64x64xf32>
+    tt.return
+  }
+}
+""")
+
+    context, _ = _make_mthreads_builder()
+    module = ir.parse_mlir_module(str(fixture), context)
+    printed = str(module)
+
+    assert printed.count("musa_tle.set_layout") == 6
+    assert "tle.gpu.set_layout" not in printed
+    assert "#ttg.blocked" in printed
+    assert "#ttg.slice" in printed
+    assert "#ttg.musa_wmma" in printed
+    assert "#ttg.musa_sqmma" in printed
+    assert "#ttg.dot_op" in printed
+
+
+@pytest.mark.parametrize(
+    "tensor_type,target_encoding,diagnostic",
+    [
+        ("tensor<16x16xf32>", "#shared_a", "target_encoding must be a distributed encoding"),
+        ("tensor<16x16xf32>", '"not-a-layout"', "target_encoding must be a distributed encoding"),
+        (
+            "tensor<16x16xf32>",
+            "#layout_1d_a",
+            "target encoding rank 1 must match source tensor rank 2",
+        ),
+        ("tensor<16xf32>", "#layout_a", "target encoding rank 2 must match source tensor rank 1"),
+    ],
+)
+def test_mthreads_tle_set_layout_verifier_rejects_invalid_target_encoding(tmp_path, capfd, tensor_type, target_encoding,
+                                                                          diagnostic):
+    fixture = tmp_path / "mthreads_tle_invalid_set_layout_target.mlir"
+    fixture.write_text(f"""{_CONVERSION_LAYOUTS}
+module {{
+  tt.func public @invalid_target(%arg0: {tensor_type}) {{
+    %0 = musa_tle.set_layout %arg0 {{target_encoding = {target_encoding}}} : {tensor_type} -> {tensor_type}
+    tt.return
+  }}
+}}
+""")
+
+    context, _ = _make_mthreads_builder()
+    with pytest.raises(RuntimeError):
+        ir.parse_mlir_module(str(fixture), context)
+
+    error = capfd.readouterr().err
+    assert diagnostic in error
+    assert "Assertion" not in error
+    assert "signal caught" not in error
+    assert "PassManager::run failed" not in error
+
+
+@pytest.mark.parametrize(
+    "tensor_type,target_layout,expected_layout",
+    [
+        ("tensor<16x16xf32>", "#layout_a", "#ttg.blocked"),
+        ("tensor<16xf32>", "#slice_a", "#ttg.slice"),
+    ],
+)
+def test_mthreads_tle_set_layout_lowers_identity_without_convert(tmp_path, tensor_type, target_layout, expected_layout):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        f"""
+  tt.func public @identity(%arg0: {tensor_type}) {{
+    %0 = musa_tle.set_layout %arg0 {{target_encoding = {target_layout}}} : {tensor_type} -> {tensor_type}
+    tt.return
+  }}
+""",
+    )
+
+    function_line = next(line for line in ttgir.splitlines() if "@identity" in line)
+    assert ", #" in function_line
+    assert expected_layout in ttgir
+    assert "ttg.convert_layout" not in ttgir
+    _assert_set_layout_lowered(ttgir)
+
+
+def test_mthreads_tle_set_layout_updates_dense_constant_type(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @constant_source() {
+    %value = arith.constant dense<0.0> : tensor<16x16xf32>
+    %0 = musa_tle.set_layout %value {target_encoding = #layout_a} : tensor<16x16xf32> -> tensor<16x16xf32>
+    tt.return
+  }
+""",
+    )
+
+    constant_line = next(line for line in ttgir.splitlines() if "arith.constant" in line)
+    target = _explicit_result_encoding(constant_line)
+    assert _type_encoding_aliases(constant_line) == [target]
+    assert re.search(
+        rf"arith\.constant(?: \{{[^}}]*\}})? dense<0\.000000e\+00> : "
+        rf"tensor<16x16xf32, {re.escape(target)}>",
+        ttgir,
+    ), ttgir
+    assert "ttg.convert_layout" not in ttgir
+    _assert_set_layout_lowered(ttgir)
+
+
+def test_mthreads_tle_set_layout_merges_shared_root_uses_in_one_domain(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @shared_root_one_domain() {
+    %seed_value = arith.constant dense<0> : tensor<128xi32>
+    %seed = musa_tle.set_layout %seed_value {target_encoding = #layout_1d_a} : tensor<128xi32> -> tensor<128xi32>
+    %shared = arith.constant dense<1> : tensor<128xi32>
+    %sum0 = arith.addi %seed, %shared : tensor<128xi32>
+    %sum1 = arith.addi %seed, %shared : tensor<128xi32>
+    tt.return
+  }
+""",
+    )
+
+    shared_lines = [line for line in ttgir.splitlines() if "arith.constant" in line and "dense<1>" in line]
+    assert len(shared_lines) == 1
+    shared_encoding = _explicit_result_encoding(shared_lines[0])
+    add_lines = [line for line in ttgir.splitlines() if "arith.addi" in line]
+    assert len(add_lines) == 2
+    assert all(shared_encoding in line for line in add_lines)
+    assert "ttg.convert_layout" not in ttgir
+
+
+def test_mthreads_tle_set_layout_isolates_shared_rank3_slice_domains(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @shared_rank3_slice_domains() {
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %shared = tt.expand_dims %range {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+    %rows = tt.expand_dims %shared {axis = 2 : i32} : tensor<1x128xi32> -> tensor<1x128x1xi32>
+    %cols = tt.expand_dims %shared {axis = 1 : i32} : tensor<1x128xi32> -> tensor<1x1x128xi32>
+    %row_layout = musa_tle.set_layout %rows {target_encoding = #layout_3d_a} : tensor<1x128x1xi32> -> tensor<1x128x1xi32>
+    %col_layout = musa_tle.set_layout %cols {target_encoding = #layout_3d_b} : tensor<1x1x128xi32> -> tensor<1x1x128xi32>
+    tt.return
+  }
+""",
+    )
+
+    range_lines = [line for line in ttgir.splitlines() if "tt.make_range" in line]
+    shared_expand_lines = [line for line in ttgir.splitlines() if "tt.expand_dims" in line and "axis = 0" in line]
+    branch_expand_lines = [
+        line for line in ttgir.splitlines() if "tt.expand_dims" in line and ("axis = 1" in line or "axis = 2" in line)
+    ]
+    assert len(range_lines) == 2, ttgir
+    assert len(shared_expand_lines) == 2, ttgir
+    assert len(branch_expand_lines) == 2, ttgir
+    assert len({line.split(" -> ", 1)[1] for line in shared_expand_lines}) == 2
+    assert len({_explicit_result_encoding(line) for line in branch_expand_lines}) == 2
+    _assert_set_layout_lowered(ttgir)
+
+
+@pytest.mark.parametrize("caller_first", [False, True])
+def test_mthreads_tle_set_layout_synchronizes_noinline_function_abi(tmp_path, caller_first):
+    callee = """
+  tt.func private @layout_callee(%arg0: tensor<128xi32>) -> (tensor<128xi32>, i32) {
+    %layout = musa_tle.set_layout %arg0 {target_encoding = #layout_1d_a} : tensor<128xi32> -> tensor<128xi32>
+    %c7_i32 = arith.constant 7 : i32
+    tt.return %layout, %c7_i32 : tensor<128xi32>, i32
+  }
+"""
+    caller = """
+  tt.func public @layout_caller() {
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %first:2 = tt.call @layout_callee(%range) : (tensor<128xi32>) -> (tensor<128xi32>, i32)
+    %second:2 = tt.call @layout_callee(%range) : (tensor<128xi32>) -> (tensor<128xi32>, i32)
+    tt.return
+  }
+"""
+    body = caller + callee if caller_first else callee + caller
+    ttgir = _convert_set_layout_to_ttgir(tmp_path, body)
+
+    callee_line = next(line for line in ttgir.splitlines() if "tt.func private @layout_callee" in line)
+    call_lines = [line for line in ttgir.splitlines() if "tt.call @layout_callee" in line]
+    return_line = next(line for line in ttgir.splitlines() if "tt.return" in line and "i32" in line)
+    encoding = _type_encoding_aliases(callee_line)[0]
+    assert len(call_lines) == 2, ttgir
+    assert all(encoding in line for line in call_lines), ttgir
+    assert encoding in return_line, ttgir
+    assert all(line.count("i32") >= 1 for line in call_lines), ttgir
+
+
+def test_mthreads_tle_set_layout_synchronizes_multilevel_call_results(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @layout_root() {
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %result = tt.call @layout_bridge(%range) : (tensor<128xi32>) -> tensor<128xi32>
+    tt.return
+  }
+  tt.func private @layout_bridge(%arg0: tensor<128xi32>) -> tensor<128xi32> {
+    %result = tt.call @layout_leaf(%arg0) : (tensor<128xi32>) -> tensor<128xi32>
+    tt.return %result : tensor<128xi32>
+  }
+  tt.func private @layout_leaf(%arg0: tensor<128xi32>) -> tensor<128xi32> {
+    %layout = musa_tle.set_layout %arg0 {target_encoding = #layout_1d_a} : tensor<128xi32> -> tensor<128xi32>
+    tt.return %layout : tensor<128xi32>
+  }
+""",
+    )
+
+    function_lines = [line for line in ttgir.splitlines() if "tt.func" in line and "@layout_" in line]
+    call_lines = [line for line in ttgir.splitlines() if "tt.call @layout_" in line]
+    assert len(function_lines) == 3, ttgir
+    assert len(call_lines) == 2, ttgir
+    encoding = _type_encoding_aliases(function_lines[1])[0]
+    assert all(encoding in line for line in function_lines[1:]), ttgir
+    assert all(encoding in line for line in call_lines), ttgir
+
+
+def test_mthreads_tle_set_layout_propagates_call_result_contract_to_callee(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func private @layout_producer() -> tensor<128xi32> {
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    tt.return %range : tensor<128xi32>
+  }
+  tt.func public @layout_consumer() {
+    %result = tt.call @layout_producer() : () -> tensor<128xi32>
+    %layout = musa_tle.set_layout %result {target_encoding = #layout_1d_a} : tensor<128xi32> -> tensor<128xi32>
+    tt.return
+  }
+""",
+    )
+
+    producer_line = next(line for line in ttgir.splitlines() if "tt.func private @layout_producer" in line)
+    call_line = next(line for line in ttgir.splitlines() if "tt.call @layout_producer" in line)
+    producer_return = next(line for line in ttgir.splitlines() if "tt.return" in line and "tensor<128xi32" in line)
+    encoding = _type_encoding_aliases(producer_line)[0]
+    assert encoding in call_line, ttgir
+    assert encoding in producer_return, ttgir
+
+
+def test_mthreads_tle_set_layout_unifies_encoded_and_unencoded_returns(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func private @mixed_returns(%condition: i1) -> tensor<128xi32> {
+    cf.cond_br %condition, ^bb1, ^bb2
+  ^bb1:
+    %range_a = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %layout_a = musa_tle.set_layout %range_a {target_encoding = #layout_1d_a} : tensor<128xi32> -> tensor<128xi32>
+    tt.return %layout_a : tensor<128xi32>
+  ^bb2:
+    %range_b = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    tt.return %range_b : tensor<128xi32>
+  }
+""",
+    )
+
+    function_line = next(line for line in ttgir.splitlines() if "tt.func private @mixed_returns" in line)
+    return_lines = [line for line in ttgir.splitlines() if "tt.return" in line]
+    range_lines = [line for line in ttgir.splitlines() if "tt.make_range" in line]
+    encoding = _type_encoding_aliases(function_line)[0]
+    assert len(return_lines) == 2, ttgir
+    assert len(range_lines) == 2, ttgir
+    assert all(encoding in line for line in return_lines), ttgir
+    assert all(encoding in line for line in range_lines), ttgir
+
+
+def test_mthreads_tle_set_layout_rejects_conflicting_return_abi(tmp_path, capfd):
+    with pytest.raises(RuntimeError):
+        _convert_set_layout_to_ttgir(
+            tmp_path,
+            """
+  tt.func private @conflicting_return() -> tensor<128xi32> {
+    %condition = arith.constant true
+    cf.cond_br %condition, ^bb1, ^bb2
+  ^bb1:
+    %range_a = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %layout_a = musa_tle.set_layout %range_a {target_encoding = #layout_1d_a} : tensor<128xi32> -> tensor<128xi32>
+    tt.return %layout_a : tensor<128xi32>
+  ^bb2:
+    %range_b = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %layout_b = musa_tle.set_layout %range_b {target_encoding = #layout_1d_b} : tensor<128xi32> -> tensor<128xi32>
+    tt.return %layout_b : tensor<128xi32>
+  }
+""",
+        )
+
+    error = capfd.readouterr().err
+    assert "conflicting MUSA TLE ABI encodings for result #0" in error
+    assert "sizePerThread = [1]" in error
+    assert "sizePerThread = [2]" in error
+
+
+def test_mthreads_tle_set_layout_rejects_conflicting_call_argument_abi(tmp_path, capfd):
+    with pytest.raises(RuntimeError):
+        _convert_set_layout_to_ttgir(
+            tmp_path,
+            """
+  tt.func private @argument_callee(%arg0: tensor<128xi32>) {
+    tt.return
+  }
+  tt.func public @argument_caller() {
+    %range_a = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %range_b = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %layout_a = musa_tle.set_layout %range_a {target_encoding = #layout_1d_a} : tensor<128xi32> -> tensor<128xi32>
+    %layout_b = musa_tle.set_layout %range_b {target_encoding = #layout_1d_b} : tensor<128xi32> -> tensor<128xi32>
+    tt.call @argument_callee(%layout_a) : (tensor<128xi32>) -> ()
+    tt.call @argument_callee(%layout_b) : (tensor<128xi32>) -> ()
+    tt.return
+  }
+""",
+        )
+
+    error = capfd.readouterr().err
+    assert "conflicting MUSA TLE ABI encodings for argument #0" in error
+    assert "sizePerThread = [1]" in error
+    assert "sizePerThread = [2]" in error
+
+
+def test_mthreads_tle_set_layout_does_not_clone_memory_roots(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @shared_load(%ptrs: tensor<32x!tt.ptr<f32>>) {
+    %loaded = tt.load %ptrs : tensor<32x!tt.ptr<f32>>
+    %lhs = musa_tle.set_layout %loaded {target_encoding = #layout_1d_a} : tensor<32xf32> -> tensor<32xf32>
+    %rhs = musa_tle.set_layout %loaded {target_encoding = #layout_1d_b} : tensor<32xf32> -> tensor<32xf32>
+    tt.return
+  }
+""",
+    )
+
+    assert ttgir.count("tt.load") == 1
+    assert ttgir.count("ttg.convert_layout") == 1
+    _assert_set_layout_lowered(ttgir)
+
+
+def test_mthreads_tle_root_isolation_is_noop_without_set_layout(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @shared_root_without_set_layout() {
+    %shared = arith.constant dense<1> : tensor<128xi32>
+    %sum0 = arith.addi %shared, %shared : tensor<128xi32>
+    %sum1 = arith.addi %shared, %shared : tensor<128xi32>
+    tt.return
+  }
+""",
+    )
+
+    shared_lines = [line for line in ttgir.splitlines() if "arith.constant" in line and "dense<1>" in line]
+    assert len(shared_lines) == 1
+    assert "tle.explicit_encoding." not in ttgir
+
+
+def test_mthreads_tle_set_layout_hard_hint_overrides_soft_hint(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @hard_over_soft(%arg0: tensor<16x16xf32>) {
+    %0 = musa_tle.set_layout %arg0 {target_encoding = #layout_a} : tensor<16x16xf32> -> tensor<16x16xf32>
+    %1 = musa_tle.set_layout %0 {target_encoding = #layout_b} : tensor<16x16xf32> -> tensor<16x16xf32>
+    tt.return
+  }
+""",
+    )
+
+    convert_lines = [line for line in ttgir.splitlines() if "ttg.convert_layout" in line]
+    assert len(convert_lines) == 1
+    explicit, source, result = _convert_layout_encodings(convert_lines[0])
+    assert source != result
+    assert explicit in result
+    assert explicit not in source
+    _assert_set_layout_lowered(ttgir)
+
+
+def test_mthreads_tle_set_layout_merges_matching_hard_hints(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @matching_hard_hints(%arg0: tensor<16x16xf32>, %arg1: tensor<16x16xf32>) {
+    %0 = musa_tle.set_layout %arg0 {target_encoding = #layout_a} : tensor<16x16xf32> -> tensor<16x16xf32>
+    %1 = musa_tle.set_layout %arg1 {target_encoding = #layout_a} : tensor<16x16xf32> -> tensor<16x16xf32>
+    %2 = arith.addf %0, %1 : tensor<16x16xf32>
+    tt.return
+  }
+""",
+    )
+
+    add_line = next(line for line in ttgir.splitlines() if "arith.addf" in line)
+    target = _explicit_result_encoding(add_line)
+    assert _type_encoding_aliases(add_line) == [target]
+    assert "ttg.convert_layout" not in ttgir
+    _assert_set_layout_lowered(ttgir)
+
+
+def test_mthreads_tle_set_layout_rejects_conflicting_hard_hints(tmp_path, capfd):
+    with pytest.raises(RuntimeError):
+        _convert_set_layout_to_ttgir(
+            tmp_path,
+            """
+  tt.func public @conflicting_hard_hints(%arg0: tensor<16x16xf32>, %arg1: tensor<16x16xf32>) {
+    %0 = musa_tle.set_layout %arg0 {target_encoding = #layout_a} : tensor<16x16xf32> -> tensor<16x16xf32>
+    %1 = musa_tle.set_layout %arg1 {target_encoding = #layout_b} : tensor<16x16xf32> -> tensor<16x16xf32>
+    %2 = arith.addf %0, %1 : tensor<16x16xf32>
+    tt.return
+  }
+""",
+        )
+
+    diagnostic = capfd.readouterr().err
+    assert "found conflicting MUSA TLE encoding hints for value" in diagnostic
+    assert "threadsPerWarp = [1, 32]" in diagnostic
+    assert "threadsPerWarp = [32, 1]" in diagnostic
+
+
+def test_mthreads_tle_hint_pass_is_noop_without_set_layout(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @without_set_layout(%arg0: f32, %arg1: f32) {
+    %0 = arith.addf %arg0, %arg1 : f32
+    tt.return
+  }
+""",
+    )
+
+    assert "musa_tle.set_layout" not in ttgir
+    assert "arith.addf" in ttgir
+
+
+@pytest.mark.parametrize("direction", ["forward", "backward"])
+def test_mthreads_tle_set_layout_propagates_through_scf_for(tmp_path, direction):
+    if direction == "forward":
+        prelude = """
+    %seed = musa_tle.set_layout %arg0 {target_encoding = #layout_a} : tensor<16x16xf32> -> tensor<16x16xf32>
+"""
+        init = "%seed"
+        epilogue = """
+    %use = arith.addf %loop, %loop : tensor<16x16xf32>
+"""
+    else:
+        prelude = ""
+        init = "%arg0"
+        epilogue = """
+    %encoded = musa_tle.set_layout %loop {target_encoding = #layout_a} : tensor<16x16xf32> -> tensor<16x16xf32>
+"""
+
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        f"""
+  tt.func public @for_{direction}(%arg0: tensor<16x16xf32>) {{
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c2 = arith.constant 2 : i32
+{prelude}
+    %loop = scf.for %iv = %c0 to %c2 step %c1 iter_args(%iter = {init}) -> (tensor<16x16xf32>) : i32 {{
+      %next = arith.addf %iter, %iter : tensor<16x16xf32>
+      scf.yield %next : tensor<16x16xf32>
+    }}
+{epilogue}
+    tt.return
+  }}
+""",
+    )
+
+    add_line = next(line for line in ttgir.splitlines() if "arith.addf" in line)
+    target = _explicit_result_encoding(add_line)
+    for line in ttgir.splitlines():
+        if "scf.for" in line or "scf.yield" in line or "arith.addf" in line:
+            assert target in line, line
+    assert "ttg.convert_layout" not in ttgir
+    _assert_set_layout_lowered(ttgir)
+
+
+def test_mthreads_tle_set_layout_propagates_through_scf_while(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @while_forward(%arg0: tensor<16x16xf32>) {
+    %true = arith.constant true
+    %seed = musa_tle.set_layout %arg0 {target_encoding = #layout_a} : tensor<16x16xf32> -> tensor<16x16xf32>
+    %loop = scf.while (%before = %seed) : (tensor<16x16xf32>) -> (tensor<16x16xf32>) {
+      scf.condition(%true) %before : tensor<16x16xf32>
+    } do {
+    ^bb0(%after: tensor<16x16xf32>):
+      %next = arith.addf %after, %after : tensor<16x16xf32>
+      scf.yield %next : tensor<16x16xf32>
+    }
+    %use = arith.addf %loop, %loop : tensor<16x16xf32>
+    tt.return
+  }
+""",
+    )
+
+    add_line = next(line for line in ttgir.splitlines() if "arith.addf" in line)
+    target = _explicit_result_encoding(add_line)
+    for line in ttgir.splitlines():
+        if any(op in line for op in ("scf.while", "scf.condition", "scf.yield", "arith.addf")):
+            assert target in line, line
+    assert re.search(rf"\^bb0\([^\n]*{re.escape(target)}", ttgir), ttgir
+    assert "ttg.convert_layout" not in ttgir
+    _assert_set_layout_lowered(ttgir)
+
+
+def test_mthreads_tle_set_layout_propagates_from_while_condition_and_yield(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @while_condition(%arg0: tensor<16x16xf32>) {
+    %true = arith.constant true
+    %loop = scf.while (%before = %arg0) : (tensor<16x16xf32>) -> (tensor<16x16xf32>) {
+      %encoded = musa_tle.set_layout %before {target_encoding = #layout_a} : tensor<16x16xf32> -> tensor<16x16xf32>
+      scf.condition(%true) %encoded : tensor<16x16xf32>
+    } do {
+    ^bb0(%after: tensor<16x16xf32>):
+      scf.yield %after : tensor<16x16xf32>
+    }
+    tt.return
+  }
+  tt.func public @while_yield(%arg0: tensor<16x16xf32>) {
+    %true = arith.constant true
+    %loop = scf.while (%before = %arg0) : (tensor<16x16xf32>) -> (tensor<16x16xf32>) {
+      scf.condition(%true) %before : tensor<16x16xf32>
+    } do {
+    ^bb0(%after: tensor<16x16xf32>):
+      %encoded = musa_tle.set_layout %after {target_encoding = #layout_b} : tensor<16x16xf32> -> tensor<16x16xf32>
+      scf.yield %encoded : tensor<16x16xf32>
+    }
+    tt.return
+  }
+""",
+    )
+
+    function_lines = [line for line in ttgir.splitlines() if "tt.func public @while_" in line]
+    assert len(function_lines) == 2
+    condition_layout = _type_encoding_aliases(function_lines[0])[0]
+    yield_layout = _type_encoding_aliases(function_lines[1])[0]
+    assert condition_layout != yield_layout
+    while_lines = [line for line in ttgir.splitlines() if "scf.while" in line]
+    condition_lines = [line for line in ttgir.splitlines() if "scf.condition" in line]
+    yield_lines = [line for line in ttgir.splitlines() if "scf.yield" in line]
+    assert condition_layout in while_lines[0] and condition_layout in condition_lines[0]
+    assert yield_layout in while_lines[1] and yield_layout in yield_lines[1]
+    assert "ttg.convert_layout" not in ttgir
+    _assert_set_layout_lowered(ttgir)
+
+
+def test_mthreads_tle_set_layout_propagates_through_scf_if(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @if_forward(%arg0: tensor<16x16xf32>) {
+    %true = arith.constant true
+    %seed = musa_tle.set_layout %arg0 {target_encoding = #layout_a} : tensor<16x16xf32> -> tensor<16x16xf32>
+    %branch = scf.if %true -> (tensor<16x16xf32>) {
+      scf.yield %seed : tensor<16x16xf32>
+    } else {
+      scf.yield %arg0 : tensor<16x16xf32>
+    }
+    %use = arith.addf %branch, %branch : tensor<16x16xf32>
+    tt.return
+  }
+""",
+    )
+
+    add_line = next(line for line in ttgir.splitlines() if "arith.addf" in line)
+    target = _explicit_result_encoding(add_line)
+    for line in ttgir.splitlines():
+        if "scf.if" in line or "scf.yield" in line or "arith.addf" in line:
+            assert target in line, line
+    assert "ttg.convert_layout" not in ttgir
+    _assert_set_layout_lowered(ttgir)
+
+
+@pytest.mark.parametrize("control_flow", ["for", "if"])
+def test_mthreads_tle_set_layout_rejects_control_flow_hard_conflicts(tmp_path, capfd, control_flow):
+    if control_flow == "for":
+        body = """
+  tt.func public @for_conflict(%arg0: tensor<16x16xf32>, %arg1: tensor<16x16xf32>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c2 = arith.constant 2 : i32
+    %init = musa_tle.set_layout %arg0 {target_encoding = #layout_a} : tensor<16x16xf32> -> tensor<16x16xf32>
+    %yielded = musa_tle.set_layout %arg1 {target_encoding = #layout_b} : tensor<16x16xf32> -> tensor<16x16xf32>
+    %loop = scf.for %iv = %c0 to %c2 step %c1 iter_args(%iter = %init) -> (tensor<16x16xf32>) : i32 {
+      scf.yield %yielded : tensor<16x16xf32>
+    }
+    tt.return
+  }
+"""
+    else:
+        body = """
+  tt.func public @if_conflict(%arg0: tensor<16x16xf32>, %arg1: tensor<16x16xf32>) {
+    %true = arith.constant true
+    %then = musa_tle.set_layout %arg0 {target_encoding = #layout_a} : tensor<16x16xf32> -> tensor<16x16xf32>
+    %else = musa_tle.set_layout %arg1 {target_encoding = #layout_b} : tensor<16x16xf32> -> tensor<16x16xf32>
+    %branch = scf.if %true -> (tensor<16x16xf32>) {
+      scf.yield %then : tensor<16x16xf32>
+    } else {
+      scf.yield %else : tensor<16x16xf32>
+    }
+    tt.return
+  }
+"""
+
+    with pytest.raises(RuntimeError):
+        _convert_set_layout_to_ttgir(tmp_path, body)
+
+    diagnostic = capfd.readouterr().err
+    assert "found conflicting MUSA TLE encoding hints for value" in diagnostic
+    assert "threadsPerWarp = [1, 32]" in diagnostic
+    assert "threadsPerWarp = [32, 1]" in diagnostic
+
+
+def test_mthreads_tle_set_layout_propagates_dot_accumulator_only(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @chained_dot_accumulator() {
+    %lhs_value = arith.constant dense<0.0> : tensor<16x16xbf16>
+    %lhs_encoded = musa_tle.set_layout %lhs_value {target_encoding = #lhs} : tensor<16x16xbf16> -> tensor<16x16xbf16>
+    %rhs_value = arith.constant dense<0.0> : tensor<16x16xbf16>
+    %rhs_encoded = musa_tle.set_layout %rhs_value {target_encoding = #rhs} : tensor<16x16xbf16> -> tensor<16x16xbf16>
+    %acc_value = arith.constant dense<0.0> : tensor<16x16xf32>
+    %acc_encoded = musa_tle.set_layout %acc_value {target_encoding = #mma} : tensor<16x16xf32> -> tensor<16x16xf32>
+    %first = tt.dot %lhs_encoded, %rhs_encoded, %acc_encoded : tensor<16x16xbf16> * tensor<16x16xbf16> -> tensor<16x16xf32>
+    %second = tt.dot %lhs_encoded, %rhs_encoded, %first : tensor<16x16xbf16> * tensor<16x16xbf16> -> tensor<16x16xf32>
+    tt.return
+  }
+""",
+    )
+
+    dot_lines = [line for line in ttgir.splitlines() if "tt.dot" in line]
+    assert len(dot_lines) == 2
+    for line in dot_lines:
+        assert "#ttg.dot_op<{opIdx = 0, parent = #mma}>" in line
+        assert "#ttg.dot_op<{opIdx = 1, parent = #mma}>" in line
+        assert "#mma" in line
+    assert "#ttg.musa_wmma" in ttgir
+    assert "ttg.convert_layout" not in ttgir
+
+
+def test_mthreads_tle_set_layout_propagates_into_local_pointers_and_load(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @local_pointer_forward(%idx: tensor<32xi32>) {
+    %encoded_idx = musa_tle.set_layout %idx {target_encoding = #layout_1d_a} : tensor<32xi32> -> tensor<32xi32>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<32xf32, #shared_1d, #smem, mutable>
+    %ptrs = "musa_tle.local_pointers"(%buf, %encoded_idx) : (!ttg.memdesc<32xf32, #shared_1d, #smem, mutable>, tensor<32xi32>) -> tensor<32x!tt.ptr<f32, 3>>
+    %loaded = tt.load %ptrs : tensor<32x!tt.ptr<f32, 3>>
+    tt.return
+  }
+""",
+    )
+
+    local_pointer_line = next(line for line in ttgir.splitlines() if "musa_tle.local_pointers" in line)
+    load_line = next(line for line in ttgir.splitlines() if "tt.load" in line)
+    local_encoding = re.search(r"tle\.explicit_encoding\.0 = (#\w+)", local_pointer_line).group(1)
+    assert local_encoding in local_pointer_line
+    assert f"tle.explicit_memory_encoding = {local_encoding}" in load_line
+    assert local_encoding in load_line
+    assert re.search(r"(?<!musa_)tle\.local_pointers", ttgir) is None
+
+
+def test_mthreads_tle_set_layout_propagates_from_local_pointer_to_index(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @local_pointer_backward(%idx: tensor<32xi32>) {
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<32xf32, #shared_1d, #smem, mutable>
+    %ptrs = "musa_tle.local_pointers"(%buf, %idx) : (!ttg.memdesc<32xf32, #shared_1d, #smem, mutable>, tensor<32xi32>) -> tensor<32x!tt.ptr<f32, 3>>
+    %encoded_ptrs = musa_tle.set_layout %ptrs {target_encoding = #layout_1d_b} : tensor<32x!tt.ptr<f32, 3>> -> tensor<32x!tt.ptr<f32, 3>>
+    tt.return
+  }
+""",
+    )
+
+    function_line = next(line for line in ttgir.splitlines() if "@local_pointer_backward" in line)
+    local_pointer_line = next(line for line in ttgir.splitlines() if "musa_tle.local_pointers" in line)
+    local_encoding = re.search(r"tle\.explicit_encoding\.0 = (#\w+)", local_pointer_line).group(1)
+    assert local_encoding in function_line
+    assert local_encoding in local_pointer_line
+
+
+def test_mthreads_tle_set_layout_marks_local_pointer_memory_ops(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @local_pointer_memory_ops(%idx: tensor<32xi32>) {
+    %encoded_idx = musa_tle.set_layout %idx {target_encoding = #layout_1d_a} : tensor<32xi32> -> tensor<32xi32>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<32xf32, #shared_1d, #smem, mutable>
+    %ptrs = "musa_tle.local_pointers"(%buf, %encoded_idx) : (!ttg.memdesc<32xf32, #shared_1d, #smem, mutable>, tensor<32xi32>) -> tensor<32x!tt.ptr<f32, 3>>
+    %value = arith.constant dense<1.0> : tensor<32xf32>
+    %loaded = tt.load %ptrs : tensor<32x!tt.ptr<f32, 3>>
+    tt.store %ptrs, %value : tensor<32x!tt.ptr<f32, 3>>
+    %rmw = tt.atomic_rmw fadd, relaxed, cta, %ptrs, %value : (tensor<32x!tt.ptr<f32, 3>>, tensor<32xf32>) -> tensor<32xf32>
+    %cas = tt.atomic_cas relaxed, cta, %ptrs, %value, %value : (tensor<32x!tt.ptr<f32, 3>>, tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
+    tt.return
+  }
+""",
+    )
+
+    memory_lines = [
+        line for line in ttgir.splitlines()
+        if any(op in line for op in ("tt.load", "tt.store", "tt.atomic_rmw", "tt.atomic_cas"))
+    ]
+    assert len(memory_lines) == 4
+    local_pointer_line = next(line for line in ttgir.splitlines() if "musa_tle.local_pointers" in line)
+    local_encoding = re.search(r"tle\.explicit_encoding\.0 = (#\w+)", local_pointer_line).group(1)
+    for line in memory_lines:
+        assert f"tle.explicit_memory_encoding = {local_encoding}" in line, line
+        assert local_encoding in line, line
+
+
+def test_mthreads_tle_set_layout_does_not_mark_unconstrained_memory_ops(tmp_path):
+    ttgir = _convert_set_layout_to_ttgir(
+        tmp_path,
+        """
+  tt.func public @unconstrained_memory(%base: !tt.ptr<f32>) {
+    %ptrs = tt.splat %base : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
+    %loaded = tt.load %ptrs : tensor<32x!tt.ptr<f32>>
+    tt.return
+  }
+""",
+    )
+
+    assert "tt.load" in ttgir
+    assert "tle.explicit_memory_encoding" not in ttgir
+
+
+def test_mthreads_tle_set_layout_rejects_conflicting_memory_encodings(tmp_path, capfd):
+    with pytest.raises(RuntimeError):
+        _convert_set_layout_to_ttgir(
+            tmp_path,
+            """
+  tt.func public @conflicting_memory(%idx: tensor<32xi32>) {
+    %encoded_idx = musa_tle.set_layout %idx {target_encoding = #layout_1d_a} : tensor<32xi32> -> tensor<32xi32>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<32xf32, #shared_1d, #smem, mutable>
+    %ptrs = "musa_tle.local_pointers"(%buf, %encoded_idx) : (!ttg.memdesc<32xf32, #shared_1d, #smem, mutable>, tensor<32xi32>) -> tensor<32x!tt.ptr<f32, 3>>
+    %value = arith.constant dense<1.0> : tensor<32xf32>
+    %encoded_value = musa_tle.set_layout %value {target_encoding = #layout_1d_b} : tensor<32xf32> -> tensor<32xf32>
+    tt.store %ptrs, %encoded_value : tensor<32x!tt.ptr<f32, 3>>
+    tt.return
+  }
+""",
+        )
+
+    diagnostic = capfd.readouterr().err
+    assert "has conflicting explicit MUSA TLE memory encodings" in diagnostic
+    assert "sizePerThread = [1]" in diagnostic
+    assert "sizePerThread = [2]" in diagnostic
+
+
+def test_mthreads_tle_coalesce_preserves_explicit_load_layout(tmp_path):
+    ttgir = _run_ttgir_coalesce(
+        tmp_path,
+        """
+  tt.func public @explicit_rebuild(%base: !tt.ptr<f32>) {
+    %offsets = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #layout_1d_b>
+    %bases = tt.splat %base : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #layout_1d_b>
+    %ptrs = tt.addptr %bases, %offsets : tensor<1024x!tt.ptr<f32>, #layout_1d_b>, tensor<1024xi32, #layout_1d_b>
+    %loaded = tt.load %ptrs {tle.explicit_encoding.0 = #layout_1d_b, tle.explicit_memory_encoding = #layout_1d_b} : tensor<1024x!tt.ptr<f32>, #layout_1d_b>
+    tt.return
+  }
+""",
+    )
+
+    load_line = next(line for line in ttgir.splitlines() if "tt.load" in line)
+    memory_match = re.search(r"tle\.explicit_memory_encoding = (#\w+)", load_line)
+    assert memory_match is not None, load_line
+    memory_encoding = memory_match.group(1)
+    result_match = re.search(r"tle\.explicit_encoding\.0 = (#\w+)", load_line)
+    assert result_match is not None, load_line
+    assert result_match.group(1) == memory_encoding
+    assert memory_encoding in load_line
+    assert "ttg.convert_layout" not in ttgir
+
+
+def test_mthreads_tle_coalesce_preserves_explicit_store_layout(tmp_path):
+    ttgir = _run_ttgir_coalesce(
+        tmp_path,
+        """
+  tt.func public @explicit_store(%base: !tt.ptr<f32>) {
+    %offsets = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #layout_1d_b>
+    %bases = tt.splat %base : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #layout_1d_b>
+    %ptrs = tt.addptr %bases, %offsets : tensor<1024x!tt.ptr<f32>, #layout_1d_b>, tensor<1024xi32, #layout_1d_b>
+    %value = arith.constant dense<1.0> : tensor<1024xf32, #layout_1d_b>
+    tt.store %ptrs, %value {tle.explicit_memory_encoding = #layout_1d_b} : tensor<1024x!tt.ptr<f32>, #layout_1d_b>
+    tt.return
+  }
+""",
+    )
+
+    store_line = next(line for line in ttgir.splitlines() if "tt.store" in line)
+    memory_match = re.search(r"tle\.explicit_memory_encoding = (#\w+)", store_line)
+    assert memory_match is not None, store_line
+    assert memory_match.group(1) in store_line
+    assert "ttg.convert_layout" not in ttgir
+
+
+def test_mthreads_tle_coalesce_rejects_pointer_memory_layout_conflict(tmp_path, capfd):
+    with pytest.raises(RuntimeError):
+        _run_ttgir_coalesce(
+            tmp_path,
+            """
+  tt.func public @conflicting_pointer_memory_layout(%base: !tt.ptr<f32>) {
+    %offsets = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #layout_1d_a>
+    %bases = tt.splat %base : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #layout_1d_a>
+    %ptrs = tt.addptr %bases, %offsets : tensor<1024x!tt.ptr<f32>, #layout_1d_a>, tensor<1024xi32, #layout_1d_a>
+    %loaded = tt.load %ptrs {tle.explicit_memory_encoding = #layout_1d_b} : tensor<1024x!tt.ptr<f32>, #layout_1d_a>
+    tt.return
+  }
+""",
+        )
+
+    diagnostic = capfd.readouterr().err
+    assert "has explicit MUSA TLE memory encoding that does not match the pointer tensor encoding" in diagnostic
+    assert "pointer:" in diagnostic
+    assert "explicit memory:" in diagnostic
+    assert "sizePerThread = [1]" in diagnostic
+    assert "sizePerThread = [2]" in diagnostic
+
+
+def test_mthreads_tle_coalesce_keeps_ordinary_memory_optimization(tmp_path):
+    ttgir = _run_ttgir_coalesce(
+        tmp_path,
+        """
+  tt.func public @ordinary_rebuild(%base: !tt.ptr<f32>) {
+    %offsets = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #layout_1d_a>
+    %bases = tt.splat %base : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #layout_1d_a>
+    %ptrs = tt.addptr %bases, %offsets : tensor<1024x!tt.ptr<f32>, #layout_1d_a>, tensor<1024xi32, #layout_1d_a>
+    %loaded = tt.load %ptrs : tensor<1024x!tt.ptr<f32>, #layout_1d_a>
+    %value = arith.constant dense<1.0> : tensor<1024xf32, #layout_1d_a>
+    tt.store %ptrs, %value : tensor<1024x!tt.ptr<f32>, #layout_1d_a>
+    tt.return
+  }
+""",
+    )
+
+    assert "tt.load" in ttgir
+    assert "tt.store" in ttgir
+    assert "ttg.convert_layout" in ttgir
+    assert "tle.explicit_encoding." not in ttgir
+    assert "tle.explicit_memory_encoding" not in ttgir
+
+
+@pytest.mark.parametrize("hard", [False, True])
+def test_mthreads_tle_coalesce_descriptor_transfers_explicit_result_layout(tmp_path, hard):
+    attrs = " {tle.explicit_encoding.0 = #layout_a}" if hard else ""
+    after_coalesce, finalized = _run_ttgir_coalesce_and_finalize_explicit_layouts(
+        tmp_path,
+        f"""
+  tt.func public @descriptor_rebuild(%desc: !tt.tensordesc<tensor<16x16xf32, #shared_a>>) -> tensor<16x16xf32, #layout_a> {{
+    %c0 = arith.constant 0 : i32
+    %loaded = tt.descriptor_load %desc[%c0, %c0]{attrs} : !tt.tensordesc<tensor<16x16xf32, #shared_a>> -> tensor<16x16xf32, #layout_a>
+    tt.return %loaded : tensor<16x16xf32, #layout_a>
+  }}
+""",
+    )
+
+    descriptor = next(line for line in after_coalesce.splitlines() if "tt.descriptor_load" in line)
+    bridge = next(line for line in after_coalesce.splitlines() if "ttg.convert_layout" in line)
+    optimized_encoding, hard_encoding = _type_encoding_aliases(bridge)
+    assert optimized_encoding != hard_encoding
+    assert _type_encoding_aliases(descriptor)[-1] == optimized_encoding
+    assert "tle.explicit_encoding." not in descriptor
+    assert "tle.explicit_memory_encoding" not in after_coalesce
+    if hard:
+        assert after_coalesce.count("tle.explicit_encoding.0") == 1
+        assert _explicit_result_encoding(bridge) == hard_encoding
+    else:
+        assert "tle.explicit_encoding." not in after_coalesce
+
+    assert "tle.explicit_encoding." not in finalized
+    assert "tle.explicit_memory_encoding" not in finalized
+    finalized_descriptor = next(line for line in finalized.splitlines() if "tt.descriptor_load" in line)
+    finalized_bridge = next(line for line in finalized.splitlines() if "ttg.convert_layout" in line)
+    finalized_source, finalized_target = _type_encoding_aliases(finalized_bridge)
+    assert finalized_source != finalized_target
+    assert finalized_source == optimized_encoding
+    assert finalized_target == hard_encoding
+    assert _type_encoding_aliases(finalized_descriptor)[-1] == finalized_source
+
+
+def test_mthreads_tle_remove_layout_conversions_prefers_hard_encoding(tmp_path):
+    ttgir = _run_ttgir_remove_layout_conversions(
+        tmp_path,
+        """
+  tt.func public @hard_over_soft(%arg0: tensor<16x16xf32, #layout_a>, %arg1: tensor<16x16xf32, #layout_a>, %out: tensor<16x16x!tt.ptr<f32>, #layout_b>) {
+    %soft = ttg.convert_layout %arg0 : tensor<16x16xf32, #layout_a> -> tensor<16x16xf32, #layout_b>
+    %hard = ttg.convert_layout %arg1 {tle.explicit_encoding.0 = #layout_b} : tensor<16x16xf32, #layout_a> -> tensor<16x16xf32, #layout_b>
+    %sum = arith.addf %soft, %hard : tensor<16x16xf32, #layout_b>
+    tt.store %out, %sum : tensor<16x16x!tt.ptr<f32>, #layout_b>
+    tt.return
+  }
+""",
+    )
+
+    hard_line = next(line for line in ttgir.splitlines() if "tle.explicit_encoding.0" in line)
+    hard_encoding, _, hard_result = _convert_layout_encodings(hard_line)
+    assert hard_encoding in hard_result
+    add_line = next(line for line in ttgir.splitlines() if "arith.addf" in line)
+    assert hard_encoding in add_line
+
+
+def test_mthreads_tle_remove_layout_conversions_preserves_rematerialization_anchor(tmp_path):
+    ttgir = _run_ttgir_remove_layout_conversions(
+        tmp_path,
+        """
+  tt.func public @hard_rematerialization_boundary(%lhs_scalar: f32, %rhs_scalar: f32, %out: tensor<16x16x!tt.ptr<f32>, #layout_b>) {
+    %lhs = tt.splat %lhs_scalar : f32 -> tensor<16x16xf32, #layout_a>
+    %rhs = tt.splat %rhs_scalar : f32 -> tensor<16x16xf32, #layout_a>
+    %sum = arith.addf %lhs, %rhs : tensor<16x16xf32, #layout_a>
+    %hard = ttg.convert_layout %sum {tle.explicit_encoding.0 = #layout_b} : tensor<16x16xf32, #layout_a> -> tensor<16x16xf32, #layout_b>
+    %use = arith.mulf %hard, %hard : tensor<16x16xf32, #layout_b>
+    tt.store %out, %use : tensor<16x16x!tt.ptr<f32>, #layout_b>
+    tt.return
+  }
+""",
+    )
+
+    assert ttgir.count("tle.explicit_encoding.0") == 1
+    assert ttgir.count("ttg.convert_layout") == 1
+    hard_line = next(line for line in ttgir.splitlines() if "tle.explicit_encoding.0" in line)
+    explicit, _, result = _convert_layout_encodings(hard_line)
+    assert explicit in result
+
+
+def test_mthreads_tle_remove_layout_conversions_does_not_hoist_hard_convert(tmp_path):
+    ttgir = _run_ttgir_remove_layout_conversions(
+        tmp_path,
+        """
+  tt.func public @hard_hoist_boundary(%arg0: tensor<16x16xi8, #layout_a>, %out: tensor<16x16x!tt.ptr<i32>, #layout_b>) {
+    %extended = arith.extui %arg0 : tensor<16x16xi8, #layout_a> to tensor<16x16xi32, #layout_a>
+    %hard = ttg.convert_layout %extended {tle.explicit_encoding.0 = #layout_b} : tensor<16x16xi32, #layout_a> -> tensor<16x16xi32, #layout_b>
+    %use = arith.addi %hard, %hard : tensor<16x16xi32, #layout_b>
+    tt.store %out, %use : tensor<16x16x!tt.ptr<i32>, #layout_b>
+    tt.return
+  }
+""",
+    )
+
+    lines = ttgir.splitlines()
+    ext_index = next(i for i, line in enumerate(lines) if "arith.extui" in line)
+    hard_index = next(i for i, line in enumerate(lines) if "tle.explicit_encoding.0" in line)
+    ext_result = re.search(r"(%[\w]+) = arith\.extui", lines[ext_index]).group(1)
+    assert ext_index < hard_index
+    assert ext_result in lines[hard_index]
+    assert ttgir.count("tle.explicit_encoding.0") == 1
+
+
+def test_mthreads_tle_remove_layout_conversions_does_not_fold_hard_source(tmp_path):
+    ttgir = _run_ttgir_remove_layout_conversions(
+        tmp_path,
+        """
+  tt.func public @hard_local_store_boundary(%arg0: tensor<32xf32, #layout_1d_a>) {
+    %hard = ttg.convert_layout %arg0 {tle.explicit_encoding.0 = #layout_1d_b} : tensor<32xf32, #layout_1d_a> -> tensor<32xf32, #layout_1d_b>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<32xf32, #shared_1d, #smem, mutable>
+    ttg.local_store %hard, %buf : tensor<32xf32, #layout_1d_b> -> !ttg.memdesc<32xf32, #shared_1d, #smem, mutable>
+    tt.return
+  }
+""",
+    )
+
+    hard_line = next(line for line in ttgir.splitlines() if "tle.explicit_encoding.0" in line)
+    hard_result = re.search(r"(%[\w]+) = ttg\.convert_layout", hard_line).group(1)
+    hard_encoding, _, _ = _convert_layout_encodings(hard_line)
+    store_line = next(line for line in ttgir.splitlines() if "ttg.local_store" in line)
+    assert hard_result in store_line
+    assert hard_encoding in store_line
+
+
+def test_mthreads_tle_remove_layout_conversions_preserves_hard_anchor_across_rounds(tmp_path):
+    ttgir = _run_ttgir_remove_layout_conversions(
+        tmp_path,
+        """
+  tt.func public @repeated_hard_anchor(%out: tensor<16x16x!tt.ptr<f32>, #layout_b>) {
+    %value = arith.constant dense<1.0> : tensor<16x16xf32, #layout_a>
+    %hard = ttg.convert_layout %value {tle.explicit_encoding.0 = #layout_b} : tensor<16x16xf32, #layout_a> -> tensor<16x16xf32, #layout_b>
+    %use = arith.addf %hard, %hard : tensor<16x16xf32, #layout_b>
+    tt.store %out, %use : tensor<16x16x!tt.ptr<f32>, #layout_b>
+    tt.return
+  }
+""",
+        repeat=2,
+    )
+
+    assert ttgir.count("ttg.convert_layout") == 1
+    assert ttgir.count("tle.explicit_encoding.0") == 1
+    hard_line = next(line for line in ttgir.splitlines() if "tle.explicit_encoding.0" in line)
+    explicit, _, result = _convert_layout_encodings(hard_line)
+    assert explicit in result
+
+
+def test_mthreads_tle_remove_layout_conversions_keeps_ordinary_cleanup(tmp_path):
+    ttgir = _run_ttgir_remove_layout_conversions(
+        tmp_path,
+        """
+  tt.func public @ordinary_redundant_convert(%arg0: tensor<16x16xf32, #layout_a>) {
+    %redundant = ttg.convert_layout %arg0 : tensor<16x16xf32, #layout_a> -> tensor<16x16xf32, #layout_a>
+    %use = arith.addf %redundant, %redundant : tensor<16x16xf32, #layout_a>
+    tt.return
+  }
+""",
+    )
+
+    assert "ttg.convert_layout" not in ttgir
+    assert "tle.explicit_encoding." not in ttgir
+
+
+def test_mthreads_tle_remove_layout_conversions_does_not_retarget_hard_sqmma_store(tmp_path):
+    ttgir = _run_ttgir_remove_layout_conversions(
+        tmp_path,
+        """
+  tt.func public @hard_sqmma_store(%ptrs: tensor<64x64x!tt.ptr<f32>, #layout_a>) {
+    %value = arith.constant dense<1.0> : tensor<64x64xf32, #sqmma>
+    %hard = ttg.convert_layout %value {tle.explicit_encoding.0 = #layout_a} : tensor<64x64xf32, #sqmma> -> tensor<64x64xf32, #layout_a>
+    tt.store %ptrs, %hard : tensor<64x64x!tt.ptr<f32>, #layout_a>
+    tt.return
+  }
+""",
+        extra_module_attrs='"tle.enable_encoding_rematerialization" = true',
+    )
+
+    hard_line = next(line for line in ttgir.splitlines() if "tle.explicit_encoding.0" in line)
+    hard_result = re.search(r"(%[\w]+) = ttg\.convert_layout", hard_line).group(1)
+    hard_encoding, _, _ = _convert_layout_encodings(hard_line)
+    store_line = next(line for line in ttgir.splitlines() if "tt.store" in line)
+    assert hard_result in store_line
+    assert hard_encoding in store_line
+
+
+def test_mthreads_tle_select_encodings_prefers_hard_local_pointer_layout(tmp_path):
+    ttgir = _run_ttgir_select_encodings(
+        tmp_path,
+        """
+  tt.func public @hard_local_pointer(%idx: tensor<32xi32, #layout_1d_a>) {
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<32xf32, #shared_1d, #smem, mutable>
+    %ptrs = "musa_tle.local_pointers"(%buf, %idx) {tle.explicit_encoding.0 = #layout_1d_a} : (!ttg.memdesc<32xf32, #shared_1d, #smem, mutable>, tensor<32xi32, #layout_1d_a>) -> tensor<32x!tt.ptr<f32, 3>, #layout_1d_a>
+    %adapted = ttg.convert_layout %ptrs : tensor<32x!tt.ptr<f32, 3>, #layout_1d_a> -> tensor<32x!tt.ptr<f32, 3>, #layout_1d_b>
+    %loaded = tt.load %adapted : tensor<32x!tt.ptr<f32, 3>, #layout_1d_b>
+    tt.return
+  }
+""",
+    )
+
+    local_pointer_line = next(line for line in ttgir.splitlines() if "musa_tle.local_pointers" in line)
+    load_line = next(line for line in ttgir.splitlines() if "tt.load" in line)
+    hard_encoding = _explicit_result_encoding(local_pointer_line)
+    assert hard_encoding in local_pointer_line.split(" -> ", 1)[1]
+    assert hard_encoding in load_line
+
+
+def test_mthreads_tle_select_encodings_uses_explicit_memory_layout(tmp_path):
+    ttgir = _run_ttgir_select_encodings(
+        tmp_path,
+        """
+  tt.func public @hard_memory_consumer(%idx: tensor<32xi32, #layout_1d_a>) {
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<32xf32, #shared_1d, #smem, mutable>
+    %ptrs = "musa_tle.local_pointers"(%buf, %idx) : (!ttg.memdesc<32xf32, #shared_1d, #smem, mutable>, tensor<32xi32, #layout_1d_a>) -> tensor<32x!tt.ptr<f32, 3>, #layout_1d_a>
+    %adapted = ttg.convert_layout %ptrs : tensor<32x!tt.ptr<f32, 3>, #layout_1d_a> -> tensor<32x!tt.ptr<f32, 3>, #layout_1d_b>
+    %loaded = tt.load %adapted {tle.explicit_encoding.0 = #layout_1d_b, tle.explicit_memory_encoding = #layout_1d_b} : tensor<32x!tt.ptr<f32, 3>, #layout_1d_b>
+    tt.return
+  }
+""",
+    )
+
+    local_pointer_line = next(line for line in ttgir.splitlines() if "musa_tle.local_pointers" in line)
+    load_line = next(line for line in ttgir.splitlines() if "tt.load" in line)
+    hard_encoding = _explicit_result_encoding(load_line)
+    assert hard_encoding in local_pointer_line
+    assert f"tle.explicit_memory_encoding = {hard_encoding}" in load_line
+    assert not any("ttg.convert_layout" in line and "!tt.ptr" in line for line in ttgir.splitlines())
+
+
+def test_mthreads_tle_select_encodings_rejects_conflicting_hard_layouts(tmp_path, capfd):
+    with pytest.raises(RuntimeError):
+        _run_ttgir_select_encodings(
+            tmp_path,
+            """
+  tt.func public @conflicting_local_pointer(%idx: tensor<32xi32, #layout_1d_a>) {
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<32xf32, #shared_1d, #smem, mutable>
+    %ptrs = "musa_tle.local_pointers"(%buf, %idx) {tle.explicit_encoding.0 = #layout_1d_a} : (!ttg.memdesc<32xf32, #shared_1d, #smem, mutable>, tensor<32xi32, #layout_1d_a>) -> tensor<32x!tt.ptr<f32, 3>, #layout_1d_a>
+    %loaded = tt.load %ptrs {tle.explicit_memory_encoding = #layout_1d_b} : tensor<32x!tt.ptr<f32, 3>, #layout_1d_a>
+    tt.return
+  }
+""",
+        )
+
+    diagnostic = capfd.readouterr().err
+    assert "has conflicting explicit MUSA TLE memory encodings" in diagnostic
+    assert "sizePerThread = [1]" in diagnostic
+    assert "sizePerThread = [2]" in diagnostic
+
+
+def test_mthreads_tle_select_encodings_preserves_hard_pointer_boundary(tmp_path):
+    ttgir = _run_ttgir_select_encodings(
+        tmp_path,
+        """
+  tt.func public @hard_pointer_boundary(%idx: tensor<32xi32, #layout_1d_a>) {
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<32xf32, #shared_1d, #smem, mutable>
+    %ptrs = "musa_tle.local_pointers"(%buf, %idx) : (!ttg.memdesc<32xf32, #shared_1d, #smem, mutable>, tensor<32xi32, #layout_1d_a>) -> tensor<32x!tt.ptr<f32, 3>, #layout_1d_a>
+    %hard = ttg.convert_layout %ptrs {tle.explicit_encoding.0 = #layout_1d_b} : tensor<32x!tt.ptr<f32, 3>, #layout_1d_a> -> tensor<32x!tt.ptr<f32, 3>, #layout_1d_b>
+    %loaded = tt.load %hard : tensor<32x!tt.ptr<f32, 3>, #layout_1d_b>
+    tt.return
+  }
+""",
+    )
+
+    local_pointer_line = next(line for line in ttgir.splitlines() if "musa_tle.local_pointers" in line)
+    hard_line = next(line for line in ttgir.splitlines() if "tle.explicit_encoding.0" in line)
+    assert "ttg.convert_layout" in hard_line
+    explicit, source, result = _convert_layout_encodings(hard_line)
+    assert explicit in result
+    assert explicit not in source
+    assert next(iter(_type_encoding_aliases(source))) in local_pointer_line
+
+
+def test_mthreads_tle_select_encodings_keeps_ordinary_voting(tmp_path):
+    ttgir = _run_ttgir_select_encodings(
+        tmp_path,
+        """
+  tt.func public @ordinary_voting(%idx: tensor<32xi32, #layout_1d_a>) {
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<32xf32, #shared_1d, #smem, mutable>
+    %ptrs = "musa_tle.local_pointers"(%buf, %idx) : (!ttg.memdesc<32xf32, #shared_1d, #smem, mutable>, tensor<32xi32, #layout_1d_a>) -> tensor<32x!tt.ptr<f32, 3>, #layout_1d_a>
+    %adapted = ttg.convert_layout %ptrs : tensor<32x!tt.ptr<f32, 3>, #layout_1d_a> -> tensor<32x!tt.ptr<f32, 3>, #layout_1d_b>
+    %loaded0 = tt.load %adapted : tensor<32x!tt.ptr<f32, 3>, #layout_1d_b>
+    %loaded1 = tt.load %adapted : tensor<32x!tt.ptr<f32, 3>, #layout_1d_b>
+    tt.return
+  }
+""",
+    )
+
+    local_pointer_line = next(line for line in ttgir.splitlines() if "musa_tle.local_pointers" in line)
+    load_lines = [line for line in ttgir.splitlines() if "tt.load" in line]
+    assert len(load_lines) == 2
+    load_encoding = _type_encoding_aliases(load_lines[0])[0]
+    assert load_encoding in local_pointer_line
+    assert "tle.explicit_encoding." not in ttgir
+    assert "tle.explicit_memory_encoding" not in ttgir
+
+
+def test_mthreads_tle_optimize_thread_locality_preserves_hard_reshape(tmp_path):
+    ttgir = _run_ttgir_optimize_thread_locality(
+        tmp_path,
+        """
+  tt.func public @hard_reshape(%arg0: tensor<64x16xf32, #reshape_layout>) -> tensor<64xf32, #reshape_slice> {
+    %reshaped = tt.reshape %arg0 allow_reorder {tle.explicit_encoding.0 = #reshape_layout} : tensor<64x16xf32, #reshape_layout> -> tensor<64x16xf32, #reshape_layout>
+    %reduced = "tt.reduce"(%reshaped) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %max = arith.maximumf %lhs, %rhs : f32
+      tt.reduce.return %max : f32
+    }) : (tensor<64x16xf32, #reshape_layout>) -> tensor<64xf32, #reshape_slice>
+    tt.return %reduced : tensor<64xf32, #reshape_slice>
+  }
+""",
+        num_warps=2,
+    )
+
+    reshape_line = next(line for line in ttgir.splitlines() if "tt.reshape" in line)
+    explicit = _explicit_result_encoding(reshape_line)
+    assert explicit in reshape_line.split(" -> ", 1)[1]
+    assert "efficient_layout" not in reshape_line
+    assert "ttg.convert_layout" not in ttgir
+
+
+def test_mthreads_tle_optimize_thread_locality_keeps_ordinary_reshape(tmp_path):
+    ttgir = _run_ttgir_optimize_thread_locality(
+        tmp_path,
+        """
+  tt.func public @ordinary_reshape(%arg0: tensor<64x16xf32, #reshape_layout>) -> tensor<64xf32, #reshape_slice> {
+    %reshaped = tt.reshape %arg0 allow_reorder : tensor<64x16xf32, #reshape_layout> -> tensor<64x16xf32, #reshape_layout>
+    %reduced = "tt.reduce"(%reshaped) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %max = arith.maximumf %lhs, %rhs : f32
+      tt.reduce.return %max : f32
+    }) : (tensor<64x16xf32, #reshape_layout>) -> tensor<64xf32, #reshape_slice>
+    tt.return %reduced : tensor<64xf32, #reshape_slice>
+  }
+""",
+        num_warps=2,
+    )
+
+    reshape_line = next(line for line in ttgir.splitlines() if "tt.reshape" in line)
+    assert "efficient_layout" in reshape_line
+    assert "ttg.convert_layout" in ttgir
+    assert "tle.explicit_encoding." not in ttgir
+
+
+def test_mthreads_tle_optimize_thread_locality_preserves_hard_gather(tmp_path):
+    ttgir = _run_ttgir_optimize_thread_locality(
+        tmp_path,
+        """
+  tt.func public @hard_gather(%src: tensor<64x64xf32, #layout_a>, %idx: tensor<64x64xi32, #layout_a>) -> tensor<64x64xf32, #layout_a> {
+    %gathered = tt.gather %src[%idx] {axis = 0 : i32, tle.explicit_encoding.0 = #layout_a} : (tensor<64x64xf32, #layout_a>, tensor<64x64xi32, #layout_a>) -> tensor<64x64xf32, #layout_a>
+    tt.return %gathered : tensor<64x64xf32, #layout_a>
+  }
+""",
+    )
+
+    gather_line = next(line for line in ttgir.splitlines() if "tt.gather" in line)
+    explicit = _explicit_result_encoding(gather_line)
+    assert explicit in gather_line.split(" -> ", 1)[1]
+    assert "efficient_layout" not in gather_line
+    assert "ttg.convert_layout" not in ttgir
+
+
+def test_mthreads_tle_optimize_thread_locality_keeps_ordinary_gather(tmp_path):
+    ttgir = _run_ttgir_optimize_thread_locality(
+        tmp_path,
+        """
+  tt.func public @ordinary_gather(%src: tensor<64x64xf32, #layout_a>, %idx: tensor<64x64xi32, #layout_a>) -> tensor<64x64xf32, #layout_a> {
+    %gathered = tt.gather %src[%idx] {axis = 0 : i32} : (tensor<64x64xf32, #layout_a>, tensor<64x64xi32, #layout_a>) -> tensor<64x64xf32, #layout_a>
+    tt.return %gathered : tensor<64x64xf32, #layout_a>
+  }
+""",
+    )
+
+    gather_line = next(line for line in ttgir.splitlines() if "tt.gather" in line)
+    assert "efficient_layout" in gather_line
+    assert ttgir.count("ttg.convert_layout") == 3
+    assert "tle.explicit_encoding." not in ttgir
+
+
+def test_mthreads_tle_optimize_thread_locality_keeps_adjacent_hard_boundary(tmp_path):
+    ttgir = _run_ttgir_optimize_thread_locality(
+        tmp_path,
+        """
+  tt.func public @hard_gather_input(%src: tensor<64x64xf32, #layout_b>, %idx: tensor<64x64xi32, #layout_a>) -> tensor<64x64xf32, #layout_a> {
+    %hard = ttg.convert_layout %src {tle.explicit_encoding.0 = #layout_a} : tensor<64x64xf32, #layout_b> -> tensor<64x64xf32, #layout_a>
+    %gathered = tt.gather %hard[%idx] {axis = 0 : i32} : (tensor<64x64xf32, #layout_a>, tensor<64x64xi32, #layout_a>) -> tensor<64x64xf32, #layout_a>
+    tt.return %gathered : tensor<64x64xf32, #layout_a>
+  }
+""",
+    )
+
+    hard_line = next(line for line in ttgir.splitlines() if "tle.explicit_encoding.0" in line)
+    explicit, source, result = _convert_layout_encodings(hard_line)
+    assert explicit in result
+    assert explicit not in source
+    gather_line = next(line for line in ttgir.splitlines() if "tt.gather" in line)
+    assert "efficient_layout" in gather_line
+    assert ttgir.count("tle.explicit_encoding.0") == 1
+
+
+@pytest.mark.parametrize("hard_anchor", ["reduce", "update"])
+def test_mthreads_tle_optimize_thread_locality_preserves_hard_reduction(tmp_path, hard_anchor):
+    reduce_attrs = " {tle.explicit_encoding.0 = #slice_dim1_a}" if hard_anchor == "reduce" else ""
+    update_attrs = " {tle.explicit_encoding.0 = #slice_dim1_a}" if hard_anchor == "update" else ""
+    ttgir = _run_ttgir_optimize_thread_locality(
+        tmp_path,
+        f"""
+  tt.func public @hard_reduction(%ptrs: tensor<32x128x!tt.ptr<f32>, #layout_a>, %limit: i32) -> tensor<32xf32, #slice_dim1_a> {{
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %init = arith.constant dense<0.0> : tensor<32xf32, #slice_dim1_a>
+    %loop = scf.for %iv = %c0 to %limit step %c1 iter_args(%acc = %init) -> (tensor<32xf32, #slice_dim1_a>) : i32 {{
+      %loaded = tt.load %ptrs : tensor<32x128x!tt.ptr<f32>, #layout_a>
+      %reduced = "tt.reduce"(%loaded) <{{axis = 1 : i32}}> ({{
+      ^bb0(%lhs: f32, %rhs: f32):
+        %sum = arith.addf %lhs, %rhs : f32
+        tt.reduce.return %sum : f32
+      }}){reduce_attrs} : (tensor<32x128xf32, #layout_a>) -> tensor<32xf32, #slice_dim1_a>
+      %updated = arith.addf %acc, %reduced{update_attrs} : tensor<32xf32, #slice_dim1_a>
+      scf.yield %updated : tensor<32xf32, #slice_dim1_a>
+    }}
+    tt.return %loop : tensor<32xf32, #slice_dim1_a>
+  }}
+""",
+    )
+
+    assert ttgir.count('"tt.reduce"') == 1
+    assert "tt.reshape" not in ttgir
+    assert ttgir.count("tle.explicit_encoding.0") == 1
+
+
+def test_mthreads_tle_optimize_thread_locality_keeps_ordinary_reduction(tmp_path):
+    ttgir = _run_ttgir_optimize_thread_locality(
+        tmp_path,
+        """
+  tt.func public @ordinary_reduction(%ptrs: tensor<32x128x!tt.ptr<f32>, #layout_a>, %limit: i32) -> tensor<32xf32, #slice_dim1_a> {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %init = arith.constant dense<0.0> : tensor<32xf32, #slice_dim1_a>
+    %loop = scf.for %iv = %c0 to %limit step %c1 iter_args(%acc = %init) -> (tensor<32xf32, #slice_dim1_a>) : i32 {
+      %loaded = tt.load %ptrs : tensor<32x128x!tt.ptr<f32>, #layout_a>
+      %reduced = "tt.reduce"(%loaded) <{axis = 1 : i32}> ({
+      ^bb0(%lhs: f32, %rhs: f32):
+        %sum = arith.addf %lhs, %rhs : f32
+        tt.reduce.return %sum : f32
+      }) : (tensor<32x128xf32, #layout_a>) -> tensor<32xf32, #slice_dim1_a>
+      %updated = arith.addf %acc, %reduced : tensor<32xf32, #slice_dim1_a>
+      scf.yield %updated : tensor<32xf32, #slice_dim1_a>
+    }
+    tt.return %loop : tensor<32xf32, #slice_dim1_a>
+  }
+""",
+    )
+
+    assert ttgir.count('"tt.reduce"') == 3
+    assert "tt.reshape" in ttgir
+    assert "efficient_layout" in ttgir
+    assert "ttg.convert_layout" in ttgir
+    assert "tle.explicit_encoding." not in ttgir
+
+
+@pytest.mark.parametrize("hard", [True, False], ids=["hard", "ordinary"])
+def test_mthreads_tle_optimize_sqmma_accumulator_layout_respects_hard_boundary(tmp_path, hard):
+    attrs = " {tle.explicit_encoding.0 = #layout_a}" if hard else ""
+    ttgir = _run_ttgir_musa_pass(
+        tmp_path,
+        f"""
+  tt.func public @sqmma_accumulator(
+      %a: !ttg.memdesc<64x32xf16, #shared_a, #smem, mutable>,
+      %b: !ttg.memdesc<32x64xf16, #shared_b, #smem, mutable>,
+      %mma_init: tensor<64x64xf32, #sqmma>,
+      %blocked_init: tensor<64x64xf32, #layout_a>,
+      %limit: index) -> tensor<64x64xf32, #layout_a> {{
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %true = arith.constant true
+    %loop:2 = scf.for %iv = %c0 to %limit step %c1 iter_args(%mma = %mma_init, %blocked = %blocked_init) -> (tensor<64x64xf32, #sqmma>, tensor<64x64xf32, #layout_a>) {{
+      %dot = ttmg.squad_dot %a, %b, %mma, %true {{eltTypeA = 4 : i32, eltTypeB = 4 : i32, eltTypeC = 7 : i32, isAsync = true, k = 32 : i32, layoutA = 0 : i32, layoutB = 0 : i32, m = 64 : i32, n = 64 : i32}} : !ttg.memdesc<64x32xf16, #shared_a, #smem, mutable> * !ttg.memdesc<32x64xf16, #shared_b, #smem, mutable> -> tensor<64x64xf32, #sqmma>
+      %wait = ttmg.squad_dot_wait %dot : tensor<64x64xf32, #sqmma>
+      %converted = ttg.convert_layout %wait{attrs} : tensor<64x64xf32, #sqmma> -> tensor<64x64xf32, #layout_a>
+      scf.yield %wait, %converted : tensor<64x64xf32, #sqmma>, tensor<64x64xf32, #layout_a>
+    }}
+    tt.return %loop#1 : tensor<64x64xf32, #layout_a>
+  }}
+""",
+        "add_optimize_sqmma_accumulator_layout",
+    )
+
+    if hard:
+        assert "tt.return %0#1" in ttgir
+        hard_line = next(line for line in ttgir.splitlines() if "tle.explicit_encoding.0" in line)
+        assert "ttg.convert_layout" in hard_line
+    else:
+        assert "%blocked = %blocked_init" not in ttgir
+        assert "tle.explicit_encoding." not in ttgir
+
+
+@pytest.mark.parametrize("hard", [True, False], ids=["hard", "ordinary"])
+def test_mthreads_tle_canonicalize_sqmma_result_conversion_respects_hard_boundary(tmp_path, hard):
+    attrs = " {tle.explicit_encoding.0 = #layout_a}" if hard else ""
+    ttgir = _run_ttgir_musa_pass(
+        tmp_path,
+        f"""
+  tt.func public @sqmma_result(%arg0: tensor<64x64xf32, #sqmma>) -> tensor<64x64xf16, #layout_a> {{
+    %converted = ttg.convert_layout %arg0{attrs} : tensor<64x64xf32, #sqmma> -> tensor<64x64xf32, #layout_a>
+    %truncated = arith.truncf %converted : tensor<64x64xf32, #layout_a> to tensor<64x64xf16, #layout_a>
+    tt.return %truncated : tensor<64x64xf16, #layout_a>
+  }}
+""",
+        "add_canonicalize_sqmma_result_conversions",
+    )
+
+    lines = ttgir.splitlines()
+    convert_idx = next(i for i, line in enumerate(lines) if "ttg.convert_layout" in line)
+    trunc_idx = next(i for i, line in enumerate(lines) if "arith.truncf" in line)
+    if hard:
+        assert convert_idx < trunc_idx
+        assert ttgir.count("tle.explicit_encoding.0") == 1
+    else:
+        assert trunc_idx < convert_idx
+        assert "tle.explicit_encoding." not in ttgir
+
+
+@pytest.mark.parametrize("hard", [True, False], ids=["hard", "ordinary"])
+def test_mthreads_tle_coalesce_async_copy_respects_explicit_memory_layout(tmp_path, hard):
+    attrs = " {tle.explicit_memory_encoding = #layout_1d_a}" if hard else ""
+    ttgir = _run_ttgir_musa_pass(
+        tmp_path,
+        f"""
+  tt.func public @async_copy(%ptrs: tensor<32x!tt.ptr<f32>, #layout_1d_a>) {{
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<32xf32, #shared_1d, #smem, mutable>
+    %token = ttg.async_copy_global_to_local %ptrs, %buf{attrs} : tensor<32x!tt.ptr<f32>, #layout_1d_a> -> <32xf32, #shared_1d, #smem, mutable>
+    tt.return
+  }}
+""",
+        "add_coalesce_async_copy",
+    )
+
+    if hard:
+        copy_line = next(line for line in ttgir.splitlines() if "ttg.async_copy_global_to_local" in line)
+        assert "tle.explicit_memory_encoding" in copy_line
+        explicit = re.search(r"tle\.explicit_memory_encoding = (#\w+)", copy_line).group(1)
+        assert copy_line.count(explicit) >= 2
+        assert "ttg.convert_layout" not in ttgir
+    else:
+        assert "tle.explicit_memory_encoding" not in ttgir
+
+
+def test_mthreads_tle_coalesce_async_copy_rejects_conflicting_explicit_memory_layout(tmp_path, capfd):
+    with pytest.raises(RuntimeError):
+        _run_ttgir_musa_pass(
+            tmp_path,
+            """
+  tt.func public @async_copy_conflict(%ptrs: tensor<32x!tt.ptr<f32>, #layout_1d_a>) {
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<32xf32, #shared_1d, #smem, mutable>
+    %token = ttg.async_copy_global_to_local %ptrs, %buf {tle.explicit_memory_encoding = #layout_1d_b} : tensor<32x!tt.ptr<f32>, #layout_1d_a> -> <32xf32, #shared_1d, #smem, mutable>
+    tt.return
+  }
+""",
+            "add_coalesce_async_copy",
+        )
+
+    diagnostic = capfd.readouterr().err
+    assert "conflicts with the async-copy source encoding" in diagnostic
+
+
+def test_mthreads_tle_set_layout_survives_full_sqmma_ttgir_pipeline():
+    layout = MusaSqmmaEncoding([3, 1], [4, 1], [128, 128, 64])
+    compiled = compile_musa(
+        _set_layout_sqmma_pipeline_kernel,
+        {"out": "*fp32", "LAYOUT": "constexpr"},
+        {"LAYOUT": layout},
+    )
+    ttgir = compiled.asm["ttgir"]
+
+    assert "musa_tle.set_layout" not in ttgir
+    assert "ttmg.squad_dot" in ttgir
+    assert "#ttg.musa_sqmma" in ttgir
+    assert "tle.explicit_encoding." not in ttgir
+    assert "tle.explicit_memory_encoding" not in ttgir
+    assert "tle.explicit_encoding." not in compiled.asm["llir"]
+    assert "tle.explicit_memory_encoding" not in compiled.asm["llir"]
+
+
+def test_mthreads_tle_finalize_explicit_layouts_keeps_ordinary_pipeline():
+    compiled = compile_musa(_ordinary_ttgir_pipeline_kernel, {"out": "*fp32"})
+    ttgir = compiled.asm["ttgir"]
+    assert "tt.store" in ttgir
+    assert "musa_tle.set_layout" not in ttgir
+    assert "tle.explicit_encoding." not in ttgir
+    assert "tle.explicit_memory_encoding" not in ttgir
+
+
+def test_mthreads_tle_explicit_wmma_uses_fp32_carrier_for_fp16_result(tmp_path):
+    ttgir = _run_ttgir_musa_pass(
+        tmp_path,
+        """
+  tt.func public @explicit_wmma_fp16() -> tensor<16x16xf16, #mma> {
+    %lhs = arith.constant dense<0.0> : tensor<16x16xf16, #lhs>
+    %rhs = arith.constant dense<0.0> : tensor<16x16xf16, #rhs>
+    %acc = arith.constant dense<0.0> : tensor<16x16xf16, #mma>
+    %result = tt.dot %lhs, %rhs, %acc : tensor<16x16xf16, #lhs> * tensor<16x16xf16, #rhs> -> tensor<16x16xf16, #mma>
+    tt.return %result : tensor<16x16xf16, #mma>
+  }
+""",
+        "add_accelerate_matmul",
+    )
+
+    assert "ttmg.wmma_dot" in ttgir
+    assert "-> tensor<16x16xf32, #mma>" in ttgir
+    assert "arith.truncf" in ttgir
+    assert "to tensor<16x16xf16, #mma>" in ttgir
+    assert " tt.dot " not in ttgir
+
+
+@pytest.mark.parametrize(
+    "encoding,lhs_encoding,rhs_encoding,diagnostic",
+    [
+        (
+            "#wmma_unsupported",
+            "#lhs_unsupported",
+            "#rhs_unsupported",
+            "instruction shape and element types are unsupported",
+        ),
+    ],
+)
+def test_mthreads_tle_explicit_wmma_rejects_unsupported_contracts(tmp_path, capfd, encoding, lhs_encoding, rhs_encoding,
+                                                                  diagnostic):
+    with pytest.raises(RuntimeError):
+        _run_ttgir_musa_pass(
+            tmp_path,
+            f"""
+  tt.func public @invalid_explicit_wmma() {{
+    %lhs = arith.constant dense<0.0> : tensor<16x16xbf16, {lhs_encoding}>
+    %rhs = arith.constant dense<0.0> : tensor<16x16xbf16, {rhs_encoding}>
+    %acc = arith.constant dense<0.0> : tensor<16x16xf32, {encoding}>
+    %result = tt.dot %lhs, %rhs, %acc : tensor<16x16xbf16, {lhs_encoding}> * tensor<16x16xbf16, {rhs_encoding}> -> tensor<16x16xf32, {encoding}>
+    tt.return
+  }}
+""",
+            "add_accelerate_matmul",
+        )
+    error = capfd.readouterr().err
+    assert "cannot lower explicit MUSA WMMA dot" in error
+    assert diagnostic in error
+
+
+def test_mthreads_tle_explicit_wmma_rejects_module_warp_mismatch(tmp_path, capfd):
+    with pytest.raises(RuntimeError):
+        _run_ttgir_musa_pass(
+            tmp_path,
+            """
+  tt.func public @invalid_explicit_wmma_warps() {
+    %lhs = arith.constant dense<0.0> : tensor<16x16xbf16, #lhs_bad_warps>
+    %rhs = arith.constant dense<0.0> : tensor<16x16xbf16, #rhs_bad_warps>
+    %acc = arith.constant dense<0.0> : tensor<16x16xf32, #wmma_bad_warps>
+    %result = tt.dot %lhs, %rhs, %acc : tensor<16x16xbf16, #lhs_bad_warps> * tensor<16x16xbf16, #rhs_bad_warps> -> tensor<16x16xf32, #wmma_bad_warps>
+    tt.return
+  }
+""",
+            "add_accelerate_matmul",
+        )
+    error = capfd.readouterr().err
+    assert "Layout has 2 warps per CTA" in error
+    assert "the context requires 4 warps per CTA" in error
+
+
+def test_mthreads_tle_explicit_wmma_rejects_disable_wmma(monkeypatch, tmp_path, capfd):
+    monkeypatch.setenv("DISABLE_WMMA", "1")
+    with pytest.raises(RuntimeError):
+        _run_ttgir_musa_pass(
+            tmp_path,
+            """
+  tt.func public @disabled_explicit_wmma() {
+    %lhs = arith.constant dense<0.0> : tensor<16x16xbf16, #lhs>
+    %rhs = arith.constant dense<0.0> : tensor<16x16xbf16, #rhs>
+    %acc = arith.constant dense<0.0> : tensor<16x16xf32, #mma>
+    %result = tt.dot %lhs, %rhs, %acc : tensor<16x16xbf16, #lhs> * tensor<16x16xbf16, #rhs> -> tensor<16x16xf32, #mma>
+    tt.return
+  }
+""",
+            "add_accelerate_matmul",
+        )
+    error = capfd.readouterr().err
+    assert "cannot lower explicit MUSA WMMA dot" in error
+    assert "DISABLE_WMMA conflicts with an explicit MUSA WMMA layout" in error
+
+
+@pytest.mark.parametrize("kind", ["block", "slice", "transpose", "dual-domain"])
+@requires_musa_runtime
+def test_mthreads_tle_layout_runtime(kind):
+    block = 16
+    layout_a = tle.gpu.BlockEncoding([1, 1], [1, 32], [4, 1], [1, 0])
+    layout_b = tle.gpu.BlockEncoding([1, 1], [32, 1], [1, 4], [0, 1])
+    if kind == "block":
+        kernel = _set_layout_block_numeric_kernel
+        shape = (block, block)
+        reference = torch.arange(block * block, dtype=torch.float32).reshape(shape) * 1.25 - 7.0
+        source = reference.to("musa")
+        actual = torch.empty_like(source)
+        compiled = _warmup_and_run(kernel, source, actual, block, layout_a, num_warps=4)
+        expected = reference
+    elif kind == "slice":
+        kernel = _set_layout_slice_numeric_kernel
+        layout = tle.gpu.SlicedEncoding(0, layout_a)
+        shape = (block, )
+        reference = torch.arange(block, dtype=torch.float32) * 1.25 - 7.0
+        source = reference.to("musa")
+        actual = torch.empty_like(source)
+        compiled = _warmup_and_run(kernel, source, actual, block, layout, num_warps=4)
+        expected = reference
+    elif kind == "transpose":
+        shape = (block, block)
+        reference = torch.arange(block * block, dtype=torch.float32).reshape(shape) * 0.5 - 3.0
+        source = reference.to("musa")
+        actual = torch.empty_like(source)
+        compiled = _warmup_and_run(
+            _set_layout_transpose_numeric_kernel,
+            source,
+            actual,
+            block,
+            layout_a,
+            layout_b,
+            num_warps=4,
+        )
+        trans_lines = [line for line in compiled.asm["ttgir"].splitlines() if "tt.trans" in line]
+        assert len(trans_lines) == 1
+        assert trans_lines[0].count("#") >= 2
+        expected = reference.T * 2.0 + 1.0
+    else:
+        shape = (block, block)
+        reference = torch.full(shape, 3.25, dtype=torch.float32)
+        actual = torch.empty(shape, device="musa", dtype=torch.float32)
+        alternate = torch.empty_like(actual)
+        compiled = _warmup_and_run(
+            _set_layout_dual_domain_numeric_kernel,
+            actual,
+            alternate,
+            block,
+            layout_a,
+            layout_b,
+            num_warps=4,
+        )
+        torch.testing.assert_close(alternate.cpu(), reference, rtol=0, atol=0)
+        expected = reference
+
+    _assert_runtime_pipeline_ir(compiled)
+    torch.testing.assert_close(actual.cpu(), expected, rtol=0, atol=0)
+
+
+@requires_musa_runtime
+def test_mthreads_tle_shared_rank3_slice_runtime():
+    block = 128
+    row_layout = tle.gpu.BlockEncoding([1, 1, 1], [1, 32, 1], [1, 4, 1], [2, 1, 0])
+    col_layout = tle.gpu.BlockEncoding([1, 1, 1], [1, 1, 32], [1, 1, 4], [2, 1, 0])
+    actual_rows = torch.empty(block, device="musa", dtype=torch.float32)
+    actual_cols = torch.empty_like(actual_rows)
+
+    compiled = _warmup_and_run(
+        _set_layout_shared_rank3_slice_numeric_kernel,
+        actual_rows,
+        actual_cols,
+        block,
+        row_layout,
+        col_layout,
+        num_warps=4,
+    )
+
+    _assert_runtime_pipeline_ir(compiled)
+    expected = torch.arange(block, dtype=torch.float32)
+    torch.testing.assert_close(actual_rows.cpu(), expected, rtol=0, atol=0)
+    torch.testing.assert_close(actual_cols.cpu(), expected, rtol=0, atol=0)
+
+
+@requires_musa_runtime
+def test_mthreads_tle_noinline_function_abi_runtime():
+    block = 128
+    parent = tle.gpu.BlockEncoding([1, 1], [1, 32], [4, 1], [1, 0])
+    layout = tle.gpu.SlicedEncoding(0, parent)
+    actual = torch.empty(block, device="musa", dtype=torch.float32)
+
+    compiled = _warmup_and_run(
+        _set_layout_noinline_numeric_kernel,
+        actual,
+        block,
+        layout,
+        num_warps=4,
+    )
+
+    _assert_runtime_pipeline_ir(compiled)
+    expected = torch.arange(block, dtype=torch.float32)
+    torch.testing.assert_close(actual.cpu(), expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("kind", ["wmma", "sqmma"])
+@requires_musa_runtime
+def test_mthreads_tle_explicit_and_automatic_mma_runtime(monkeypatch, kind):
+    monkeypatch.delenv("DISABLE_WMMA", raising=False)
+    monkeypatch.delenv("DISABLE_SQMMA", raising=False)
+    if kind == "wmma":
+        kernel = _explicit_musa_wmma_kernel
+        mma = MusaWmmaEncoding([3, 1], [2, 2], [16, 8, 16])
+        block_m, block_n, block_k = 16, 16, 16
+        dtype = torch.bfloat16
+        mnemonic = "ttmg.wmma_dot"
+    else:
+        kernel = _explicit_musa_sqmma_kernel
+        mma = MusaSqmmaEncoding([3, 1], [4, 1], [32, 64, 16])
+        block_m, block_n, block_k = 64, 64, 32
+        dtype = torch.float16
+        mnemonic = "ttmg.squad_dot"
+    lhs_layout = MusaDotOperandEncoding(0, mma)
+    rhs_layout = MusaDotOperandEncoding(1, mma)
+    lhs = torch.full((block_m, block_k), 1.0, device="musa", dtype=dtype)
+    rhs = torch.full((block_k, block_n), 2.0, device="musa", dtype=dtype)
+    actual = torch.empty((block_m, block_n), device="musa", dtype=torch.float32)
+    automatic = torch.empty_like(actual)
+
+    explicit_compiled = _warmup_and_run(
+        kernel,
+        actual,
+        mma,
+        lhs_layout,
+        rhs_layout,
+        num_warps=4,
+    )
+    automatic_compiled = _warmup_and_run(
+        _automatic_musa_mma_numeric_kernel,
+        lhs,
+        rhs,
+        automatic,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        BLOCK_K=block_k,
+        num_warps=4,
+    )
+
+    _assert_runtime_pipeline_ir(explicit_compiled, mnemonic)
+    automatic_ttgir = automatic_compiled.asm["ttgir"]
+    assert automatic_ttgir.count(mnemonic) == 1
+    assert " tt.dot " not in automatic_ttgir
+    assert "nvvm" not in automatic_compiled.asm["llir"].lower()
+    reference = lhs.cpu().float() @ rhs.cpu().float()
+    torch.testing.assert_close(actual.cpu(), reference, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(automatic.cpu(), reference, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(actual, automatic, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("kind", ["layout", "rank3-shared-slice", "noinline-abi", "wmma", "sqmma"])
+@pytest.mark.skipif(_musa_runtime_available(), reason="covered by MUSA runtime tests")
+def test_mthreads_tle_runtime_compile_fallback(kind):
+    if kind == "layout":
+        layout_a = tle.gpu.BlockEncoding([1, 1], [1, 32], [4, 1], [1, 0])
+        layout_b = tle.gpu.BlockEncoding([1, 1], [32, 1], [1, 4], [0, 1])
+        compiled = compile_musa(
+            _set_layout_dual_domain_numeric_kernel,
+            {
+                "out_a": "*fp32",
+                "out_b": "*fp32",
+                "BLOCK": "constexpr",
+                "LAYOUT_A": "constexpr",
+                "LAYOUT_B": "constexpr",
+            },
+            {"BLOCK": 16, "LAYOUT_A": layout_a, "LAYOUT_B": layout_b},
+        )
+        _assert_runtime_pipeline_ir(compiled)
+        return
+
+    if kind == "rank3-shared-slice":
+        row_layout = tle.gpu.BlockEncoding([1, 1, 1], [1, 32, 1], [1, 4, 1], [2, 1, 0])
+        col_layout = tle.gpu.BlockEncoding([1, 1, 1], [1, 1, 32], [1, 1, 4], [2, 1, 0])
+        compiled = compile_musa(
+            _set_layout_shared_rank3_slice_numeric_kernel,
+            {
+                "out_rows": "*fp32",
+                "out_cols": "*fp32",
+                "BLOCK": "constexpr",
+                "ROW_LAYOUT": "constexpr",
+                "COL_LAYOUT": "constexpr",
+            },
+            {"BLOCK": 128, "ROW_LAYOUT": row_layout, "COL_LAYOUT": col_layout},
+        )
+        _assert_runtime_pipeline_ir(compiled)
+        return
+
+    if kind == "noinline-abi":
+        parent = tle.gpu.BlockEncoding([1, 1], [1, 32], [4, 1], [1, 0])
+        layout = tle.gpu.SlicedEncoding(0, parent)
+        compiled = compile_musa(
+            _set_layout_noinline_numeric_kernel,
+            {
+                "out": "*fp32",
+                "BLOCK": "constexpr",
+                "LAYOUT": "constexpr",
+            },
+            {"BLOCK": 128, "LAYOUT": layout},
+        )
+        _assert_runtime_pipeline_ir(compiled)
+        return
+
+    if kind == "wmma":
+        kernel = _explicit_musa_wmma_kernel
+        mma = MusaWmmaEncoding([3, 1], [2, 2], [16, 8, 16])
+        mnemonic = "ttmg.wmma_dot"
+    else:
+        kernel = _explicit_musa_sqmma_kernel
+        mma = MusaSqmmaEncoding([3, 1], [4, 1], [32, 64, 16])
+        mnemonic = "ttmg.squad_dot"
+    lhs_layout = MusaDotOperandEncoding(0, mma)
+    rhs_layout = MusaDotOperandEncoding(1, mma)
+    compiled = compile_musa(
+        kernel,
+        {
+            "out": "*fp32",
+            "MMA_LAYOUT": "constexpr",
+            "LHS_LAYOUT": "constexpr",
+            "RHS_LAYOUT": "constexpr",
+        },
+        {"MMA_LAYOUT": mma, "LHS_LAYOUT": lhs_layout, "RHS_LAYOUT": rhs_layout},
+    )
+    _assert_runtime_pipeline_ir(compiled, mnemonic)
+
+
+def test_mthreads_tle_explicit_sqmma_uses_fp32_carrier_for_fp16_result(tmp_path):
+    ttgir = _run_ttgir_musa_pass(
+        tmp_path,
+        """
+  tt.func public @explicit_sqmma_fp16() -> tensor<64x64xf16, #sqmma_explicit> {
+    %lhs = arith.constant dense<0.0> : tensor<64x32xf16, #sqmma_lhs_explicit>
+    %rhs = arith.constant dense<0.0> : tensor<32x64xf16, #sqmma_rhs_explicit>
+    %acc = arith.constant dense<0.0> : tensor<64x64xf16, #sqmma_explicit>
+    %result = tt.dot %lhs, %rhs, %acc : tensor<64x32xf16, #sqmma_lhs_explicit> * tensor<32x64xf16, #sqmma_rhs_explicit> -> tensor<64x64xf16, #sqmma_explicit>
+    tt.return %result : tensor<64x64xf16, #sqmma_explicit>
+  }
+""",
+        "add_accelerate_matmul",
+    )
+
+    assert "ttmg.squad_dot" in ttgir
+    assert "-> tensor<64x64xf32, #mma>" in ttgir
+    assert "arith.truncf" in ttgir
+    assert "to tensor<64x64xf16, #mma>" in ttgir
+    assert " tt.dot " not in ttgir
+
+
+@pytest.mark.parametrize(
+    "encoding,lhs_encoding,rhs_encoding,diagnostic",
+    [
+        (
+            "#sqmma_unsupported",
+            "#sqmma_lhs_unsupported",
+            "#sqmma_rhs_unsupported",
+            "instruction shape and element types are unsupported",
+        ),
+    ],
+)
+def test_mthreads_tle_explicit_sqmma_rejects_unsupported_contracts(
+    tmp_path,
+    capfd,
+    encoding,
+    lhs_encoding,
+    rhs_encoding,
+    diagnostic,
+):
+    with pytest.raises(RuntimeError):
+        _run_ttgir_musa_pass(
+            tmp_path,
+            f"""
+  tt.func public @invalid_explicit_sqmma() {{
+    %lhs = arith.constant dense<0.0> : tensor<64x32xbf16, {lhs_encoding}>
+    %rhs = arith.constant dense<0.0> : tensor<32x64xbf16, {rhs_encoding}>
+    %acc = arith.constant dense<0.0> : tensor<64x64xf32, {encoding}>
+    %result = tt.dot %lhs, %rhs, %acc : tensor<64x32xbf16, {lhs_encoding}> * tensor<32x64xbf16, {rhs_encoding}> -> tensor<64x64xf32, {encoding}>
+    tt.return
+  }}
+""",
+            "add_accelerate_matmul",
+        )
+    error = capfd.readouterr().err
+    assert "cannot lower explicit MUSA SQMMA dot" in error
+    assert diagnostic in error
+
+
+def test_mthreads_tle_explicit_sqmma_rejects_unmaterializable_shared_operand(tmp_path, capfd):
+    with pytest.raises(RuntimeError):
+        _run_ttgir_musa_pass(
+            tmp_path,
+            """
+  tt.func public @invalid_explicit_sqmma_shared(%raw_lhs: tensor<64x32xbf16>) {
+    %lhs = ttg.convert_layout %raw_lhs : tensor<64x32xbf16> -> tensor<64x32xbf16, #sqmma_lhs_explicit>
+    %rhs = arith.constant dense<0.0> : tensor<32x64xbf16, #sqmma_rhs_explicit>
+    %acc = arith.constant dense<0.0> : tensor<64x64xf32, #sqmma_explicit>
+    %result = tt.dot %lhs, %rhs, %acc : tensor<64x32xbf16, #sqmma_lhs_explicit> * tensor<32x64xbf16, #sqmma_rhs_explicit> -> tensor<64x64xf32, #sqmma_explicit>
+    tt.return
+  }
+""",
+            "add_accelerate_matmul",
+        )
+    error = capfd.readouterr().err
+    assert "cannot lower explicit MUSA SQMMA dot" in error
+    assert "operand cannot be materialized in shared memory" in error
+
+
+def test_mthreads_tle_explicit_sqmma_rejects_invalid_squad_layout(tmp_path, capfd):
+    fixture = tmp_path / "mthreads_tle_invalid_explicit_sqmma_squad.mlir"
+    fixture.write_text(f"{_CONVERSION_LAYOUTS}\n"
+                       "#sqmma_bad_squad = #ttg.musa_sqmma<{versionMajor = 3, versionMinor = 1, "
+                       "warpsPerCTA = [2, 2], instrShape = [32, 64, 16]}>\n"
+                       "module attributes {\"ttg.num-ctas\" = 1 : i32, \"ttg.num-warps\" = 4 : i32, "
+                       "ttg.target = \"musa:ph1\", \"ttg.threads-per-warp\" = 32 : i32} {}\n")
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    with pytest.raises(RuntimeError):
+        ir.parse_mlir_module(str(fixture), context)
+    assert "SQMMA expects warpsPerCTA[0] to be a multiple of 4" in capfd.readouterr().err
+
+
+def test_mthreads_tle_explicit_sqmma_rejects_mismatched_parent(tmp_path, capfd):
+    with pytest.raises(RuntimeError):
+        _run_ttgir_musa_pass(
+            tmp_path,
+            """
+  tt.func public @invalid_explicit_sqmma_parent() {
+    %lhs = arith.constant dense<0.0> : tensor<64x32xbf16, #lhs>
+    %rhs = arith.constant dense<0.0> : tensor<32x64xbf16, #sqmma_rhs_explicit>
+    %acc = arith.constant dense<0.0> : tensor<64x64xf32, #sqmma_explicit>
+    %result = tt.dot %lhs, %rhs, %acc : tensor<64x32xbf16, #lhs> * tensor<32x64xbf16, #sqmma_rhs_explicit> -> tensor<64x64xf32, #sqmma_explicit>
+    tt.return
+  }
+""",
+            "add_accelerate_matmul",
+        )
+    error = capfd.readouterr().err
+    assert "Incompatible parent encoding" in error
+
+
+def test_mthreads_tle_explicit_sqmma_rejects_disable_sqmma(monkeypatch, tmp_path, capfd):
+    monkeypatch.setenv("DISABLE_SQMMA", "1")
+    with pytest.raises(RuntimeError):
+        _run_ttgir_musa_pass(
+            tmp_path,
+            """
+  tt.func public @disabled_explicit_sqmma() {
+    %lhs = arith.constant dense<0.0> : tensor<64x32xbf16, #sqmma_lhs_explicit>
+    %rhs = arith.constant dense<0.0> : tensor<32x64xbf16, #sqmma_rhs_explicit>
+    %acc = arith.constant dense<0.0> : tensor<64x64xf32, #sqmma_explicit>
+    %result = tt.dot %lhs, %rhs, %acc : tensor<64x32xbf16, #sqmma_lhs_explicit> * tensor<32x64xbf16, #sqmma_rhs_explicit> -> tensor<64x64xf32, #sqmma_explicit>
+    tt.return
+  }
+""",
+            "add_accelerate_matmul",
+        )
+    error = capfd.readouterr().err
+    assert "cannot lower explicit MUSA SQMMA dot" in error
+    assert "DISABLE_SQMMA conflicts with an explicit MUSA SQMMA layout" in error
+
+
+@pytest.mark.parametrize(
+    "lhs_type,rhs_type,result_type,diagnostic",
+    [
+        (
+            "tensor<16x16xbf16, #rhs>",
+            "tensor<16x16xbf16, #rhs>",
+            "tensor<16x16xf32, #mma>",
+            "Wrong opIdx",
+        ),
+        (
+            "tensor<16x16xbf16, #lhs>",
+            "tensor<16x16xbf16, #lhs>",
+            "tensor<16x16xf32, #mma>",
+            "Wrong opIdx",
+        ),
+        (
+            "tensor<16x16xbf16, #sqmma_lhs_explicit>",
+            "tensor<16x16xbf16, #rhs>",
+            "tensor<16x16xf32, #mma>",
+            "Incompatible parent encoding",
+        ),
+        (
+            "tensor<16x16xbf16, #lhs>",
+            "tensor<16x16xbf16, #sqmma_rhs_explicit>",
+            "tensor<16x16xf32, #mma>",
+            "Incompatible parent encoding",
+        ),
+        (
+            "tensor<64x32xbf16, #sqmma_rhs_explicit>",
+            "tensor<32x64xbf16, #sqmma_rhs_explicit>",
+            "tensor<64x64xf32, #sqmma_explicit>",
+            "Wrong opIdx",
+        ),
+        (
+            "tensor<64x32xbf16, #sqmma_lhs_explicit>",
+            "tensor<32x64xbf16, #sqmma_lhs_explicit>",
+            "tensor<64x64xf32, #sqmma_explicit>",
+            "Wrong opIdx",
+        ),
+        (
+            "tensor<64x32xbf16, #lhs>",
+            "tensor<32x64xbf16, #sqmma_rhs_explicit>",
+            "tensor<64x64xf32, #sqmma_explicit>",
+            "Incompatible parent encoding",
+        ),
+        (
+            "tensor<64x32xbf16, #sqmma_lhs_explicit>",
+            "tensor<32x64xbf16, #rhs>",
+            "tensor<64x64xf32, #sqmma_explicit>",
+            "Incompatible parent encoding",
+        ),
+    ],
+)
+def test_mthreads_tle_explicit_mma_rejects_operand_index_and_parent_matrix(
+    tmp_path,
+    capfd,
+    lhs_type,
+    rhs_type,
+    result_type,
+    diagnostic,
+):
+    with pytest.raises(RuntimeError):
+        _run_ttgir_musa_pass(
+            tmp_path,
+            f"""
+  tt.func public @invalid_explicit_musa_mma_contract() {{
+    %lhs = arith.constant dense<0.0> : {lhs_type}
+    %rhs = arith.constant dense<0.0> : {rhs_type}
+    %acc = arith.constant dense<0.0> : {result_type}
+    %result = tt.dot %lhs, %rhs, %acc : {lhs_type} * {rhs_type} -> {result_type}
+    tt.return
+  }}
+""",
+            "add_accelerate_matmul",
+        )
+    assert diagnostic in capfd.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "parent,operand_index,kind",
+    [
+        ("#mma", 0, "WMMA"),
+        ("#mma", 1, "WMMA"),
+        ("#sqmma_explicit", 0, "SQMMA"),
+        ("#sqmma_explicit", 1, "SQMMA"),
+    ],
+)
+def test_mthreads_tle_explicit_mma_rejects_nonzero_k_width(
+    tmp_path,
+    capfd,
+    parent,
+    operand_index,
+    kind,
+):
+    fixture = (tmp_path / f"mthreads_tle_invalid_{kind.lower()}_k_width_{operand_index}.mlir")
+    fixture.write_text(f"{_CONVERSION_LAYOUTS}\n"
+                       f"#invalid_k_width = #ttg.dot_op<{{opIdx = {operand_index}, parent = {parent}, kWidth = 1}}>\n"
+                       "module {}\n")
+
+    _, backend = mthreads_backend()
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    with pytest.raises(RuntimeError):
+        ir.parse_mlir_module(str(fixture), context)
+    error = capfd.readouterr().err
+    assert "ttg.dot_op kWidth parameter is not supported" in error
+    assert f"for MUSA {kind} parent" in error
+
+
+def test_mthreads_tle_set_layout_rejects_chained_dot_accumulator_conflict(
+    tmp_path,
+    capfd,
+):
+    with pytest.raises(RuntimeError):
+        _convert_set_layout_to_ttgir(
+            tmp_path,
+            """
+  tt.func public @conflicting_chained_dot_accumulator() {
+    %lhs_value = arith.constant dense<1.0> : tensor<16x16xbf16>
+    %lhs = musa_tle.set_layout %lhs_value {target_encoding = #lhs} : tensor<16x16xbf16> -> tensor<16x16xbf16>
+    %rhs_value = arith.constant dense<2.0> : tensor<16x16xbf16>
+    %rhs = musa_tle.set_layout %rhs_value {target_encoding = #rhs} : tensor<16x16xbf16> -> tensor<16x16xbf16>
+    %acc_value = arith.constant dense<0.0> : tensor<16x16xf32>
+    %acc = musa_tle.set_layout %acc_value {target_encoding = #mma} : tensor<16x16xf32> -> tensor<16x16xf32>
+    %first = tt.dot %lhs, %rhs, %acc : tensor<16x16xbf16> * tensor<16x16xbf16> -> tensor<16x16xf32>
+    %conflict = musa_tle.set_layout %first {target_encoding = #wmma_explicit} : tensor<16x16xf32> -> tensor<16x16xf32>
+    %second = tt.dot %lhs, %rhs, %conflict : tensor<16x16xbf16> * tensor<16x16xbf16> -> tensor<16x16xf32>
+    tt.return
+  }
+""",
+        )
+    error = capfd.readouterr().err
+    assert "Incompatible parent encoding" in error
+    assert "failed to infer returned types" in error
+    assert "#ttg.musa_wmma" in error
+
+
+@pytest.mark.parametrize("kind", ["wmma", "sqmma"])
+@requires_musa_runtime
+def test_mthreads_tle_explicit_mma_chained_runtime(kind):
+    if kind == "wmma":
+        kernel = _explicit_musa_wmma_chained_kernel
+        mma = MusaWmmaEncoding([3, 1], [4, 1], [16, 16, 16])
+        block_m, block_n, block_k = 16, 16, 16
+        mnemonic = "ttmg.wmma_dot"
+    else:
+        kernel = _explicit_musa_sqmma_chained_kernel
+        mma = MusaSqmmaEncoding([3, 1], [4, 1], [32, 64, 16])
+        block_m, block_n, block_k = 64, 64, 32
+        mnemonic = "ttmg.squad_dot"
+    lhs_layout = MusaDotOperandEncoding(0, mma)
+    rhs_layout = MusaDotOperandEncoding(1, mma)
+    actual = torch.empty((block_m, block_n), device="musa", dtype=torch.float32)
+
+    compiled = _warmup_and_run(
+        kernel,
+        actual,
+        mma,
+        lhs_layout,
+        rhs_layout,
+        num_warps=4,
+    )
+
+    _assert_runtime_pipeline_ir(compiled, mnemonic, native_dot_count=2)
+    _assert_direct_native_dot_chain(compiled.asm["ttgir"], mnemonic)
+    reference = torch.full((block_m, block_n), 4.0 * block_k, dtype=torch.float32)
+    torch.testing.assert_close(actual.cpu(), reference, rtol=1e-3, atol=1e-3)
+
+
+def test_mthreads_tle_finalize_explicit_layouts_preserves_final_encodings(tmp_path):
+    before, finalized = _run_ttgir_finalize_explicit_layouts(
+        tmp_path,
+        """
+  tt.func public @finalize_layouts(%arg0: tensor<16x16xf32, #layout_a>, %out: tensor<16x16x!tt.ptr<f32>, #layout_b>) {
+    %hard = ttg.convert_layout %arg0 {tle.explicit_encoding.0 = #layout_b} : tensor<16x16xf32, #layout_a> -> tensor<16x16xf32, #layout_b>
+    %identity = ttg.convert_layout %hard {tle.explicit_encoding.0 = #layout_b} : tensor<16x16xf32, #layout_b> -> tensor<16x16xf32, #layout_b>
+    tt.store %out, %identity {tle.explicit_memory_encoding = #layout_b} : tensor<16x16x!tt.ptr<f32>, #layout_b>
+    tt.return
+  }
+""",
+    )
+
+    assert before.count("tle.explicit_encoding.0") == 2
+    assert "tle.explicit_memory_encoding" in before
+    assert "tle.explicit_encoding." not in finalized
+    assert "tle.explicit_memory_encoding" not in finalized
+    assert finalized.count("ttg.convert_layout") == 1
+    conversion = next(line for line in finalized.splitlines() if "ttg.convert_layout" in line)
+    source_encoding, target_encoding = _type_encoding_aliases(conversion)
+    assert source_encoding != target_encoding
+    store = next(line for line in finalized.splitlines() if "tt.store" in line)
+    assert target_encoding in store
+
+
+def test_mthreads_tle_finalize_explicit_layouts_is_idempotent_after_cse(tmp_path):
+    before, finalized = _run_ttgir_finalize_explicit_layouts(
+        tmp_path,
+        """
+  tt.func public @finalize_after_cse(%out: tensor<16x16x!tt.ptr<f32>, #layout_a>) {
+    %lhs = arith.constant {tle.explicit_encoding.0 = #layout_a} dense<1.0> : tensor<16x16xf32, #layout_a>
+    %rhs = arith.constant {tle.explicit_encoding.0 = #layout_a} dense<1.0> : tensor<16x16xf32, #layout_a>
+    %sum = arith.addf %lhs, %rhs {tle.explicit_encoding.0 = #layout_a} : tensor<16x16xf32, #layout_a>
+    tt.store %out, %sum {tle.explicit_memory_encoding = #layout_a} : tensor<16x16x!tt.ptr<f32>, #layout_a>
+    tt.return
+  }
+""",
+        finalize_repeat=2,
+        run_cse=True,
+    )
+
+    assert before.count("arith.constant") == 1
+    assert "tle.explicit_encoding.0" in before
+    assert "tle.explicit_memory_encoding" in before
+    assert "tle.explicit_encoding." not in finalized
+    assert "tle.explicit_memory_encoding" not in finalized
+    assert finalized.count("arith.constant") == 1
+    assert "tensor<16x16xf32" in finalized
+
+
+def test_mthreads_tle_finalize_explicit_layouts_keeps_ordinary_ir(tmp_path):
+    before, finalized = _run_ttgir_finalize_explicit_layouts(
+        tmp_path,
+        """
+  tt.func public @ordinary_finalize(%arg0: tensor<16x16xf32, #layout_a>, %out: tensor<16x16x!tt.ptr<f32>, #layout_a>) {
+    %value = arith.addf %arg0, %arg0 : tensor<16x16xf32, #layout_a>
+    tt.store %out, %value : tensor<16x16x!tt.ptr<f32>, #layout_a>
+    tt.return
+  }
+""",
+    )
+    assert finalized == before
+
+
+@pytest.mark.parametrize(
+    "body,diagnostic",
+    [
+        (
+            """
+  tt.func public @malformed_result_attr() {
+    %value = arith.constant {tle.explicit_encoding.bad = #layout_a} dense<1.0> : tensor<16x16xf32, #layout_a>
+    tt.return
+  }
+""",
+            "has malformed explicit MUSA TLE result encoding",
+        ),
+        (
+            """
+  tt.func public @missing_result_attr() {
+    %value = arith.constant {tle.explicit_encoding.1 = #layout_a} dense<1.0> : tensor<16x16xf32, #layout_a>
+    tt.return
+  }
+""",
+            "has explicit MUSA TLE encoding for missing result 1",
+        ),
+        (
+            """
+  tt.func public @mismatched_result_attr() {
+    %value = arith.constant {tle.explicit_encoding.0 = #layout_b} dense<1.0> : tensor<16x16xf32, #layout_a>
+    tt.return
+  }
+""",
+            "does not match the final tensor type encoding",
+        ),
+        (
+            """
+  tt.func public @memory_attr_on_non_memory_op() {
+    %value = arith.constant {tle.explicit_memory_encoding = #layout_a} dense<1.0> : tensor<16x16xf32, #layout_a>
+    tt.return
+  }
+""",
+            "explicit MUSA TLE memory encoding on a non-memory operation",
+        ),
+        (
+            """
+  tt.func public @mismatched_memory_attr(%out: tensor<16x16x!tt.ptr<f32>, #layout_a>) {
+    %value = arith.constant dense<1.0> : tensor<16x16xf32, #layout_a>
+    tt.store %out, %value {tle.explicit_memory_encoding = #layout_b} : tensor<16x16x!tt.ptr<f32>, #layout_a>
+    tt.return
+  }
+""",
+            "does not match the final pointer encoding",
+        ),
+    ],
+)
+def test_mthreads_tle_finalize_explicit_layouts_rejects_invalid_contracts(tmp_path, capfd, body, diagnostic):
+    with pytest.raises(RuntimeError):
+        _run_ttgir_finalize_explicit_layouts(tmp_path, body)
+    assert diagnostic in capfd.readouterr().err
+
+
+def test_mthreads_tle_make_ttgir_records_explicit_layout_lifecycle(monkeypatch, tmp_path):
+    repro_prefix = tmp_path / "mthreads_tle_layout_lifecycle"
+    monkeypatch.setenv("TRITON_ALWAYS_COMPILE", "1")
+    monkeypatch.setenv("TRITON_REPRODUCER_PATH", str(repro_prefix))
+
+    layout = MusaSqmmaEncoding([3, 1], [4, 1], [128, 128, 64])
+    compile_musa(
+        _set_layout_sqmma_pipeline_kernel,
+        {"out": "*fp32", "LAYOUT": "constexpr"},
+        {"LAYOUT": layout},
+    )
+
+    reproducer = (tmp_path / "mthreads_tle_layout_lifecycle.make_ttgir.repro.mlir").read_text()
+    pipeline_match = re.search(r'pipeline: "([^"]+)"', reproducer)
+    assert pipeline_match is not None, reproducer
+    pipeline = pipeline_match.group(1)
+    cleanup = "tritongpu-remove-layout-conversions"
+    finalize = "tritonmusa-tle-finalize-explicit-layouts"
+    assert pipeline.count(cleanup) == 3
+    assert pipeline.count(finalize) == 1
+
+    ordered_passes = [
+        "convert-triton-to-tritongpu",
+        "tritongpu-coalesce",
+        cleanup,
+        "tritongpu-optimize-thread-locality",
+        "tritonmusa-tle-select-encodings",
+        "tritonmusa-tle-lower-sqmma",
+        "tritonmusa-accelerate-matmul",
+        cleanup,
+        "tritonmusa-optimize-dot-operands",
+        "tritonmusa-pipeline",
+        "tritongpu-prefetch",
+        "tritongpu-coalesce-async-copy",
+        "tritonmusa-tme-lowering",
+        "tritonmusa-canonicalize-sqmma-result-conversions",
+        cleanup,
+        "tritonmusa-convert-sqmma-to-mtgpu",
+        "tritonmusa-finalize-barriers",
+        "tritonmusa-tle-prepare-warp-specialize",
+        finalize,
+    ]
+    cursor = 0
+    for pass_name in ordered_passes:
+        position = pipeline.find(pass_name, cursor)
+        assert position >= cursor, f"missing or misordered pass {pass_name}: {pipeline}"
+        cursor = position + len(pass_name)
+
+
+def test_mthreads_tle_layout_attrs_are_written_and_idempotent():
+    ttir = compile_to_ttir(_valid_layout_attrs_kernel, {})
+    assert '"ttg.num-warps" = 4 : i32' in ttir
+    assert '"ttg.threads-per-warp" = 32 : i32' in ttir
+    assert '"ttg.num-ctas" = 1 : i32' in ttir
+
+
+@pytest.mark.parametrize(
+    "kernel,diagnostic",
+    [
+        (
+            _num_warps_conflict_kernel,
+            r"mthreads TLE layout attribute 'ttg\.num-warps' mismatch: module has 4 : i32, requested 8 : i32",
+        ),
+        (
+            _num_ctas_conflict_kernel,
+            r"mthreads TLE layout attribute 'ttg\.num-ctas' mismatch: module has 1 : i32, requested 2 : i32",
+        ),
+    ],
+)
+def test_mthreads_tle_layout_attrs_reject_conflicts(kernel, diagnostic):
+    with pytest.raises(CompilationError, match=diagnostic):
+        compile_to_ttir(kernel, {})
+
+
+@pytest.mark.parametrize(
+    "constexprs,diagnostic",
+    [
+        (
+            {"num_warps": 0, "warp_size": 32, "num_ctas": 1},
+            "mthreads TLE num_warps must be a positive power of two",
+        ),
+        (
+            {"num_warps": 3, "warp_size": 32, "num_ctas": 1},
+            "mthreads TLE num_warps must be a positive power of two",
+        ),
+        (
+            {"num_warps": 4, "warp_size": 64, "num_ctas": 1},
+            r"mthreads TLE PH1 requires warp_size \(threads per warp\) to be 32",
+        ),
+        (
+            {"num_warps": 4, "warp_size": 32, "num_ctas": 0},
+            "mthreads TLE num_ctas must be positive",
+        ),
+    ],
+)
+def test_mthreads_tle_layout_attrs_reject_invalid_parameters(constexprs, diagnostic):
+    signature = {
+        "num_warps": "constexpr",
+        "warp_size": "constexpr",
+        "num_ctas": "constexpr",
+    }
+    with pytest.raises(CompilationError, match=re.escape(diagnostic) if "\\" not in diagnostic else diagnostic):
+        compile_to_ttir(_invalid_layout_attrs_kernel, signature, constexprs)

--- a/third_party/mthreads/tle/dialect/include/Dialect/MUSATLE/IR/MUSATLEOps.td
+++ b/third_party/mthreads/tle/dialect/include/Dialect/MUSATLE/IR/MUSATLEOps.td
@@ -88,6 +88,24 @@ def MUSATLE_InsertTileOp
   let hasVerifier = 1;
 }
 
+def MUSATLE_SetLayoutOp : MUSATLE_Op<"set_layout", [
+    Pure,
+    SameOperandsAndResultShape,
+    SameOperandsAndResultElementType
+]> {
+  let summary = "Attach a requested distributed encoding to a tensor value";
+  let description = [{
+    Carries a user-requested TritonGPU distributed encoding through the
+    mthreads TLE frontend. The op is lowered during Triton-to-TritonGPU
+    conversion after encoding propagation has selected legal layouts for
+    dependent values.
+  }];
+  let arguments = (ins TT_Tensor:$src, AnyAttr:$target_encoding);
+  let results = (outs TT_Tensor:$result);
+  let assemblyFormat = "$src attr-dict `:` qualified(type($src)) `->` qualified(type($result))";
+  let hasVerifier = 1;
+}
+
 def MUSATLE_ExclusiveCumsumOp
     : MUSATLE_Op<"exclusive_cumsum",
                  [Pure, SameOperandsAndResultEncoding]> {

--- a/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
+++ b/third_party/mthreads/tle/dialect/include/MUSATLE/Transforms/Passes.td
@@ -213,4 +213,19 @@ def TritonMUSAGPUTLELowerBarrierOperations
   ];
 }
 
+def TritonMUSAGPUTLEFinalizeExplicitLayouts
+    : Pass<"tritonmusa-tle-finalize-explicit-layouts", "mlir::ModuleOp"> {
+  let summary = "Finalize mthreads TLE explicit layout constraints";
+  let description = [{
+    Verify that temporary explicit result and memory encodings agree with the
+    final TTGPU tensor types, then remove the temporary attributes before LLVM
+    lowering.  Tensor encodings and non-identity layout conversions remain the
+    durable representation of the selected layouts.
+  }];
+  let dependentDialects = [
+    "mlir::triton::TritonDialect",
+    "mlir::triton::gpu::TritonGPUDialect"
+  ];
+}
+
 #endif // MUSA_TLE_TRANSFORMS_PASSES

--- a/third_party/mthreads/tle/dialect/lib/IR/Dialect.cpp
+++ b/third_party/mthreads/tle/dialect/lib/IR/Dialect.cpp
@@ -326,6 +326,28 @@ LogicalResult BarrierArriveOp::verify() {
   return success();
 }
 
+LogicalResult SetLayoutOp::verify() {
+  auto srcTy = dyn_cast<RankedTensorType>(getSrc().getType());
+  auto resultTy = dyn_cast<RankedTensorType>(getResult().getType());
+  if (!srcTy || !resultTy)
+    return emitOpError("expects source and result to be ranked tensors");
+
+  Attribute targetEncoding = getTargetEncoding();
+  if (!dyn_cast<ttg::DistributedEncodingTrait>(targetEncoding))
+    return emitOpError("target_encoding must be a distributed encoding");
+
+  auto layoutEncoding = dyn_cast<ttg::LayoutEncodingTrait>(targetEncoding);
+  if (!layoutEncoding)
+    return emitOpError("distributed target_encoding must expose a layout rank");
+
+  unsigned targetRank = layoutEncoding.getRank();
+  if (targetRank != static_cast<unsigned>(srcTy.getRank()))
+    return emitOpError("target encoding rank ")
+           << targetRank << " must match source tensor rank "
+           << srcTy.getRank();
+  return success();
+}
+
 LogicalResult ExclusiveCumsumOp::verify() {
   auto srcTy = dyn_cast<RankedTensorType>(getSrc().getType());
   if (!srcTy)

--- a/third_party/mthreads/tle/dialect/lib/Transforms/CMakeLists.txt
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_triton_library(MUSATLETransforms
+  FinalizeExplicitLayouts.cpp
   InsertLocalPointerBarriers.cpp
   LowerBarrierAllocations.cpp
   LowerBarrierOperations.cpp

--- a/third_party/mthreads/tle/dialect/lib/Transforms/FinalizeExplicitLayouts.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/FinalizeExplicitLayouts.cpp
@@ -1,0 +1,123 @@
+#ifdef __TLE__
+
+#include "TritonMUSAGPUTransforms/Passes.h"
+
+#include "mlir/IR/BuiltinOps.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir {
+
+#define GEN_PASS_DEF_TRITONMUSAGPUTLEFINALIZEEXPLICITLAYOUTS
+#include "TritonMUSAGPUTransforms/Passes.h.inc"
+
+namespace {
+
+static LogicalResult verifyExplicitResultEncoding(Operation *op,
+                                                  NamedAttribute namedAttr,
+                                                  StringRef prefix) {
+  StringRef name = namedAttr.getName().getValue();
+  StringRef suffix = name.drop_front(prefix.size());
+  unsigned resultNumber = 0;
+  if (suffix.empty() || suffix.getAsInteger(10, resultNumber))
+    return op->emitOpError("has malformed explicit MUSA TLE result encoding '")
+           << name << "'";
+  if (resultNumber >= op->getNumResults())
+    return op->emitOpError("has explicit MUSA TLE encoding for missing result ")
+           << resultNumber;
+
+  auto resultType =
+      dyn_cast<RankedTensorType>(op->getResult(resultNumber).getType());
+  if (!resultType || !resultType.getEncoding())
+    return op->emitOpError("has explicit MUSA TLE encoding on result ")
+           << resultNumber << " without a distributed ranked tensor type";
+  if (resultType.getEncoding() != namedAttr.getValue())
+    return op->emitOpError("has explicit MUSA TLE result encoding that does "
+                           "not match the final tensor type encoding:\n  ")
+           << namedAttr.getValue() << "\nand\n  " << resultType.getEncoding();
+  return success();
+}
+
+static LogicalResult verifyExplicitMemoryEncoding(Operation *op,
+                                                  Attribute encoding) {
+  Value pointer = getMemAccessPtr(op);
+  if (!pointer)
+    return op->emitOpError(
+        "has explicit MUSA TLE memory encoding on a non-memory operation");
+
+  auto pointerType = dyn_cast<RankedTensorType>(pointer.getType());
+  if (!pointerType || !pointerType.getEncoding())
+    return op->emitOpError(
+        "has explicit MUSA TLE memory encoding without an encoded tensor "
+        "pointer");
+  if (pointerType.getEncoding() != encoding)
+    return op->emitOpError("has explicit MUSA TLE memory encoding that does "
+                           "not match the final pointer encoding:\n  ")
+           << encoding << "\nand\n  " << pointerType.getEncoding();
+
+  Attribute inferredEncoding;
+  if (failed(inferTleExplicitMemoryEncoding(op, inferredEncoding)))
+    return failure();
+  if (inferredEncoding != encoding)
+    return op->emitOpError(
+        "has an inconsistent inferred explicit MUSA TLE memory encoding");
+  return success();
+}
+
+class FinalizeExplicitLayoutsPass
+    : public impl::TritonMUSAGPUTLEFinalizeExplicitLayoutsBase<
+          FinalizeExplicitLayoutsPass> {
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    StringRef resultPrefix = getTleExplicitEncodingAttrPrefix();
+    StringRef memoryName = getTleExplicitMemoryEncodingAttrName();
+
+    WalkResult verification = module.walk([&](Operation *op) -> WalkResult {
+      for (NamedAttribute attr : op->getAttrs()) {
+        StringRef name = attr.getName().getValue();
+        if (name.starts_with(resultPrefix) &&
+            failed(verifyExplicitResultEncoding(op, attr, resultPrefix)))
+          return WalkResult::interrupt();
+      }
+      if (Attribute memoryEncoding = op->getAttr(memoryName)) {
+        if (failed(verifyExplicitMemoryEncoding(op, memoryEncoding)))
+          return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (verification.wasInterrupted()) {
+      signalPassFailure();
+      return;
+    }
+
+    SmallVector<triton::gpu::ConvertLayoutOp> identityConversions;
+    module.walk([&](Operation *op) {
+      SmallVector<StringAttr> attrsToRemove;
+      for (NamedAttribute attr : op->getAttrs()) {
+        StringRef name = attr.getName().getValue();
+        if (name.starts_with(resultPrefix) || name == memoryName)
+          attrsToRemove.push_back(attr.getName());
+      }
+      for (StringAttr name : attrsToRemove)
+        op->removeAttr(name);
+
+      if (auto convert = dyn_cast<triton::gpu::ConvertLayoutOp>(op)) {
+        if (convert.getSrc().getType() == convert.getType())
+          identityConversions.push_back(convert);
+      }
+    });
+
+    for (triton::gpu::ConvertLayoutOp convert : identityConversions) {
+      convert.getResult().replaceAllUsesWith(convert.getSrc());
+      convert.erase();
+    }
+  }
+};
+
+} // namespace
+} // namespace mlir
+
+#endif // __TLE__

--- a/third_party/mthreads/tle/dialect/lib/Transforms/LowerSqmma.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/LowerSqmma.cpp
@@ -447,6 +447,10 @@ struct TritonMUSAGPUTLELowerSqmmaPass
       Value released = ttg::ConvertLayoutOp::create(builder, wait.getLoc(),
                                                     wait.getOutput().getType(),
                                                     nativeWait.getResult(0));
+      if (Attribute explicitEncoding =
+              getTleExplicitValueEncoding(wait.getOutput()))
+        setTleExplicitResultEncoding(released.getDefiningOp(), 0,
+                                     explicitEncoding);
       wait.getOutput().replaceAllUsesWith(released);
       wait.erase();
     }

--- a/third_party/mthreads/tle/dialect/lib/Transforms/SelectEncodings.cpp
+++ b/third_party/mthreads/tle/dialect/lib/Transforms/SelectEncodings.cpp
@@ -11,6 +11,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 
@@ -30,8 +31,11 @@ constexpr StringLiteral kTTConstancyAttr = "tt.constancy";
 
 static Value stripConvertLayouts(Value value) {
   Value current = value;
-  while (auto convert = current.getDefiningOp<triton::gpu::ConvertLayoutOp>())
+  while (auto convert = current.getDefiningOp<triton::gpu::ConvertLayoutOp>()) {
+    if (isTleExplicitConvertLayoutOp(convert))
+      break;
     current = convert.getSrc();
+  }
   return current;
 }
 
@@ -61,6 +65,8 @@ static Value stripIndexValueWrappers(Value value) {
   Value current = value;
   while (true) {
     if (auto convert = current.getDefiningOp<triton::gpu::ConvertLayoutOp>()) {
+      if (isTleExplicitConvertLayoutOp(convert))
+        break;
       current = convert.getSrc();
       continue;
     }
@@ -201,6 +207,8 @@ static bool valueFeedsDot(Value root) {
       if (isa<triton::DotOpInterface>(owner))
         return true;
       if (auto convert = dyn_cast<triton::gpu::ConvertLayoutOp>(owner)) {
+        if (isTleExplicitConvertLayoutOp(convert))
+          continue;
         enqueue(convert.getResult());
         continue;
       }
@@ -282,6 +290,8 @@ static Operation *peelAxisInfoCarrier(Value value) {
     if (!def)
       break;
     if (auto convert = dyn_cast<triton::gpu::ConvertLayoutOp>(def)) {
+      if (isTleExplicitConvertLayoutOp(convert))
+        return def;
       current = convert.getSrc();
       continue;
     }
@@ -424,6 +434,8 @@ collectConsumerEncodingVotes(Value root,
         continue;
       }
       if (auto convert = dyn_cast<triton::gpu::ConvertLayoutOp>(owner)) {
+        if (isTleExplicitConvertLayoutOp(convert))
+          continue;
         enqueue(convert.getResult());
         continue;
       }
@@ -441,6 +453,99 @@ collectConsumerEncodingVotes(Value root,
       }
     }
   }
+}
+
+static LogicalResult
+mergeHardEncoding(triton::musa_tle::LocalPointersOp localPointers,
+                  Attribute candidate, Attribute &hardEncoding) {
+  if (!candidate)
+    return success();
+  if (!hardEncoding) {
+    hardEncoding = candidate;
+    return success();
+  }
+  if (hardEncoding == candidate)
+    return success();
+
+  localPointers.emitOpError(
+      "has conflicting explicit MUSA TLE local pointer encodings:\n  ")
+      << hardEncoding << "\nand\n  " << candidate;
+  return failure();
+}
+
+static LogicalResult
+mergeExplicitValueEncoding(triton::musa_tle::LocalPointersOp localPointers,
+                           Value value, Attribute &hardEncoding) {
+  Attribute candidate = getTleExplicitValueEncoding(value);
+  if (!candidate)
+    return success();
+
+  auto tensorTy = dyn_cast<RankedTensorType>(value.getType());
+  if (!tensorTy || tensorTy.getEncoding() != candidate) {
+    Operation *def = value.getDefiningOp();
+    return (def ? def : localPointers.getOperation())
+        ->emitOpError("has explicit MUSA TLE result encoding that does not "
+                      "match the tensor type encoding");
+  }
+  return mergeHardEncoding(localPointers, candidate, hardEncoding);
+}
+
+static LogicalResult
+resolveHardEncoding(triton::musa_tle::LocalPointersOp localPointers,
+                    Attribute &hardEncoding) {
+  hardEncoding = nullptr;
+  if (failed(mergeExplicitValueEncoding(
+          localPointers, localPointers.getResult(), hardEncoding)))
+    return failure();
+  for (Value index : localPointers.getIndices())
+    if (failed(mergeExplicitValueEncoding(localPointers, index, hardEncoding)))
+      return failure();
+
+  llvm::SmallVector<Value> worklist;
+  llvm::DenseSet<Value> visited;
+  auto enqueue = [&](Value value) {
+    if (value && visited.insert(value).second)
+      worklist.push_back(value);
+  };
+  enqueue(localPointers.getResult());
+
+  while (!worklist.empty()) {
+    Value current = worklist.pop_back_val();
+    if (failed(
+            mergeExplicitValueEncoding(localPointers, current, hardEncoding)))
+      return failure();
+
+    for (OpOperand &use : current.getUses()) {
+      Operation *owner = use.getOwner();
+      if (isa<triton::LoadOp, triton::StoreOp, triton::AtomicRMWOp,
+              triton::AtomicCASOp>(owner)) {
+        Attribute memoryEncoding;
+        if (failed(inferTleExplicitMemoryEncoding(owner, memoryEncoding)) ||
+            failed(
+                mergeHardEncoding(localPointers, memoryEncoding, hardEncoding)))
+          return failure();
+        continue;
+      }
+      if (auto convert = dyn_cast<triton::gpu::ConvertLayoutOp>(owner)) {
+        if (!isTleExplicitConvertLayoutOp(convert))
+          enqueue(convert.getResult());
+        continue;
+      }
+      if (auto bcast = dyn_cast<triton::BroadcastOp>(owner)) {
+        enqueue(bcast.getResult());
+        continue;
+      }
+      if (auto expand = dyn_cast<triton::ExpandDimsOp>(owner)) {
+        enqueue(expand.getResult());
+        continue;
+      }
+      if (auto reshape = dyn_cast<triton::ReshapeOp>(owner)) {
+        enqueue(reshape.getResult());
+        continue;
+      }
+    }
+  }
+  return success();
 }
 
 static Attribute pickDominantEncoding(ArrayRef<EncodingVote> votes,
@@ -503,6 +608,9 @@ static void bridgeResultTypeToOldEncoding(Value result, Type oldType,
 static bool tryFoldPointerConvertLayout(triton::gpu::ConvertLayoutOp convert,
                                         OpBuilder &builder,
                                         CachedConversionMap &cache) {
+  if (isTleExplicitConvertLayoutOp(convert))
+    return false;
+
   auto srcTy = dyn_cast<RankedTensorType>(convert.getSrc().getType());
   auto dstTy = dyn_cast<RankedTensorType>(convert.getType());
   if (!srcTy || !dstTy)
@@ -618,6 +726,21 @@ class SelectEncodingsPass
     OpBuilder builder(module.getContext());
     CachedConversionMap userOperandConversionCache;
     CachedConversionMap indexOperandConversionCache;
+    llvm::DenseMap<Operation *, Attribute> hardEncodings;
+    WalkResult preflight =
+        module.walk([&](triton::musa_tle::LocalPointersOp op) -> WalkResult {
+          Attribute hardEncoding;
+          if (failed(resolveHardEncoding(op, hardEncoding)))
+            return WalkResult::interrupt();
+          if (hardEncoding)
+            hardEncodings[op.getOperation()] = hardEncoding;
+          return WalkResult::advance();
+        });
+    if (preflight.wasInterrupted()) {
+      signalPassFailure();
+      return;
+    }
+
     module.walk([&](triton::musa_tle::LocalPointersOp op) {
       // Always tag local pointer ops so barrier insertion can track hazards
       // across different pointer views of the same alloc.
@@ -649,38 +772,46 @@ class SelectEncodingsPass
       }
 
       auto encoding = tensorTy.getEncoding();
-      SmallVector<EncodingVote> votes;
-      collectConsumerEncodingVotes(op.getResult(), votes);
-      for (Value index : op.getIndices()) {
-        Attribute indexEncoding = getStrippedTensorEncoding(index);
-        if (!indexEncoding)
-          continue;
-        const bool constantLike = isConstantLikeTensorValue(index);
-        int64_t elemCount = 1;
-        if (auto indexTy = dyn_cast<RankedTensorType>(index.getType())) {
-          for (int64_t dim : indexTy.getShape()) {
-            if (dim <= 0) {
-              elemCount = 0;
-              break;
+      Attribute hardEncoding = hardEncodings.lookup(op.getOperation());
+      if (hardEncoding) {
+        if (encoding != hardEncoding) {
+          encoding = hardEncoding;
+          updated = true;
+        }
+      } else {
+        SmallVector<EncodingVote> votes;
+        collectConsumerEncodingVotes(op.getResult(), votes);
+        for (Value index : op.getIndices()) {
+          Attribute indexEncoding = getStrippedTensorEncoding(index);
+          if (!indexEncoding)
+            continue;
+          const bool constantLike = isConstantLikeTensorValue(index);
+          int64_t elemCount = 1;
+          if (auto indexTy = dyn_cast<RankedTensorType>(index.getType())) {
+            for (int64_t dim : indexTy.getShape()) {
+              if (dim <= 0) {
+                elemCount = 0;
+                break;
+              }
+              elemCount *= dim;
             }
-            elemCount *= dim;
           }
+          const int64_t depthFactor = 1 + getScfLoopDepth(op.getOperation());
+          int64_t baseScore = constantLike ? 1 : 12;
+          if (!constantLike) {
+            if (elemCount >= 1024)
+              baseScore = 192;
+            else if (elemCount >= 256)
+              baseScore = 64;
+          }
+          const int64_t score = baseScore * depthFactor;
+          votes.push_back({indexEncoding, score});
         }
-        const int64_t depthFactor = 1 + getScfLoopDepth(op.getOperation());
-        int64_t baseScore = constantLike ? 1 : 12;
-        if (!constantLike) {
-          if (elemCount >= 1024)
-            baseScore = 192;
-          else if (elemCount >= 256)
-            baseScore = 64;
+        Attribute userEncoding = pickDominantEncoding(votes, encoding);
+        if (userEncoding && userEncoding != encoding) {
+          encoding = userEncoding;
+          updated = true;
         }
-        const int64_t score = baseScore * depthFactor;
-        votes.push_back({indexEncoding, score});
-      }
-      Attribute userEncoding = pickDominantEncoding(votes, encoding);
-      if (userEncoding && userEncoding != encoding) {
-        encoding = userEncoding;
-        updated = true;
       }
       if (!encoding) {
         OpBuilder::InsertionGuard guard(builder);

--- a/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
+++ b/third_party/mthreads/tle/dialect/triton_mthreads_tle.cc
@@ -1,6 +1,8 @@
 #ifdef __TLE__
 
 #include "Dialect/MUSATLE/IR/Dialect.h"
+#include "TritonMUSACommon/MMAContractUtils.h"
+#include "TritonMUSACommon/MMAEncodingUtils.h"
 #include "TritonMUSAGPUTransforms/Passes.h"
 #include "ir.h"
 #include "mlir/IR/DialectRegistry.h"
@@ -10,8 +12,12 @@
 #include "passes.h"
 #include "tle/dialect/include/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Tools/LayoutUtils.h"
+#include "triton/Tools/LinearLayout.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
 #include <cstdint>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -20,6 +26,7 @@
 #include <vector>
 
 namespace py = pybind11;
+namespace musa = mlir::triton::musa;
 namespace ttg = mlir::triton::gpu;
 namespace tle = mlir::triton::tle;
 
@@ -91,6 +98,385 @@ ttg::CGAEncodingAttr makeCgaLayout(mlir::MLIRContext *context,
                                                ctaOrder);
 }
 
+ttg::CGAEncodingAttr
+buildMthreadsCgaLayout(mlir::MLIRContext *context,
+                       llvm::ArrayRef<std::vector<int32_t>> cgaBases,
+                       unsigned rank) {
+  for (auto [index, basis] : llvm::enumerate(cgaBases)) {
+    if (basis.size() != rank)
+      throw py::value_error("mthreads TLE CGA layout basis " +
+                            std::to_string(index) + " has rank " +
+                            std::to_string(basis.size()) + ", expected " +
+                            std::to_string(rank));
+    if (llvm::any_of(basis, [](int32_t value) { return value < 0; }))
+      throw py::value_error("mthreads TLE CGA layout basis " +
+                            std::to_string(index) +
+                            " contains a negative value");
+  }
+
+  auto block = mlir::StringAttr::get(context, "block");
+  mlir::triton::LinearLayout::BasesT bases;
+  bases[block] =
+      std::vector<std::vector<int32_t>>(cgaBases.begin(), cgaBases.end());
+  auto outDims = mlir::triton::standardOutDimNames(context, rank);
+  return ttg::CGAEncodingAttr::get(
+      context,
+      mlir::triton::LinearLayout(std::move(bases), std::move(outDims)));
+}
+
+bool isPositivePowerOfTwo(unsigned value) {
+  return value != 0 && (value & (value - 1)) == 0;
+}
+
+void validateBlockedEncodingArguments(llvm::ArrayRef<unsigned> sizePerThread,
+                                      llvm::ArrayRef<unsigned> threadsPerWarp,
+                                      llvm::ArrayRef<unsigned> warpsPerCTA,
+                                      llvm::ArrayRef<unsigned> order) {
+  unsigned rank = order.size();
+  if (rank == 0)
+    throw py::value_error(
+        "mthreads TLE blocked encoding rank must be positive");
+  if (sizePerThread.size() != rank || threadsPerWarp.size() != rank ||
+      warpsPerCTA.size() != rank)
+    throw py::value_error(
+        "mthreads TLE blocked encoding fields must have the same rank");
+
+  llvm::SmallVector<bool> seen(rank, false);
+  for (unsigned value : order) {
+    if (value >= rank || seen[value])
+      throw py::value_error(
+          "mthreads TLE blocked encoding order must be a permutation of "
+          "0..rank-1");
+    seen[value] = true;
+  }
+
+  struct PowerOfTwoField {
+    llvm::StringLiteral name;
+    llvm::ArrayRef<unsigned> values;
+  };
+  const PowerOfTwoField fields[] = {
+      {"size_per_thread", sizePerThread},
+      {"threads_per_warp", threadsPerWarp},
+      {"warps_per_cta", warpsPerCTA},
+  };
+  for (const auto &field : fields) {
+    if (llvm::any_of(field.values, [](unsigned value) {
+          return !isPositivePowerOfTwo(value);
+        }))
+      throw py::value_error("mthreads TLE blocked encoding " +
+                            field.name.str() +
+                            " entries must be positive powers of two");
+  }
+
+  uint64_t totalThreads = 1;
+  for (unsigned value : threadsPerWarp)
+    totalThreads *= value;
+  if (totalThreads != 32)
+    throw py::value_error("mthreads TLE PH1 blocked encoding requires "
+                          "product(threads_per_warp) == 32");
+}
+
+mlir::Attribute buildMthreadsBlockedLayout(
+    TritonOpBuilder &self, llvm::ArrayRef<unsigned> sizePerThread,
+    llvm::ArrayRef<unsigned> threadsPerWarp,
+    llvm::ArrayRef<unsigned> warpsPerCTA, llvm::ArrayRef<unsigned> order,
+    llvm::ArrayRef<std::vector<int32_t>> cgaBases) {
+  validateBlockedEncodingArguments(sizePerThread, threadsPerWarp, warpsPerCTA,
+                                   order);
+  auto *context = self.getContext();
+  auto cgaLayout = buildMthreadsCgaLayout(context, cgaBases, order.size());
+  auto encoding = ttg::BlockedEncodingAttr::getChecked(
+      [&]() { return mlir::emitError(self.getLastLoc()); }, context,
+      sizePerThread, threadsPerWarp, warpsPerCTA, order, cgaLayout);
+  if (!encoding)
+    throw py::value_error(
+        "mthreads TLE blocked encoding failed TTGPU verification");
+  return encoding;
+}
+
+mlir::Attribute buildMthreadsSlicedLayout(TritonOpBuilder &self, unsigned dim,
+                                          mlir::Attribute parent) {
+  auto distributed = mlir::dyn_cast<ttg::DistributedEncodingTrait>(parent);
+  if (!distributed)
+    throw py::value_error(
+        "mthreads TLE sliced encoding parent must be a distributed encoding");
+  unsigned parentRank = mlir::cast<ttg::LayoutEncodingTrait>(parent).getRank();
+  if (parentRank < 2)
+    throw py::value_error(
+        "mthreads TLE sliced encoding parent rank must be at least 2");
+  if (dim >= parentRank)
+    throw py::value_error(
+        "mthreads TLE sliced encoding dim must be less than parent rank");
+
+  auto encoding = ttg::SliceEncodingAttr::getChecked(
+      [&]() { return mlir::emitError(self.getLastLoc()); }, self.getContext(),
+      dim, distributed);
+  if (!encoding)
+    throw py::value_error(
+        "mthreads TLE sliced encoding failed TTGPU verification");
+  return encoding;
+}
+
+mlir::Attribute buildMthreadsDotOperandLayout(TritonOpBuilder &self,
+                                              unsigned operandIndex,
+                                              mlir::Attribute parent,
+                                              unsigned kWidth) {
+  if (operandIndex > 1)
+    throw py::value_error("mthreads TLE dot operand index must be 0 or 1");
+  if (!mlir::isa<ttg::MUSAWmmaEncodingAttr, ttg::MUSASqmmaEncodingAttr>(parent))
+    throw py::value_error(
+        "mthreads TLE dot operand parent must be a MUSA WMMA or SQMMA "
+        "encoding");
+  if (kWidth != 0)
+    throw py::value_error("mthreads TLE MUSA dot operand requires k_width=0");
+
+  auto encoding = ttg::DotOperandEncodingAttr::getChecked(
+      [&]() { return mlir::emitError(self.getLastLoc()); }, self.getContext(),
+      operandIndex, parent, kWidth);
+  if (!encoding)
+    throw py::value_error(
+        "mthreads TLE dot operand encoding failed TTGPU verification");
+  return encoding;
+}
+
+mlir::Type cloneMthreadsTensorTypeWithEncoding(TritonOpBuilder &self,
+                                               mlir::Type type,
+                                               mlir::Attribute encoding) {
+  auto tensorType = mlir::dyn_cast<mlir::RankedTensorType>(type);
+  if (!tensorType)
+    throw py::type_error(
+        "mthreads TLE can only clone a ranked tensor type with an encoding");
+  auto distributed = mlir::dyn_cast<ttg::DistributedEncodingTrait>(encoding);
+  if (!distributed)
+    throw py::type_error(
+        "mthreads TLE tensor encoding must be a distributed encoding");
+  unsigned encodingRank =
+      mlir::cast<ttg::LayoutEncodingTrait>(encoding).getRank();
+  if (static_cast<unsigned>(tensorType.getRank()) != encodingRank)
+    throw py::value_error(
+        "mthreads TLE tensor rank must match distributed encoding rank");
+  return tensorType.cloneWithEncoding(encoding);
+}
+
+void validateMthreadsSetLayoutArguments(mlir::Value value,
+                                        mlir::Attribute targetEncoding) {
+  auto tensorType = mlir::dyn_cast<mlir::RankedTensorType>(value.getType());
+  if (!tensorType)
+    throw py::type_error(
+        "mthreads TLE set_layout source must be a ranked tensor");
+
+  if (!mlir::dyn_cast<ttg::DistributedEncodingTrait>(targetEncoding))
+    throw py::type_error(
+        "mthreads TLE set_layout target_encoding must be a distributed "
+        "encoding");
+
+  auto layoutEncoding =
+      mlir::dyn_cast<ttg::LayoutEncodingTrait>(targetEncoding);
+  if (!layoutEncoding)
+    throw py::type_error(
+        "mthreads TLE set_layout distributed target_encoding must expose a "
+        "layout rank");
+
+  unsigned targetRank = layoutEncoding.getRank();
+  if (targetRank != static_cast<unsigned>(tensorType.getRank()))
+    throw py::value_error("mthreads TLE set_layout target encoding rank " +
+                          std::to_string(targetRank) +
+                          " must match source tensor rank " +
+                          std::to_string(tensorType.getRank()));
+}
+
+void validateMusaMmaLayoutArguments(
+    llvm::StringRef layoutName, llvm::ArrayRef<unsigned> version,
+    llvm::ArrayRef<unsigned> warpsPerCTA,
+    llvm::ArrayRef<std::vector<int32_t>> cgaBases,
+    llvm::ArrayRef<unsigned> instrShape) {
+  if (version.size() != 2)
+    throw py::value_error("mthreads TLE " + layoutName.str() +
+                          " version must contain major and minor");
+  if (version[0] != musa::kMusaPH1VersionMajor || version[1] != 1)
+    throw py::value_error("mthreads TLE " + layoutName.str() +
+                          " currently supports only MUSA PH1 version [3, 1]");
+  if (warpsPerCTA.size() != 2 && warpsPerCTA.size() != 3)
+    throw py::value_error("mthreads TLE " + layoutName.str() +
+                          " warps_per_cta rank must be 2 or 3");
+  if (llvm::any_of(warpsPerCTA,
+                   [](unsigned value) { return !isPositivePowerOfTwo(value); }))
+    throw py::value_error("mthreads TLE " + layoutName.str() +
+                          " warps_per_cta entries must be positive powers of "
+                          "two");
+  if (warpsPerCTA.size() == 3 && warpsPerCTA[2] != 1)
+    throw py::value_error("mthreads TLE " + layoutName.str() +
+                          " rank-3 warps_per_cta must end in 1");
+  if (instrShape.size() != 3)
+    throw py::value_error("mthreads TLE " + layoutName.str() +
+                          " instr_shape must contain logical (M, N, K)");
+
+  // Validate the CGA bases before constructing a LinearLayout so malformed
+  // input is reported at the Python/native boundary.
+  for (auto [index, basis] : llvm::enumerate(cgaBases)) {
+    if (basis.size() != warpsPerCTA.size())
+      throw py::value_error("mthreads TLE " + layoutName.str() +
+                            " CGA layout basis " + std::to_string(index) +
+                            " has rank " + std::to_string(basis.size()) +
+                            ", expected " + std::to_string(warpsPerCTA.size()));
+    if (llvm::any_of(basis, [](int32_t value) { return value < 0; }))
+      throw py::value_error("mthreads TLE " + layoutName.str() +
+                            " CGA layout basis " + std::to_string(index) +
+                            " contains a negative value");
+  }
+}
+
+bool isSupportedWmmaInstructionShape(llvm::ArrayRef<unsigned> instrShape) {
+  return llvm::any_of(musa::kWmmaIntrinsics, [&](const auto &intrinsic) {
+    return intrinsic.m == instrShape[0] && intrinsic.n == instrShape[1] &&
+           intrinsic.k == instrShape[2];
+  });
+}
+
+bool isSupportedSqmmaInstructionShape(llvm::ArrayRef<unsigned> instrShape) {
+  const unsigned m = instrShape[0];
+  const unsigned n = instrShape[1];
+  const unsigned k = instrShape[2];
+  return musa::isSupportedSqmma(musa::SQMMAEltType::f16,
+                                musa::SQMMAEltType::f16,
+                                musa::SQMMAEltType::f32, m, n, k) ||
+         musa::isSupportedSqmma(musa::SQMMAEltType::bf16,
+                                musa::SQMMAEltType::bf16,
+                                musa::SQMMAEltType::f32, m, n, k) ||
+         musa::isSupportedSqmma(musa::SQMMAEltType::tf32,
+                                musa::SQMMAEltType::tf32,
+                                musa::SQMMAEltType::f32, m, n, k) ||
+         musa::isSupportedSqmma(musa::SQMMAEltType::s8, musa::SQMMAEltType::s8,
+                                musa::SQMMAEltType::s32, m, n, k) ||
+         musa::isSupportedSqmma(musa::SQMMAEltType::e4m3,
+                                musa::SQMMAEltType::e4m3,
+                                musa::SQMMAEltType::f32, m, n, k) ||
+         musa::isSupportedSqmma(musa::SQMMAEltType::e5m2,
+                                musa::SQMMAEltType::e5m2,
+                                musa::SQMMAEltType::f32, m, n, k);
+}
+
+mlir::Attribute
+buildMusaWmmaLayout(TritonOpBuilder &self, llvm::ArrayRef<unsigned> version,
+                    llvm::ArrayRef<unsigned> warpsPerCTA,
+                    llvm::ArrayRef<std::vector<int32_t>> cgaBases,
+                    llvm::ArrayRef<unsigned> instrShape) {
+  validateMusaMmaLayoutArguments("WMMA", version, warpsPerCTA, cgaBases,
+                                 instrShape);
+  if (!isSupportedWmmaInstructionShape(instrShape))
+    throw py::value_error(
+        "mthreads TLE WMMA instr_shape is not supported by any PH1 WMMA "
+        "intrinsic");
+
+  auto *context = self.getContext();
+  auto cgaLayout =
+      buildMthreadsCgaLayout(context, cgaBases, warpsPerCTA.size());
+  auto encoding = ttg::MUSAWmmaEncodingAttr::getChecked(
+      [&]() { return mlir::emitError(self.getLastLoc()); }, context, version[0],
+      version[1], warpsPerCTA, cgaLayout, instrShape);
+  if (!encoding)
+    throw py::value_error(
+        "mthreads TLE WMMA encoding failed TTGPU verification");
+  return encoding;
+}
+
+mlir::Attribute
+buildMusaSqmmaLayout(TritonOpBuilder &self, llvm::ArrayRef<unsigned> version,
+                     llvm::ArrayRef<unsigned> warpsPerCTA,
+                     llvm::ArrayRef<std::vector<int32_t>> cgaBases,
+                     llvm::ArrayRef<unsigned> instrShape) {
+  validateMusaMmaLayoutArguments("SQMMA", version, warpsPerCTA, cgaBases,
+                                 instrShape);
+  if (warpsPerCTA[0] % 4 != 0)
+    throw py::value_error(
+        "mthreads TLE SQMMA warps_per_cta[0] must be a multiple of 4");
+  if (!isSupportedSqmmaInstructionShape(instrShape))
+    throw py::value_error(
+        "mthreads TLE SQMMA instr_shape is not supported by any PH1 SQMMA "
+        "type contract");
+
+  auto *context = self.getContext();
+  auto cgaLayout =
+      buildMthreadsCgaLayout(context, cgaBases, warpsPerCTA.size());
+  auto encoding = ttg::MUSASqmmaEncodingAttr::getChecked(
+      [&]() { return mlir::emitError(self.getLastLoc()); }, context, version[0],
+      version[1], warpsPerCTA, cgaLayout, instrShape);
+  if (!encoding)
+    throw py::value_error(
+        "mthreads TLE SQMMA encoding failed TTGPU verification");
+  return encoding;
+}
+
+mlir::ModuleOp findParentModule(TritonOpBuilder &self) {
+  auto *block = self.getBuilder().getInsertionBlock();
+  if (!block)
+    throw py::value_error(
+        "mthreads TLE cannot set ttg layout attributes without an insertion "
+        "block");
+
+  mlir::Operation *op = block->getParentOp();
+  while (op && !mlir::isa<mlir::ModuleOp>(op))
+    op = op->getParentOp();
+  auto module = mlir::dyn_cast_or_null<mlir::ModuleOp>(op);
+  if (!module)
+    throw py::value_error(
+        "mthreads TLE cannot find parent module for ttg layout attributes");
+  return module;
+}
+
+std::string printAttribute(mlir::Attribute attr) {
+  std::string storage;
+  llvm::raw_string_ostream stream(storage);
+  attr.print(stream);
+  return stream.str();
+}
+
+void ensureTtgLayoutAttrs(TritonOpBuilder &self, int numWarps,
+                          int threadsPerWarp, int numCtas) {
+  if (numWarps <= 0 || (static_cast<unsigned>(numWarps) &
+                        (static_cast<unsigned>(numWarps) - 1)) != 0)
+    throw py::value_error(
+        "mthreads TLE num_warps must be a positive power of two");
+  if (threadsPerWarp != 32)
+    throw py::value_error(
+        "mthreads TLE PH1 requires warp_size (threads per warp) to be 32");
+  if (numCtas <= 0)
+    throw py::value_error("mthreads TLE num_ctas must be positive");
+
+  auto module = findParentModule(self);
+  struct LayoutAttrSpec {
+    llvm::StringLiteral name;
+    int value;
+  };
+  const LayoutAttrSpec specs[] = {
+      {"ttg.num-warps", numWarps},
+      {"ttg.threads-per-warp", threadsPerWarp},
+      {"ttg.num-ctas", numCtas},
+  };
+
+  // Validate all existing attributes before adding any missing ones. This
+  // keeps the module unchanged when one of the requested values conflicts.
+  for (const auto &spec : specs) {
+    auto attr = module->getAttr(spec.name);
+    if (!attr)
+      continue;
+    auto integer = mlir::dyn_cast<mlir::IntegerAttr>(attr);
+    if (!integer || !integer.getType().isInteger(32) ||
+        integer.getInt() != spec.value) {
+      throw py::value_error("mthreads TLE layout attribute '" +
+                            spec.name.str() + "' mismatch: module has " +
+                            printAttribute(attr) + ", requested " +
+                            std::to_string(spec.value) + " : i32");
+    }
+  }
+
+  auto i32 = mlir::IntegerType::get(self.getContext(), 32);
+  for (const auto &spec : specs) {
+    if (!module->hasAttr(spec.name))
+      module->setAttr(spec.name, mlir::IntegerAttr::get(i32, spec.value));
+  }
+}
+
 mlir::Attribute getSharedMemorySpace(mlir::MLIRContext *context,
                                      const std::string &storage) {
   if (storage == "smem" || storage == "share_memory" ||
@@ -122,6 +508,59 @@ void init_triton_musa_tle_ir(py::module m) {
 
   auto &builderCls = *builderClsPtr;
   builderCls
+      .def("ensure_ttg_layout_attrs",
+           [](TritonOpBuilder &self, int numWarps, int threadsPerWarp,
+              int numCtas) {
+             ensureTtgLayoutAttrs(self, numWarps, threadsPerWarp, numCtas);
+           })
+      .def("get_blocked_encoding",
+           [](TritonOpBuilder &self, std::vector<unsigned> sizePerThread,
+              std::vector<unsigned> threadsPerWarp,
+              std::vector<unsigned> warpsPerCTA, std::vector<unsigned> order,
+              std::vector<std::vector<int32_t>> cgaBases) -> mlir::Attribute {
+             return buildMthreadsBlockedLayout(self, sizePerThread,
+                                               threadsPerWarp, warpsPerCTA,
+                                               order, cgaBases);
+           })
+      .def("get_sliced_encoding",
+           [](TritonOpBuilder &self, unsigned dim,
+              mlir::Attribute parent) -> mlir::Attribute {
+             return buildMthreadsSlicedLayout(self, dim, parent);
+           })
+      .def("get_dot_operand_layout",
+           [](TritonOpBuilder &self, unsigned operandIndex,
+              mlir::Attribute parent, unsigned kWidth) -> mlir::Attribute {
+             return buildMthreadsDotOperandLayout(self, operandIndex, parent,
+                                                  kWidth);
+           })
+      .def("clone_tensor_type_with_encoding",
+           [](TritonOpBuilder &self, mlir::Type type,
+              mlir::Attribute encoding) -> mlir::Type {
+             return cloneMthreadsTensorTypeWithEncoding(self, type, encoding);
+           })
+      .def("get_musa_wmma_layout",
+           [](TritonOpBuilder &self, std::vector<unsigned> version,
+              std::vector<unsigned> warpsPerCTA,
+              std::vector<std::vector<int32_t>> cgaBases,
+              std::vector<unsigned> instrShape) -> mlir::Attribute {
+             return buildMusaWmmaLayout(self, version, warpsPerCTA, cgaBases,
+                                        instrShape);
+           })
+      .def("get_musa_sqmma_layout",
+           [](TritonOpBuilder &self, std::vector<unsigned> version,
+              std::vector<unsigned> warpsPerCTA,
+              std::vector<std::vector<int32_t>> cgaBases,
+              std::vector<unsigned> instrShape) -> mlir::Attribute {
+             return buildMusaSqmmaLayout(self, version, warpsPerCTA, cgaBases,
+                                         instrShape);
+           })
+      .def("create_tle_gpu_set_layout",
+           [](TritonOpBuilder &self, mlir::Value value,
+              mlir::Attribute targetEncoding) -> mlir::Value {
+             validateMthreadsSetLayoutArguments(value, targetEncoding);
+             return self.create<mlir::triton::musa_tle::SetLayoutOp>(
+                 value.getType(), value, targetEncoding);
+           })
       .def("make_swizzled_shared_encoding_attr",
            [](TritonOpBuilder &self, unsigned vectorSize, unsigned perPhase,
               unsigned maxPhase, std::vector<unsigned> order,
@@ -526,6 +965,8 @@ void init_triton_musa_tle_dialect_passes_ttgpuir(py::module m) {
                      mlir::createTritonMUSAGPUTLELowerTMETransactions);
   ADD_PASS_WRAPPER_0("add_tle_lower_barrier_operations",
                      mlir::createTritonMUSAGPUTLELowerBarrierOperations);
+  ADD_PASS_WRAPPER_0("add_tle_finalize_explicit_layouts",
+                     mlir::createTritonMUSAGPUTLEFinalizeExplicitLayouts);
   ADD_PASS_WRAPPER_0("add_tle_insert_local_pointer_barriers",
                      mlir::createTritonMUSAGPUTLEInsertLocalPointerBarriers);
   ADD_PASS_WRAPPER_0("add_tle_optimize_local_pointer_loads",

--- a/third_party/mthreads/tle/frontend/lib/Transforms/EarlyAssignMemorySpace.cpp
+++ b/third_party/mthreads/tle/frontend/lib/Transforms/EarlyAssignMemorySpace.cpp
@@ -83,6 +83,12 @@ getAsyncLoadContiguity(tt::LoadOp op,
 static bool
 canLowerAsyncMemorySpaceLoad(tt::LoadOp op,
                              tt::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
+#ifdef __TLE__
+  Attribute explicitMemoryEncoding;
+  if (failed(inferTleExplicitMemoryEncoding(op, explicitMemoryEncoding)) ||
+      explicitMemoryEncoding || getTleExplicitValueEncoding(op.getResult()))
+    return false;
+#endif // __TLE__
   if (op->use_empty())
     return false;
   auto resultTy = dyn_cast<RankedTensorType>(op.getType());

--- a/third_party/mthreads/tle/frontend/lib/Transforms/LowerAsyncLoad.cpp
+++ b/third_party/mthreads/tle/frontend/lib/Transforms/LowerAsyncLoad.cpp
@@ -87,6 +87,12 @@ getAsyncLoadContiguity(tt::LoadOp op,
 
 static bool canLowerAsyncLoad(tt::LoadOp op,
                               tt::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
+#ifdef __TLE__
+  Attribute explicitMemoryEncoding;
+  if (failed(inferTleExplicitMemoryEncoding(op, explicitMemoryEncoding)) ||
+      explicitMemoryEncoding || getTleExplicitValueEncoding(op.getResult()))
+    return false;
+#endif // __TLE__
   if (op->use_empty())
     return false;
   auto resultTy = dyn_cast<RankedTensorType>(op.getType());


### PR DESCRIPTION
  ### tle.gpu.set_layout(x, layout)

  Applies a compile-time distributed layout constraint to a tensor while preserving its shape, element type, and numerical value.

  Supported layouts include:

  - Blocked and Slice encodings.
  - Backend-local MusaWmmaEncoding.
  - Backend-local MusaSqmmaEncoding.
  - Backend-local MusaDotOperandEncoding.

  The target layout must be a distributed encoding and its rank must match the source tensor rank. Shared-memory layouts and incompatible encodings are rejected with an explicit diagnostic.

  ### Layout propagation

  The requested layout is treated as a hard constraint and propagated through:

  - Elementwise, broadcast, reshape, expand-dims, reduction, and scan operations.
  - Structured and unstructured control flow, including block arguments and yielded values.
  - Pointer-producing expressions and memory operations.
  - Tensor descriptor loads across Coalesce and explicit-layout finalization.
  - Private/noinline function arguments, return values, call operands, and call results.
  - Multi-level call graphs using a module-level fixed point independent of caller/callee declaration order.

  Shared layout-polymorphic producers are isolated when different users require incompatible Slice layouts. Safe register producers may be cloned by layout domain, while memory roots such as loads are not duplicated.

  Conflicting hard layouts are rejected instead of being silently overwritten.

  ### Lowering path

  - The frontend dispatches to the mthreads specialization under triton.experimental.tle.language.gpu.mthreads.
  - The operation is represented by the backend-local musa_tle.set_layout op; the shared TLE dialect is not linked into the mthreads build.
  - The MUSATLE verifier validates the distributed encoding and tensor rank before layout propagation.
  - During TTIR → TTGIR conversion, the requested encoding is materialized directly in tensor types.
  - musa_tle.set_layout is removed after propagation and does not remain as a runtime operation.
  - Backend-local explicit-result metadata preserves hard descriptor layouts through Coalesce and is validated and removed by the finalizer.
  - Existing Triton function, call, and return conversion patterns consume the synchronized tensor types without changing the non-TLE path.

  ### Limitations

  - Source and result must be ranked tensors with the same shape and element type.
  - The target must be a supported distributed encoding with matching rank.
  - Shared-memory encodings cannot be used as the target layout.
  - Two incompatible hard layout requirements in the same propagation domain are rejected.
  - Explicit tensor layout ABIs on external tt.func declarations are not supported; private/noinline helpers are supported.