### PR TITLE
[BUILD] Enable LLVM 20 build for the cpu backend (riscv64)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -488,6 +488,11 @@ if(TRITON_BUILD_PYTHON_MODULE)
         LLVMPowerPCAsmParser
         LLVMPowerPCCodeGen
       )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "riscv")
+      list(APPEND TRITON_LIBRARIES
+        LLVMRISCVCodeGen
+        LLVMRISCVAsmParser
+      )
   else()
     message(FATAL_ERROR "LLVM codegen/ASM parser libs: This HW architecture (${CMAKE_SYSTEM_PROCESSOR}) is not configured in cmake lib dependencies.")
   endif()

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -998,7 +998,7 @@ void FuncOp::build(OpBuilder &builder, OperationState &state, StringRef name,
   if (argAttrs.empty())
     return;
   assert(type.getNumInputs() == argAttrs.size());
-  call_interface_impl::addArgAndResultAttrs(
+  function_interface_impl::addArgAndResultAttrs(
       builder, state, argAttrs, /*resultAttrs=*/std::nullopt,
       getArgAttrsAttrName(state.name), getResAttrsAttrName(state.name));
 }

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -92,7 +92,7 @@ void init_triton_passes_ttgpuir(py::module &&m) {
 
 void init_triton_passes_convert(py::module &&m) {
   using namespace mlir;
-  ADD_PASS_WRAPPER_0("add_scf_to_cf", createSCFToControlFlowPass);
+  ADD_PASS_WRAPPER_0("add_scf_to_cf", createConvertSCFToCFPass);
   ADD_PASS_WRAPPER_0("add_cf_to_llvmir", createConvertControlFlowToLLVMPass);
   ADD_PASS_WRAPPER_0("add_index_to_llvmir", createConvertIndexToLLVMPass);
   ADD_PASS_WRAPPER_0("add_arith_to_llvmir", createArithToLLVMConversionPass);


### PR DESCRIPTION
## Motivation

The `triton_v3.3.x` branch (cpu / triton-shared backends) still uses LLVM 19-era MLIR API names, so it fails to build against LLVM 20. This PR forward-ports the three call sites so the cpu backend can be built with LLVM 20 — which is what we use to compile Triton kernels down to RISC-V RVV on a riscv64 guest.

## Changes

- `CMakeLists.txt`: add `LLVMRISCVCodeGen` / `LLVMRISCVAsmParser` to `TRITON_LIBRARIES` for `riscv64` (mirrors the existing x86/ARM/PowerPC branches), so `TRITON_BUILD_PYTHON_MODULE` links the RISC-V codegen libs.
- `lib/Dialect/Triton/IR/Ops.cpp`: `call_interface_impl::addArgAndResultAttrs` → `function_interface_impl::addArgAndResultAttrs` (LLVM 20 rename, upstream llvm-project commit 3328f681).
- `python/src/passes.cc`: `createSCFToControlFlowPass` → `createConvertSCFToCFPass` (same LLVM 20 rename).

No behavior change — pure API-name migration plus a new riscv64 CMake branch.

## Verification

- `git apply --check` clean on latest `triton_v3.3.x` (bf9c62c3).
- Builds and runs against LLVM 20 in a riscv64 (QEMU) guest; the cpu backend compiles `@triton.jit` kernels to RISC-V RVV object code.
- Grep confirms no remaining `call_interface_impl` / `createSCFToControlFlowPass` references in the changed files.

## Notes

- Targets the `triton_v3.3.x` branch (cpu / triton-shared live there, per the README backend table), not `main` (Triton 3.6 GPU backends).
- The riscv64 CMake branch is additive and scoped to `CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64|riscv"`, so other architectures are unaffected.