### PR TITLE
[VERSION] Export triton_key from triton.compiler.compiler to align with the Triton 3.4 interface

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -29,7 +29,7 @@ from ..backends.compiler import Language
 from ..backends.compiler import BaseBackend, GPUTarget
 from .. import __version__, knobs
 from ..runtime.autotuner import OutOfResources
-from ..runtime.cache import get_cache_manager, get_dump_manager, get_override_manager, get_cache_key, triton_key
+from ..runtime.cache import get_cache_manager, get_dump_manager, get_override_manager, get_cache_key, triton_key as triton_key
 from ..runtime.driver import driver
 from ..tools.disasm import get_sass
 from pathlib import Path

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -29,7 +29,7 @@ from ..backends.compiler import Language
 from ..backends.compiler import BaseBackend, GPUTarget
 from .. import __version__, knobs
 from ..runtime.autotuner import OutOfResources
-from ..runtime.cache import get_cache_manager, get_dump_manager, get_override_manager, get_cache_key
+from ..runtime.cache import get_cache_manager, get_dump_manager, get_override_manager, get_cache_key, triton_key
 from ..runtime.driver import driver
 from ..tools.disasm import get_sass
 from pathlib import Path


### PR DESCRIPTION
torch 2.8 inductor (`torch/_inductor/codecache.py`, `CacheBase.get_system`) imports `triton_key` from `triton.compiler.compiler` to include the triton revision in its compile-cache key. FlagTree defines `triton_key` in `triton.runtime.cache` but never re-exports it on the compiler module, so `import torch._inductor.codecache` — and any `torch.compile` path — raises `ImportError` and aborts.

This re-exports the existing symbol on the compiler module. No behavior change.

Repro before this change:

    python3 -c "from triton.compiler.compiler import triton_key"
    # ImportError: cannot import name 'triton_key' from 'triton.compiler.compiler'

This PR was written in part with the assistance of generative AI.