### PR TITLE
[XPU] Stop trusting Discrete offsets whose chain can wrap

### DIFF
--- a/third_party/xpu/lib/Dialect/TritonXPU/Transforms/OffsetAnalysis.cpp
+++ b/third_party/xpu/lib/Dialect/TritonXPU/Transforms/OffsetAnalysis.cpp
@@ -1128,6 +1128,52 @@ public:
           memoryStateTransfer(memoryState, allOffsetStateResult[token]);
     }
 
+    // Step 3.3. Guard Discrete against a wrapping offset chain.
+    // The offsets above are mocked over a small program-id range, so a `remsi`
+    // by a large constant in the chain never wraps during the analysis. A
+    // gather offset such as `(xindex % C) // K` therefore looks like a
+    // well-behaved Discrete access, whose invariant is that every lane of a
+    // core lies within [base, base + numElems) of that core's first lane (see
+    // the multiBank / negative-offset guards in checkOffset).
+    // UnrollControl::findDiscretePtrChain relies on that invariant and rewrites
+    // the gather into a contiguous gm2lm plus `lmPtr[offset - offset0]`. At the
+    // real wrap the offset jumps backwards by C, the LM index goes far out of
+    // range and the kernel traps. Fall back to Unknown so the safe per-element
+    // gather path is used instead.
+    if (memoryState == OffsetState::Discrete &&
+        isa<triton::xpu::GM2LMOp>(memoryOp)) {
+      for (auto *op : opChain) {
+        auto remOp = dyn_cast<arith::RemSIOp>(op);
+        if (!remOp)
+          continue;
+        auto constOp = remOp.getRhs().getDefiningOp<arith::ConstantOp>();
+        if (!constOp)
+          continue;
+        int64_t remConst = 0;
+        if (auto denseAttr =
+                mlir::dyn_cast<DenseElementsAttr>(constOp.getValue())) {
+          if (!denseAttr.isSplat())
+            continue;
+          remConst = denseAttr.getSplatValue<APInt>().getSExtValue();
+        } else if (auto intAttr =
+                       mlir::dyn_cast<IntegerAttr>(constOp.getValue())) {
+          remConst = intAttr.getValue().getSExtValue();
+        } else {
+          continue;
+        }
+        if (remConst > static_cast<int64_t>(numElems)) {
+          fixedStride = -1;
+          rowLen = -1;
+          rowStride = -1;
+          LLVM_DEBUG(llvm::dbgs()
+                     << "[OffsetState]: Detected remsi pattern, override "
+                        "Discrete to Unknown (wrap period "
+                     << remConst << ")\n");
+          return OffsetState::Unknown;
+        }
+      }
+    }
+
     bool canBeLrie = findUserOp<triton::AddPtrOp>(memoryOp) &&
                      !findUserOp<arith::SelectOp>(memoryOp);
     if (atomicSim && !analysisFlag && canBeLrie) {

--- a/third_party/xpu/python/test/unit/language/test_xpu_compat.py
+++ b/third_party/xpu/python/test/unit/language/test_xpu_compat.py
@@ -42,6 +42,20 @@ def libdevice_kernel(lhs, rhs, dst, n_elements: tl.constexpr, BLOCK: tl.constexp
     tl.store(dst + offsets, value, mask=mask)
 
 
+@triton.jit
+def index_copy_scatter_kernel(src_ptr, index_ptr, out_ptr, SRC_ROW: tl.constexpr, INNER: tl.constexpr,
+                              DST_ROW: tl.constexpr, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    outer = offs // SRC_ROW
+    row_offset = offs % SRC_ROW
+    index_offset = row_offset // INNER
+    inner_offset = row_offset % INNER
+    value = tl.load(src_ptr + offs)
+    index = tl.load(index_ptr + index_offset).to(tl.int32)
+    dst = outer.to(tl.int64) * DST_ROW + index.to(tl.int64) * INNER + inner_offset
+    tl.store(out_ptr + dst, value)
+
+
 def _extern_functions():
     tree = ast.parse(_libdevice_path().read_text())
     return [
@@ -163,3 +177,28 @@ def test_xpu_representative_libdevice_externs(device):
     dst = torch.empty_like(lhs)
     libdevice_kernel[(1, )](lhs, rhs, dst, n_elements=lhs.numel(), BLOCK=8)
     assert torch.isfinite(dst).all()
+
+
+def test_xpu_index_copy_scatter_wrapping_gather(device):
+    # The gather offset `(offs % SRC_ROW) // INNER` wraps back to 0 once offs
+    # crosses SRC_ROW. OffsetAnalysis mocks a small program-id range that never
+    # observes the wrap, so the access used to be classified Discrete and the
+    # gather was rewritten into a contiguous DMA plus `lmPtr[offset - offset0]`,
+    # which indexes far outside the LM buffer and traps the kernel.
+    outer, dst_dim, index_len, inner, block = 8, 4099, 2049, 3, 1024
+    src_row = index_len * inner
+    grid = (2 * src_row // block, )
+
+    torch.manual_seed(0)
+    out = torch.zeros((outer, dst_dim, inner), dtype=torch.float32, device=device)
+    src = torch.randn((outer, index_len, inner), dtype=torch.float32, device=device)
+    index = torch.randperm(index_len, dtype=torch.int64, device=device)
+
+    offs = torch.arange(grid[0] * block, device=device)
+    row = offs % src_row
+    dst_offs = (offs // src_row) * (dst_dim * inner) + index[row // inner] * inner + row % inner
+    expected = out.clone()
+    expected.reshape(-1)[dst_offs] = src.reshape(-1)[offs]
+
+    index_copy_scatter_kernel[grid](src, index, out, SRC_ROW=src_row, INNER=inner, DST_ROW=dst_dim * inner, BLOCK=block)
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)


### PR DESCRIPTION
OffsetAnalysis mocks program ids over a small range, so a `remsi` by a large constant in the offset chain never wraps during the analysis. For a gather offset such as `(offs % SRC_ROW) // INNER` the mocked samples look like a well-behaved Discrete access, whose invariant is that every lane of a core lies within [base, base + numElems) of that core's first lane.

UnrollControl::findDiscretePtrChain relies on that invariant and rewrites the gather into a contiguous gm2lm plus `lmPtr[offset - offset0]`. At the real wrap the offset jumps backwards by the modulus, the LM index goes far out of range and the kernel traps with a hardware exception.

Fall back to Unknown when the offset chain of a Discrete gm2lm contains a modulo by a constant larger than numElems, so the safe per-element gather path is used. Add a regression test that reproduces the index_copy-style scatter.

<!-- PR Title Format:
[TLE][BUILD][TEST][CI/CD][DOC][PROTON][BACKEND][FLIR] Brief description
[LANGUAGE][AUTOTUNER][LAYOUT][PIPELINE][WarpSpecialization] Brief description
Do not set the following title tags: [FEATURE][BUG][FixBug][Refine] ...
-->
